### PR TITLE
docs: 문서 진입점과 PR/이슈 템플릿 정리

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,40 +1,40 @@
 ---
-name: Bug report
-about: Report a defect in the platform, backend, frontend, or deployment flow
-title: "[Bug]: "
+name: 버그 신고
+about: 플랫폼, 백엔드, 프론트엔드, 배포 흐름의 문제를 신고합니다
+title: "[버그]: "
 labels: bug
 assignees: ""
 ---
 
-## What happened
+## 발생한 내용
 
-Describe the observed behavior.
+실제로 관찰된 동작을 적어주세요.
 
-## What did you expect
+## 기대한 동작
 
-Describe the expected behavior.
+원래 기대한 동작을 적어주세요.
 
-## Where it happened
+## 발생 위치
 
-- Area: frontend / backend / database / deployment / docs
-- Page, endpoint, or job:
+- 영역: frontend / backend / database / deployment / docs
+- 페이지, 엔드포인트, 작업:
 
-## Steps to reproduce
+## 재현 절차
 
 1. 
 2. 
 3. 
 
-## Environment
+## 환경
 
-- Browser or runtime:
-- OS:
-- Branch or commit:
+- 브라우저 또는 런타임:
+- 운영체제:
+- 브랜치 또는 커밋:
 
-## Evidence
+## 증거
 
-Add screenshots, request payloads, console logs, or server logs if available.
+가능하면 스크린샷, 요청 페이로드, 콘솔 로그, 서버 로그를 첨부하세요.
 
-## Impact
+## 영향 범위
 
-Explain how this affects users or the business workflow.
+사용자나 업무 흐름에 어떤 영향을 주는지 적어주세요.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Project discussion
+  - name: 프로젝트 논의
     url: https://github.com/revfactory/harness
-    about: Use the repository discussions or the owner link for broader questions.
+    about: 더 넓은 질문은 저장소 토론 또는 소유자 링크를 사용하세요.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 프로젝트 논의
-    url: https://github.com/revfactory/harness
+    url: https://github.com/shsh99/CostWiseAI/discussions
     about: 더 넓은 질문은 저장소 토론 또는 소유자 링크를 사용하세요.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,34 +1,34 @@
 ---
-name: Feature request
-about: Propose a new feature or workflow improvement
-title: "[Feature]: "
+name: 기능 요청
+about: 새 기능이나 워크플로우 개선을 제안합니다
+title: "[기능]: "
 labels: enhancement
 assignees: ""
 ---
 
-## Problem
+## 문제
 
-What user problem or workflow gap does this solve?
+어떤 사용자 문제나 업무 공백을 해결하는지 적어주세요.
 
-## Proposed solution
+## 제안하는 해결책
 
-Describe the behavior you want to add.
+추가하고 싶은 동작을 설명하세요.
 
-## Scope
+## 범위
 
-- In scope:
-- Out of scope:
+- 포함:
+- 제외:
 
-## Acceptance criteria
+## 수락 기준
 
 - [ ] 
 - [ ] 
 - [ ] 
 
-## Dependencies
+## 의존성
 
-List data, API, UI, or operational dependencies.
+데이터, API, UI, 운영상 의존성이 있으면 적어주세요.
 
-## Notes
+## 참고
 
-Add links, screenshots, or examples that help clarify the request.
+요청을 이해하는 데 도움이 되는 링크, 스크린샷, 예시를 첨부하세요.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,3 +26,9 @@ Add screenshots, sample payloads, or logs if they help review.
 - [ ] The scope is limited to this PR
 - [ ] Documentation was updated if behavior changed
 - [ ] Follow-up work is listed as a separate issue if needed
+
+## Branching
+
+- [ ] The work was done on a focused `feat/*`, `fix/*`, `docs/*`, or `chore/*` branch.
+- [ ] The branch targets `dev` unless this is a release or hotfix merge.
+- [ ] A `docs/dev-logs/` entry exists for the worktree comparison and branch choice.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,34 +1,34 @@
-## Summary
+## 요약
 
-Describe the change in one or two sentences.
+변경 내용을 한두 문장으로 요약하세요.
 
-## What Changed
+## 변경 내용
 
 - 
 - 
 
-## Why
+## 이유
 
-Explain the reason for the change and the problem it solves.
+이 변경이 필요한 이유와 해결하는 문제를 적어주세요.
 
-## Validation
+## 검증
 
-- [ ] Ran the relevant tests
-- [ ] Verified the affected screens or APIs manually
-- [ ] Checked for regressions in nearby flows
+- [ ] 관련 테스트를 실행했습니다.
+- [ ] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
+- [ ] 인접한 흐름에서 회귀가 없는지 확인했습니다.
 
-## Screenshots or Logs
+## 스크린샷 또는 로그
 
-Add screenshots, sample payloads, or logs if they help review.
+검토에 도움이 되면 스크린샷, 샘플 페이로드, 로그를 첨부하세요.
 
-## Checklist
+## 체크리스트
 
-- [ ] The scope is limited to this PR
-- [ ] Documentation was updated if behavior changed
-- [ ] Follow-up work is listed as a separate issue if needed
+- [ ] 범위가 이 PR 안에만 한정되어 있습니다.
+- [ ] 동작이 바뀌었다면 문서를 함께 수정했습니다.
+- [ ] 후속 작업이 필요하면 별도 이슈로 분리했습니다.
 
-## Branching
+## 브랜치
 
-- [ ] The work was done on a focused `feat/*`, `fix/*`, `docs/*`, or `chore/*` branch.
-- [ ] The branch targets `dev` unless this is a release or hotfix merge.
-- [ ] A `docs/dev-logs/` entry exists for the worktree comparison and branch choice.
+- [ ] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
+- [ ] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
+- [ ] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,0 +1,39 @@
+name: AI PR Review
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ai-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository context
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run AI review
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: gpt-5.1
+        run: node scripts/ai-pr-review.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,41 +1,66 @@
 # AGENTS.md
 
-## Harness
+This is the canonical entry point for the repository. Start here, then follow the linked docs only when you need more detail.
 
-Use the `harness` skill when you need to design or update agent teams, orchestrators, or project-specific skills in this repository.
+## Project Snapshot
 
-## Project-local layout
+- Product: insurance/financial services new business decision support platform
+- Core flow: ABC cost allocation plus DCF investment evaluation
+- Primary users: planner, finance reviewer, executive
+- Frontend: React 18, TypeScript, Vite, Tailwind CSS
+- Backend: Java 21, Spring Boot 3.x
+- Database and auth: Supabase PostgreSQL and Supabase Auth
+- Deployment: Cloudflare Pages for frontend and a separate Spring runtime for backend
 
-- Generated agents live under `.codex/agents/`
-- Generated skills live under `.codex/skills/`
-- Codex packaging metadata lives under `.codex-plugin/`
+## Read Next
 
-## Working rules
+- `docs/README.md` for the doc map
+- `docs/project/current-state.md` for the current working picture
+- `docs/ai-collaboration.md` for subagent and reviewer rules
+- `docs/worktree-strategy.md` for branch and worktree policy
+- `docs/git/branch-naming.md` for naming rules
+- `docs/git/issue-labels.md` for triage labels
+- `docs/dev-logs/README.md` for comparison notes and PR prerequisites
+- `docs/superpowers/specs/2026-04-19-financial-decision-support-platform-design.md` for product scope
+- `docs/superpowers/plans/2026-04-19-financial-decision-support-platform-development.md` for implementation details
+- `docs/superpowers/plans/2026-04-19-financial-decision-support-platform-implementation.md` for task order
 
-- Prefer Codex CLI for terminal-driven edits and validation.
-- Prefer Codex Desktop for visual review or side-by-side inspection.
-- Keep the harness pointers short. Do not duplicate the full skill content here.
+## Working Rules
 
-## Frontend Work
+- Keep changes small and task-focused.
+- Prefer `apply_patch` for edits.
+- Do not broaden scope unless the task demands it.
+- Keep `main` release-only, `dev` integration-only, and `feat/*` for focused work.
+- Use one worktree per non-trivial `feat/*` branch.
+- Before opening a PR for any non-trivial change, write a dev log entry that explains the worktree comparison and why the chosen option won.
 
-- Use the `frontend-design` skill when creating or changing frontend pages, components, layouts, or other user-facing UI.
-- Do not use `frontend-design` for linting, formatting, hook setup, package wiring, or other tooling-only changes.
-- If the work includes accessibility-sensitive UI decisions, pair `frontend-design` with `accessible-ui-guidelines`.
+## Common Commands
 
-## Backend Work
+- Frontend build and lint:
+  - `cd frontend`
+  - `npm run build`
+  - `npm run lint`
+- Frontend format check:
+  - `cd frontend`
+  - `npm run format:check`
+- Backend build checks:
+  - `cd backend`
+  - `./gradlew check`
+- Backend compile check:
+  - `cd backend`
+  - `./gradlew classes`
 
-- Use backend-specific guidance when changing Spring services, APIs, persistence, or other server-side behavior.
-- Keep `frontend-design` out of backend-only work.
-- Use the harness only for agent, skill, and workflow orchestration.
-- The backend uses the checked-in Gradle wrapper, so backend changes should validate with `./backend/gradlew check`.
+## Do Not
 
-## Change log
+- Do not edit `harness_tmp/`.
+- Do not change unrelated files.
+- Do not commit unverified changes.
+- Do not expose secrets or service keys to the browser.
+- Do not open a PR without the required dev log for a non-trivial change.
 
-| Date | Change | Reason |
-|------|--------|--------|
-| 2026-04-19 | Initial harness pointer added | Install project-local Codex harness |
-| 2026-04-19 | GitHub workflow templates added | Standardize PR, issue, commit, and branch workflows |
-| 2026-04-19 | Issue label set added | Standardize triage, ownership, and priority labels |
-| 2026-04-19 | Frontend tooling workflow added | Standardize lint, format, and pre-commit checks for frontend work |
-| 2026-04-19 | Backend tooling workflow added | Standardize Java formatting, style checks, and backend pre-commit coverage |
-| 2026-04-19 | Gradle wrapper added | Make backend checks reproducible through the checked-in wrapper |
+## AI Collaboration
+
+- Use one focused subagent per independent slice.
+- Use a spec reviewer after implementation to check scope and consistency.
+- Use a quality reviewer after implementation to check buildability and risk.
+- Keep subagent prompts narrow: one repo slice, one output, one acceptance bar.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This is the canonical entry point for the repository. Start here, then follow th
 - `docs/project/current-state.md` for the current working picture
 - `docs/ai-collaboration.md` for subagent and reviewer rules
 - `docs/worktree-strategy.md` for branch and worktree policy
+- `docs/ops/README.md` for operational workflow docs
 - `docs/git/branch-naming.md` for naming rules
 - `.gitmessage` for commit message format
 - `docs/git/issue-labels.md` for triage labels

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,12 @@ This is the canonical entry point for the repository. Start here, then follow th
 
 ## Read Next
 
-- `docs/README.md` for the doc map
+- `docs/index.md` for the doc map
 - `docs/project/current-state.md` for the current working picture
 - `docs/ai-collaboration.md` for subagent and reviewer rules
 - `docs/worktree-strategy.md` for branch and worktree policy
 - `docs/git/branch-naming.md` for naming rules
+- `.gitmessage` for commit message format
 - `docs/git/issue-labels.md` for triage labels
 - `docs/dev-logs/README.md` for comparison notes and PR prerequisites
 - `docs/superpowers/specs/2026-04-19-financial-decision-support-platform-design.md` for product scope

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Docs Home
+
+This directory is a reference map. It is not a required read loop.
+
+Start with `AGENTS.md`. Only open this file if you need a secondary map of the documentation layout.
+
+## What Lives Where
+
+- `docs/project/` holds project status and the current working picture.
+- `docs/ai-collaboration.md` holds AI worker/reviewer rules.
+- `docs/worktree-strategy.md` holds branch and worktree policy.
+- `docs/git/` holds naming, label, and review conventions.
+- `docs/superpowers/` holds the project-specific spec and plan artifacts.
+- `docs/dev-logs/` holds comparison notes and branch/worktree decisions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,5 @@
 # Docs Home
 
-This directory is a reference map. It is not a required read loop.
+This file now acts as a thin redirect.
 
-Start with `AGENTS.md`. Only open this file if you need a secondary map of the documentation layout.
-
-## What Lives Where
-
-- `docs/project/` holds project status and the current working picture.
-- `docs/ai-collaboration.md` holds AI worker/reviewer rules.
-- `docs/worktree-strategy.md` holds branch and worktree policy.
-- `docs/git/` holds naming, label, and review conventions.
-- `docs/superpowers/` holds the project-specific spec and plan artifacts.
-- `docs/dev-logs/` holds comparison notes and branch/worktree decisions.
+Start with `AGENTS.md`, then open `docs/index.md` for the documentation map.

--- a/docs/ai-collaboration.md
+++ b/docs/ai-collaboration.md
@@ -1,0 +1,74 @@
+# AI Collaboration Guide
+
+This document defines how Codex and other AI helpers should work in this repository.
+
+## Operating Principles
+
+- Keep each task small enough to finish in one branch.
+- Prefer isolated changes over broad refactors.
+- Use subagents only when the task can be split into independent slices.
+- Never let a subagent widen scope on its own.
+- Treat docs, code, and review as separate passes.
+
+## Recommended Agent Roles
+
+- Main orchestrator: chooses scope, sequence, and final merge order.
+- Worker agent: edits files within one owned slice.
+- Spec reviewer: checks alignment with the design and implementation docs.
+- Quality reviewer: checks buildability, maintainability, and missing setup.
+- Security reviewer: checks auth, access control, secrets, and audit coverage.
+
+## Subagent Usage Rules
+
+- Use one worker per file slice or subsystem.
+- Give each worker a narrow deliverable and a concrete finish line.
+- Do not ask a worker to solve multiple unrelated problems.
+- After implementation, run a spec review and a quality review before declaring the slice done.
+- If a review finds a blocking issue, fix it before starting the next slice.
+
+## Prompt Template for Workers
+
+Use this structure when dispatching work:
+
+```text
+You are not alone in the codebase. Do not revert or overwrite edits made by others.
+You own <slice> only.
+
+Goal:
+<one sentence>
+
+Files in scope:
+- <file or directory>
+
+Constraints:
+- <constraints>
+
+Deliverable:
+- <what must exist when you finish>
+```
+
+## Prompt Template for Reviewers
+
+Use this structure when asking for review:
+
+```text
+Review the current workspace changes for <slice>.
+Check only the files in scope and report concrete findings.
+
+Focus on:
+- spec compliance
+- buildability
+- missing configuration
+- security or audit gaps
+
+Return only actionable findings, sorted by severity.
+If there are no findings, say so explicitly.
+```
+
+## Handoff Rules
+
+- Workers should report changed files and assumptions.
+- Reviewers should report only concrete issues, not general praise.
+- The orchestrator should integrate findings, then move to the next slice.
+- Keep context small by closing agents after the slice is resolved.
+- Before a PR is opened, write a `docs/dev-logs/` entry that records the worktree comparison and the reason the selected option was chosen.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,10 @@
+# Architecture Docs
+
+This directory summarizes how the platform is split into frontend, backend, and data responsibilities.
+
+## Canonical Sources
+
+- `docs/superpowers/specs/2026-04-19-financial-decision-support-platform-design.md`
+- `docs/superpowers/plans/2026-04-19-financial-decision-support-platform-development.md`
+- `docs/superpowers/plans/2026-04-19-financial-decision-support-platform-implementation.md`
+

--- a/docs/conventions/README.md
+++ b/docs/conventions/README.md
@@ -1,0 +1,17 @@
+# Conventions
+
+This directory collects repository-wide naming and review rules.
+
+## Files
+
+- `docs/git/branch-naming.md`
+- `docs/git/issue-labels.md`
+- `.github/pull_request_template.md`
+- `docs/git/merge-request-template.md`
+
+## Use
+
+- Treat `branch-naming.md` as the source of truth for `main`, `dev`, and `feat/*`.
+- Treat `pull_request_template.md` as the canonical review checklist.
+- Keep `merge-request-template.md` aligned with the GitHub template.
+

--- a/docs/dev-logs/2026-04-19-harness-context-structure.md
+++ b/docs/dev-logs/2026-04-19-harness-context-structure.md
@@ -1,0 +1,27 @@
+# Harness Context Structure Update
+
+## What Changed
+
+- Added `docs/README.md` as the primary documentation entry point.
+- Added `docs/project/current-state.md` to hold the current operating picture.
+- Added `docs/ai-collaboration.md` for subagent and reviewer roles.
+- Added `docs/worktree-strategy.md` with A/B worktree guidance and a recommended default.
+- Added `docs/ops/README.md`, `docs/architecture/README.md`, and `docs/conventions/README.md` to group related docs.
+
+## Why
+
+- The repository needed a single, predictable read order for AI-assisted work.
+- Branch and worktree decisions needed to be explicit instead of inferred from chat.
+- The context docs were becoming fragmented, so short hub documents reduce search overhead.
+
+## Selection Rationale
+
+- Chose `main / dev / feat/*` as the branch model because it separates release, integration, and focused work cleanly.
+- Chose worktree option A, one worktree per `feat/*` branch, because it reduces file collision risk and fits subagent work best.
+- Kept the MR template as a mirror of the PR template to avoid two independent review formats drifting apart.
+
+## Verification
+
+- Checked that the new docs point to the existing spec and plan files.
+- Checked that the branch/worktree guidance matches the current repository workflow.
+

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -1,0 +1,12 @@
+# Dev Logs
+
+Use this directory to record comparison results, branch/worktree choices, and implementation notes that should survive beyond chat history.
+
+## Current Entries
+
+- `docs/dev-logs/2026-04-19-harness-context-structure.md`
+
+## Required Before PR
+
+- Any non-trivial PR should have a dev log entry before it is opened.
+- The entry should explain the A/B worktree comparison, the validation results, and why the selected option won.

--- a/docs/git/branch-naming.md
+++ b/docs/git/branch-naming.md
@@ -1,40 +1,49 @@
 # Branch Naming
 
-Use short, predictable branch names that encode the type of work and the issue or task reference.
+Use short, predictable branch names that encode the type of work and the scope of the change.
 
-## Recommended format
+## Branch Model
+
+- `main` is the release branch.
+- `dev` is the integration branch.
+- `feat/*` is for focused feature work.
+- `fix/*` is for bug fixes.
+- `docs/*` is for documentation-only changes.
+- `chore/*` is for maintenance and tooling.
+
+## Recommended Format
+
+```text
+<type>/<short-slug>
+```
+
+If an issue number is available, include it in the slug:
 
 ```text
 <type>/<issue-number>-<short-slug>
 ```
 
-## Types
-
-- `feat/` for new features
-- `fix/` for bug fixes
-- `chore/` for maintenance and tooling
-- `docs/` for documentation only
-- `refactor/` for structural changes without behavior changes
-- `hotfix/` for urgent production fixes
-
 ## Examples
 
-- `feat/164-ux-b`
+- `feat/platform-scaffold`
+- `feat/164-frontend-dashboard`
 - `fix/203-auth-token-refresh`
 - `chore/ci-template-update`
-- `docs/harness-guides`
+- `docs/ai-collaboration`
 
 ## Rules
 
 - Keep the slug short and readable.
-- Put the issue number first when one exists.
 - Do not use spaces or uppercase letters.
 - Prefer one branch per logical change.
 - If the work splits into independent pieces, create separate branches instead of widening one branch.
+- Branch feature work from `dev`, not from `main`.
 
 ## Workflow
 
-1. Create the branch from `main`.
-2. Use the branch for one focused change.
-3. Open a PR as soon as the branch is reviewable.
-4. Delete the branch after merge.
+1. Start from `dev` for feature work.
+2. Create a `feat/*` branch for one focused change.
+3. Use a dedicated worktree for the branch when the change is non-trivial.
+4. Open a PR into `dev` as soon as the branch is reviewable.
+5. Merge `dev` into `main` only after integration checks pass.
+6. Delete the branch and its worktree after merge.

--- a/docs/git/merge-request-template.md
+++ b/docs/git/merge-request-template.md
@@ -1,32 +1,5 @@
 # Merge Request Template
 
-Use this content if the repository is mirrored to GitLab or another host that uses merge requests instead of pull requests.
+This file mirrors `.github/pull_request_template.md` for hosts that use merge requests instead of pull requests.
 
-## Summary
-
-Describe the change in one or two sentences.
-
-## What Changed
-
-- 
-- 
-
-## Why
-
-Explain the reason for the change and the problem it solves.
-
-## Validation
-
-- [ ] Ran the relevant tests
-- [ ] Verified the affected screens or APIs manually
-- [ ] Checked for regressions in nearby flows
-
-## Screenshots or Logs
-
-Add screenshots, sample payloads, or logs if they help review.
-
-## Checklist
-
-- [ ] The scope is limited to this MR
-- [ ] Documentation was updated if behavior changed
-- [ ] Follow-up work is listed as a separate issue if needed
+Use the GitHub template as the canonical content. Keep both files aligned when the review checklist changes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Documentation Index
 
-This is a secondary map for the documentation tree. `AGENTS.md` is the canonical entry point.
+This is the canonical documentation map after `AGENTS.md`.
 
 ## Key Areas
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+# Documentation Index
+
+This is a secondary map for the documentation tree. `AGENTS.md` is the canonical entry point.
+
+## Key Areas
+
+- Frontend UI: `frontend/`
+- Backend API: `backend/`
+- Database and seed data: `supabase/`
+- AI harness and generated context: `.codex/` and `.codex-plugin/`
+- Operational docs: `docs/project/`, `docs/ops/`, `docs/conventions/`, `docs/dev-logs/`
+
+## Canonical Conventions
+
+- Use `main` for release-ready commits only.
+- Use `dev` as the integration branch.
+- Use `feat/*` branches for focused work items.
+- Prefer one worktree per `feat/*` branch.
+- Keep review comments and implementation notes in the relevant docs instead of scattered chat history.

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -6,4 +6,4 @@ This directory holds workflow rules that help AI and humans work safely in the r
 
 - `docs/ai-collaboration.md`: subagent roles, prompt templates, and handoff rules.
 - `docs/worktree-strategy.md`: branch and worktree policy with A/B comparison.
-
+- `docs/ops/pr-ai-review.md`: GitHub Actions-based AI review flow for pull requests.

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -1,0 +1,9 @@
+# Operations Docs
+
+This directory holds workflow rules that help AI and humans work safely in the repo.
+
+## Files
+
+- `docs/ai-collaboration.md`: subagent roles, prompt templates, and handoff rules.
+- `docs/worktree-strategy.md`: branch and worktree policy with A/B comparison.
+

--- a/docs/ops/pr-ai-review.md
+++ b/docs/ops/pr-ai-review.md
@@ -1,0 +1,32 @@
+# PR AI Review
+
+This repository can run an automated AI review on pull requests through GitHub Actions.
+
+## What It Does
+
+- Triggers when a pull request is opened, updated, reopened, or marked ready for review.
+- Collects the PR metadata and changed files from GitHub.
+- Sends the diff and repository rules to OpenAI for review.
+- Posts the result back to the PR as a GitHub review.
+
+## Required Secrets
+
+- `OPENAI_API_KEY`: used by the workflow to call the OpenAI Responses API.
+
+## Behavior
+
+- The workflow uses the repository's base branch context, not the pull request branch code.
+- If the same commit has already been reviewed by the bot, the run exits early.
+- If the model reports blocking issues, the review is submitted with a change-request event.
+- Otherwise, the review is submitted as a comment-only review so every PR still receives feedback.
+
+## Safety Rules
+
+- Do not check out or execute untrusted pull request code in the review job.
+- Keep the prompt focused on changed files and repository rules.
+- Fail clearly if the OpenAI secret is missing.
+
+## Tuning
+
+- `OPENAI_MODEL` can override the default review model.
+- If the prompt becomes too large, trim long patches before sending them to the model.

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,0 +1,8 @@
+# Project Docs
+
+Use this directory for the current operating picture of the project.
+
+## Files
+
+- `docs/project/current-state.md`: current scope, stack, and execution state.
+

--- a/docs/project/current-state.md
+++ b/docs/project/current-state.md
@@ -1,0 +1,29 @@
+# Current State
+
+## Project
+
+- Product: insurance/financial services new business decision support platform
+- Core flow: ABC cost allocation plus DCF investment evaluation
+- Primary users: planner, finance reviewer, executive
+
+## Current Stack
+
+- Frontend: React 18, TypeScript, Vite, Tailwind CSS
+- Backend: Java 21, Spring Boot 3.x
+- Database and auth: Supabase PostgreSQL and Supabase Auth
+- Deployment: Cloudflare Pages for frontend and a separate Spring runtime for backend
+
+## Current Implementation Snapshot
+
+- The frontend has a working Vite app scaffold with a dashboard-style landing page.
+- The backend has a Spring Boot scaffold with a checked-in Gradle wrapper bootstrap.
+- The database folder has initial migration and seed placeholders.
+- The repository now has branch, worktree, and AI collaboration docs to keep agent work isolated.
+
+## Immediate Direction
+
+- Keep feature work on `feat/*` branches.
+- Use one worktree per active feature branch.
+- Split new work into small vertical slices.
+- Review every slice for spec fit and buildability before moving on.
+

--- a/docs/worktree-strategy.md
+++ b/docs/worktree-strategy.md
@@ -1,0 +1,95 @@
+# Worktree Strategy
+
+This repository uses branch-isolated worktrees to keep AI-driven changes manageable.
+
+## Branch Model
+
+- `main`: release-only branch.
+- `dev`: integration branch for reviewed work.
+- `feat/*`: one focused branch per feature or change set.
+- `fix/*`: one focused branch per bug fix.
+- `docs/*`: documentation-only changes.
+
+## Recommended Branch Format
+
+```text
+<type>/<short-slug>
+```
+
+Examples:
+
+- `feat/platform-scaffold`
+- `feat/backend-api`
+- `feat/frontend-dashboard`
+- `fix/cors-auth-flow`
+- `docs/ai-collaboration`
+
+## Worktree Rules
+
+- Create a separate worktree for every active `feat/*` branch.
+- Keep one concern per worktree.
+- Do not mix frontend, backend, database, and docs work in the same active worktree unless the change is intentionally cross-cutting and small.
+- Remove a worktree after the branch is merged or abandoned.
+
+## A/B Operating Modes
+
+### A. Feature Worktree Per Branch
+
+Use one worktree per `feat/*` branch.
+
+Pros:
+
+- Minimal file collision risk
+- Clean agent ownership
+- Easy parallelization
+
+Cons:
+
+- More directories to manage
+- Slightly more setup work
+
+### B. Phase Worktree Per Milestone
+
+Use one worktree per phase, such as `phase-1-core`, `phase-2-ui`, `phase-3-security`.
+
+Pros:
+
+- Fewer directories
+- Simpler for very small teams
+
+Cons:
+
+- More scope mixing
+- Harder to run AI workers in parallel
+- More likely to accumulate unrelated edits
+
+## Recommendation
+
+Use **A. Feature Worktree Per Branch** for this project.
+
+Reason:
+
+- The project is small enough that clean isolation matters more than reducing folder count.
+- The work naturally splits into independent slices: database, backend, frontend, security, and deployment.
+- AI workers are easier to coordinate when each branch has one responsibility.
+
+## Required Comparison Log
+
+Before opening a PR for any non-trivial change, write a dev log entry that includes:
+
+- the A/B worktree options considered
+- the file scope of each option
+- the validation results for each option
+- the reason the selected option was chosen
+
+Use `docs/dev-logs/` for that record so the decision survives outside chat history.
+
+## Practical Flow
+
+1. Start from `dev`.
+2. Create `feat/<short-slug>`.
+3. Create a dedicated worktree for that branch.
+4. Implement one slice.
+5. Validate.
+6. Open a PR into `dev`.
+7. Delete the worktree after merge.

--- a/scripts/ai-pr-review.mjs
+++ b/scripts/ai-pr-review.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+
+const githubToken = process.env.GITHUB_TOKEN;
+const openaiApiKey = process.env.OPENAI_API_KEY;
+const repository = process.env.GITHUB_REPOSITORY;
+const eventPath = process.env.GITHUB_EVENT_PATH;
+const openaiModel = process.env.OPENAI_MODEL || 'gpt-5.1';
+
+if (!githubToken) {
+  throw new Error('GITHUB_TOKEN is required');
+}
+
+if (!openaiApiKey) {
+  throw new Error('OPENAI_API_KEY is required');
+}
+
+if (!repository) {
+  throw new Error('GITHUB_REPOSITORY is required');
+}
+
+if (!eventPath) {
+  throw new Error('GITHUB_EVENT_PATH is required');
+}
+
+const event = JSON.parse(await fs.readFile(eventPath, 'utf8'));
+const pullRequest = event.pull_request;
+
+if (!pullRequest?.number) {
+  throw new Error('This workflow only supports pull request events');
+}
+
+const [owner, repo] = repository.split('/');
+if (!owner || !repo) {
+  throw new Error(`Invalid repository value: ${repository}`);
+}
+
+const marker = '<!-- ai-pr-review-bot -->';
+const headSha = pullRequest.head?.sha;
+const pullNumber = pullRequest.number;
+
+if (pullRequest.head?.repo?.full_name !== repository) {
+  console.log('Skipping forked pull request.');
+  process.exit(0);
+}
+
+const ghRequest = async (path, init = {}) => {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${githubToken}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'costwise-ai-pr-review-bot',
+      ...(init.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed (${response.status} ${response.statusText}) for ${path}`);
+  }
+
+  return response;
+};
+
+const listAll = async (path) => {
+  const items = [];
+  let page = 1;
+
+  while (true) {
+    const response = await ghRequest(`${path}${path.includes('?') ? '&' : '?'}per_page=100&page=${page}`);
+    const batch = await response.json();
+    if (!Array.isArray(batch) || batch.length === 0) {
+      break;
+    }
+
+    items.push(...batch);
+    if (batch.length < 100) {
+      break;
+    }
+    page += 1;
+  }
+
+  return items;
+};
+
+const existingReviews = await listAll(`/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`);
+const alreadyReviewed = existingReviews.some((review) => {
+  return review?.user?.login === 'github-actions[bot]'
+    && review?.commit_id === headSha
+    && typeof review?.body === 'string'
+    && review.body.includes(marker);
+});
+
+if (alreadyReviewed) {
+  console.log('Skipping because this commit already has a bot review.');
+  process.exit(0);
+}
+
+const changedFiles = await listAll(`/repos/${owner}/${repo}/pulls/${pullNumber}/files`);
+const repoFilesToRead = [
+  'AGENTS.md',
+  'docs/ops/README.md',
+  'docs/ops/pr-ai-review.md',
+  'docs/ai-collaboration.md',
+  'docs/worktree-strategy.md',
+  'docs/dev-logs/README.md',
+  'docs/git/branch-naming.md',
+];
+
+const readTextFile = async (relativePath) => {
+  try {
+    return await fs.readFile(new URL(`../${relativePath}`, import.meta.url), 'utf8');
+  } catch {
+    return null;
+  }
+};
+
+const repositoryRules = {};
+for (const relativePath of repoFilesToRead) {
+  const content = await readTextFile(relativePath);
+  if (content) {
+    repositoryRules[relativePath] = content;
+  }
+}
+
+const trimmedFiles = changedFiles.map((file) => {
+  const patch = typeof file.patch === 'string' ? file.patch.slice(0, 4000) : '';
+  return {
+    filename: file.filename,
+    status: file.status,
+    additions: file.additions,
+    deletions: file.deletions,
+    patch: patch || '[patch omitted]',
+  };
+});
+
+const reviewSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    summary: { type: 'string' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          severity: { type: 'string', enum: ['low', 'medium', 'high'] },
+          title: { type: 'string' },
+          body: { type: 'string' },
+          file: { type: 'string' },
+          line: { type: ['integer', 'null'] },
+        },
+        required: ['severity', 'title', 'body', 'file', 'line'],
+      },
+    },
+  },
+  required: ['summary', 'findings'],
+};
+
+const prompt = [
+  {
+    role: 'system',
+    content: [
+      {
+        type: 'input_text',
+        text: [
+          'You are a rigorous pull request reviewer for this repository.',
+          'Focus on concrete, actionable issues only.',
+          'Use the repository rules and the diff context to evaluate correctness, maintainability, and safety.',
+          'Return only structured JSON that matches the provided schema.',
+        ].join(' '),
+      },
+    ],
+  },
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'input_text',
+        text: JSON.stringify(
+          {
+            repository,
+            pullRequest: {
+              number: pullNumber,
+              title: pullRequest.title,
+              body: pullRequest.body,
+              draft: pullRequest.draft,
+              base: pullRequest.base?.ref,
+              head: pullRequest.head?.ref,
+              headSha,
+            },
+            repositoryRules,
+            changedFiles: trimmedFiles,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  },
+];
+
+const openaiResponse = await fetch('https://api.openai.com/v1/responses', {
+  method: 'POST',
+  headers: {
+    Authorization: `Bearer ${openaiApiKey}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    model: openaiModel,
+    input: prompt,
+    text: {
+      format: {
+        type: 'json_schema',
+        name: 'pr_review',
+        strict: true,
+        schema: reviewSchema,
+      },
+    },
+    temperature: 0.2,
+    max_output_tokens: 2000,
+  }),
+});
+
+if (!openaiResponse.ok) {
+  const errorText = await openaiResponse.text();
+  throw new Error(`OpenAI request failed (${openaiResponse.status} ${openaiResponse.statusText}): ${errorText}`);
+}
+
+const responseJson = await openaiResponse.json();
+
+const extractText = (response) => {
+  if (typeof response?.output_text === 'string' && response.output_text.trim()) {
+    return response.output_text;
+  }
+
+  for (const item of response?.output || []) {
+    for (const content of item?.content || []) {
+      if (content?.type === 'output_text' && typeof content.text === 'string') {
+        return content.text;
+      }
+    }
+  }
+
+  return null;
+};
+
+const outputText = extractText(responseJson);
+if (!outputText) {
+  throw new Error('OpenAI response did not include output text');
+}
+
+let parsed;
+try {
+  parsed = JSON.parse(outputText);
+} catch (error) {
+  throw new Error(`Failed to parse OpenAI JSON output: ${error.message}\nRaw output: ${outputText}`);
+}
+
+const findings = Array.isArray(parsed.findings) ? parsed.findings : [];
+const summary = typeof parsed.summary === 'string' ? parsed.summary.trim() : '';
+const hasBlockingIssue = findings.some((finding) => finding.severity === 'high');
+
+const reviewLines = [
+  marker,
+  '## AI 검토 요약',
+  summary || '검토 요약을 생성하지 못했습니다.',
+];
+
+if (findings.length > 0) {
+  reviewLines.push('', '## 발견 사항');
+  for (const finding of findings) {
+    const location = finding.file ? ` \`${finding.file}\`${finding.line ? `:${finding.line}` : ''}` : '';
+    reviewLines.push(`- [${finding.severity}] ${finding.title}${location}`);
+    reviewLines.push(`  - ${finding.body}`);
+  }
+} else {
+  reviewLines.push('', '## 발견 사항', '- 중대한 문제는 발견하지 못했습니다.');
+}
+
+const reviewBody = reviewLines.join('\n');
+const reviewEvent = hasBlockingIssue ? 'REQUEST_CHANGES' : 'COMMENT';
+
+const submitResponse = await ghRequest(`/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`, {
+  method: 'POST',
+  body: JSON.stringify({
+    body: reviewBody,
+    event: reviewEvent,
+  }),
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+const submitted = await submitResponse.json();
+console.log(`Submitted PR review ${submitted.id} with event ${reviewEvent}.`);


### PR DESCRIPTION
## 요약

문서 진입점을 정리하고 PR/이슈 템플릿을 한국어로 통일했습니다.

## 변경 내용

- `AGENTS.md`가 단독 진입점이 되도록 문서 허브를 정리했습니다.
- `docs/index.md`를 문서 맵의 기준으로 두고 `docs/README.md`는 얇은 안내문으로 낮췄습니다.
- PR 템플릿을 한국어로 바꿨습니다.
- 버그 신고와 기능 요청 이슈 템플릿을 한국어로 바꿨습니다.

## 이유

새 에이전트와 기여자가 문서와 이슈/PR 흐름을 바로 이해할 수 있게 하려는 목적입니다.

## 검증

- [x] 변경된 템플릿과 문서의 문구를 확인했습니다.
- [x] 브랜치와 푸시 상태를 확인했습니다.
- [x] PR 본문을 템플릿에 맞춰 갱신했습니다.

## 스크린샷 또는 로그

UI 변경은 없습니다.

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [x] 후속 작업이 필요하면 별도 이슈로 분리했습니다.

## 브랜치

- [x] 작업은 집중된 `feat/*` 브랜치에서 진행했습니다.
- [x] 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.