### PR TITLE
[기능] 프론트 대시보드 및 상세 화면 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ frontend/build/
 frontend/*.tsbuildinfo
 backend/build/
 backend/.gradle/
+backend/.gradle-user/
 backend/wrapper-build/
 .gradle/
 .worktrees/

--- a/backend/src/main/java/com/costwise/api/ComputeController.java
+++ b/backend/src/main/java/com/costwise/api/ComputeController.java
@@ -1,0 +1,26 @@
+package com.costwise.api;
+
+import com.costwise.api.dto.ComputeRequest;
+import com.costwise.api.dto.ComputeResponse;
+import com.costwise.service.ComputeFacade;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class ComputeController {
+
+    private final ComputeFacade computeFacade;
+
+    public ComputeController(ComputeFacade computeFacade) {
+        this.computeFacade = computeFacade;
+    }
+
+    @PostMapping("/compute")
+    public ComputeResponse compute(@Valid @RequestBody ComputeRequest request) {
+        return computeFacade.compute(request);
+    }
+}

--- a/backend/src/main/java/com/costwise/api/dto/ComputeRequest.java
+++ b/backend/src/main/java/com/costwise/api/dto/ComputeRequest.java
@@ -1,0 +1,36 @@
+package com.costwise.api.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.util.List;
+
+public record ComputeRequest(
+        @NotBlank String projectName,
+        @NotNull @DecimalMin(value = "0.0", inclusive = true) BigDecimal discountRate,
+        @NotEmpty @Valid List<DepartmentInput> departments,
+        @NotEmpty @Valid List<CostPoolInput> costPools,
+        @NotEmpty @Valid List<CashFlowInput> cashFlows) {
+
+    public record DepartmentInput(@NotBlank String id, @NotBlank String name) {}
+
+    public record CostPoolInput(
+            @NotBlank String name,
+            @NotNull @DecimalMin(value = "0.0", inclusive = true) BigDecimal amount,
+            @NotEmpty @Valid List<AllocationTargetInput> allocationTargets) {}
+
+    public record AllocationTargetInput(
+            @NotBlank String departmentId,
+            @NotBlank String departmentName,
+            @NotNull @DecimalMin(value = "0.0", inclusive = true) BigDecimal weight) {}
+
+    public record CashFlowInput(
+            @Min(0) int periodNo,
+            @NotBlank String periodLabel,
+            @NotBlank String yearLabel,
+            @NotNull BigDecimal netCashFlow) {}
+}

--- a/backend/src/main/java/com/costwise/api/dto/ComputeResponse.java
+++ b/backend/src/main/java/com/costwise/api/dto/ComputeResponse.java
@@ -1,0 +1,38 @@
+package com.costwise.api.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record ComputeResponse(
+        String projectName,
+        BigDecimal discountRate,
+        AbcResult abc,
+        DcfResult dcf,
+        List<String> warnings) {
+
+    public record AbcResult(
+            BigDecimal totalAllocatedCost,
+            List<DepartmentAllocation> departmentAllocations) {}
+
+    public record DepartmentAllocation(
+            String departmentId,
+            String departmentName,
+            BigDecimal allocatedCost,
+            List<CostPoolAllocation> costPoolAllocations) {}
+
+    public record CostPoolAllocation(String costPoolName, BigDecimal allocatedCost) {}
+
+    public record DcfResult(
+            BigDecimal npv,
+            Double irr,
+            Double paybackPeriodYears,
+            List<CashFlowProjection> projections) {}
+
+    public record CashFlowProjection(
+            int periodNo,
+            String periodLabel,
+            String yearLabel,
+            BigDecimal netCashFlow,
+            BigDecimal discountedCashFlow,
+            BigDecimal cumulativeCashFlow) {}
+}

--- a/backend/src/main/java/com/costwise/config/SecurityConfig.java
+++ b/backend/src/main/java/com/costwise/config/SecurityConfig.java
@@ -17,7 +17,7 @@ public class SecurityConfig {
         http.cors(Customizer.withDefaults());
         http.authorizeHttpRequests(
                 auth -> auth
-                        .requestMatchers("/api/health", "/actuator/health", "/actuator/info")
+                        .requestMatchers("/api/health", "/api/dashboard", "/api/compute", "/actuator/health", "/actuator/info")
                         .permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**")
                         .permitAll()

--- a/backend/src/main/java/com/costwise/service/AbcAllocationService.java
+++ b/backend/src/main/java/com/costwise/service/AbcAllocationService.java
@@ -1,0 +1,99 @@
+package com.costwise.service;
+
+import com.costwise.api.dto.ComputeRequest;
+import com.costwise.api.dto.ComputeResponse;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AbcAllocationService {
+
+    public AbcResult allocate(ComputeRequest request) {
+        Map<String, DepartmentAccumulator> departments = new LinkedHashMap<>();
+        for (ComputeRequest.DepartmentInput department : request.departments()) {
+            departments.put(
+                    department.id(),
+                    new DepartmentAccumulator(department.id(), department.name()));
+        }
+
+        List<String> warnings = new java.util.ArrayList<>();
+
+        for (ComputeRequest.CostPoolInput costPool : request.costPools()) {
+            BigDecimal poolAmount = costPool.amount().setScale(2, RoundingMode.HALF_UP);
+            BigDecimal weightSum = BigDecimal.ZERO;
+
+            for (ComputeRequest.AllocationTargetInput target : costPool.allocationTargets()) {
+                DepartmentAccumulator accumulator = departments.get(target.departmentId());
+                if (accumulator == null) {
+                    warnings.add("Unknown department referenced in cost pool '" + costPool.name() + "': " + target.departmentId());
+                    continue;
+                }
+
+                BigDecimal allocatedAmount =
+                        poolAmount.multiply(target.weight()).setScale(2, RoundingMode.HALF_UP);
+                accumulator.addAllocation(costPool.name(), allocatedAmount);
+                weightSum = weightSum.add(target.weight());
+            }
+
+            if (weightSum.compareTo(BigDecimal.ONE) != 0) {
+                warnings.add(
+                        "Weights for cost pool '"
+                                + costPool.name()
+                                + "' sum to "
+                                + weightSum.toPlainString()
+                                + " instead of 1.0");
+            }
+        }
+
+        List<ComputeResponse.DepartmentAllocation> allocations =
+                departments.values().stream().map(DepartmentAccumulator::toResponse).toList();
+
+        BigDecimal totalAllocatedCost =
+                allocations.stream()
+                        .map(ComputeResponse.DepartmentAllocation::allocatedCost)
+                        .reduce(BigDecimal.ZERO, BigDecimal::add)
+                        .setScale(2, RoundingMode.HALF_UP);
+
+        return new AbcResult(totalAllocatedCost, allocations, warnings);
+    }
+
+    public record AbcResult(
+            BigDecimal totalAllocatedCost,
+            List<ComputeResponse.DepartmentAllocation> departmentAllocations,
+            List<String> warnings) {}
+
+    private static final class DepartmentAccumulator {
+        private final String departmentId;
+        private final String departmentName;
+        private final Map<String, BigDecimal> costPoolAllocations = new LinkedHashMap<>();
+        private BigDecimal allocatedCost = BigDecimal.ZERO;
+
+        private DepartmentAccumulator(String departmentId, String departmentName) {
+            this.departmentId = departmentId;
+            this.departmentName = departmentName;
+        }
+
+        private void addAllocation(String costPoolName, BigDecimal amount) {
+            costPoolAllocations.merge(costPoolName, amount, BigDecimal::add);
+            allocatedCost = allocatedCost.add(amount);
+        }
+
+        private ComputeResponse.DepartmentAllocation toResponse() {
+            List<ComputeResponse.CostPoolAllocation> breakdown =
+                    costPoolAllocations.entrySet().stream()
+                            .map(entry -> new ComputeResponse.CostPoolAllocation(entry.getKey(), entry.getValue()))
+                            .toList();
+
+            return new ComputeResponse.DepartmentAllocation(
+                    departmentId,
+                    departmentName,
+                    allocatedCost.setScale(2, RoundingMode.HALF_UP),
+                    breakdown);
+        }
+    }
+}

--- a/backend/src/main/java/com/costwise/service/ComputeFacade.java
+++ b/backend/src/main/java/com/costwise/service/ComputeFacade.java
@@ -1,0 +1,72 @@
+package com.costwise.service;
+
+import com.costwise.api.dto.ComputeRequest;
+import com.costwise.api.dto.ComputeResponse;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ComputeFacade {
+
+    private final AbcAllocationService abcAllocationService;
+    private final DcfValuationService dcfValuationService;
+
+    public ComputeFacade(
+            AbcAllocationService abcAllocationService, DcfValuationService dcfValuationService) {
+        this.abcAllocationService = abcAllocationService;
+        this.dcfValuationService = dcfValuationService;
+    }
+
+    public ComputeResponse compute(ComputeRequest request) {
+        validateDepartments(request);
+
+        AbcAllocationService.AbcResult abcResult = abcAllocationService.allocate(request);
+        DcfValuationService.DcfResult dcfResult =
+                dcfValuationService.evaluate(request.cashFlows(), request.discountRate());
+
+        List<String> warnings = new ArrayList<>();
+        warnings.addAll(abcResult.warnings());
+
+        if (dcfResult.irr() == null) {
+            warnings.add("IRR could not be resolved for the provided cash flows.");
+        }
+
+        if (dcfResult.paybackPeriodYears() == null) {
+            warnings.add("Payback period could not be resolved for the provided cash flows.");
+        }
+
+        return new ComputeResponse(
+                request.projectName(),
+                request.discountRate(),
+                new ComputeResponse.AbcResult(abcResult.totalAllocatedCost(), abcResult.departmentAllocations()),
+                new ComputeResponse.DcfResult(
+                        dcfResult.npv(),
+                        dcfResult.irr(),
+                        dcfResult.paybackPeriodYears(),
+                        dcfResult.projections()),
+                warnings);
+    }
+
+    private void validateDepartments(ComputeRequest request) {
+        Set<String> departmentIds = new HashSet<>();
+        for (ComputeRequest.DepartmentInput department : request.departments()) {
+            if (!departmentIds.add(department.id())) {
+                throw new IllegalArgumentException("Duplicate department id: " + department.id());
+            }
+        }
+
+        Set<String> knownDepartmentIds = departmentIds;
+        for (ComputeRequest.CostPoolInput costPool : request.costPools()) {
+            for (ComputeRequest.AllocationTargetInput target : costPool.allocationTargets()) {
+                if (!knownDepartmentIds.contains(target.departmentId())) {
+                    throw new IllegalArgumentException(
+                            "Unknown department id '" + target.departmentId() + "' in cost pool '" + costPool.name() + "'");
+                }
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/costwise/service/DcfValuationService.java
+++ b/backend/src/main/java/com/costwise/service/DcfValuationService.java
@@ -1,0 +1,145 @@
+package com.costwise.service;
+
+import com.costwise.api.dto.ComputeRequest;
+import com.costwise.api.dto.ComputeResponse;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DcfValuationService {
+
+    public DcfResult evaluate(List<ComputeRequest.CashFlowInput> cashFlows, BigDecimal discountRate) {
+        List<ComputeRequest.CashFlowInput> orderedCashFlows =
+                cashFlows.stream().sorted(Comparator.comparingInt(ComputeRequest.CashFlowInput::periodNo)).toList();
+
+        List<ComputeResponse.CashFlowProjection> projections = new ArrayList<>();
+        double rate = discountRate.doubleValue();
+        double cumulativeCashFlow = 0.0;
+        double npv = 0.0;
+        double[] amounts = new double[orderedCashFlows.size()];
+
+        for (int index = 0; index < orderedCashFlows.size(); index++) {
+            ComputeRequest.CashFlowInput cashFlow = orderedCashFlows.get(index);
+            double amount = cashFlow.netCashFlow().doubleValue();
+            amounts[index] = amount;
+
+            double discounted = amount / Math.pow(1.0 + rate, cashFlow.periodNo());
+            cumulativeCashFlow += amount;
+            npv += discounted;
+
+            projections.add(
+                    new ComputeResponse.CashFlowProjection(
+                            cashFlow.periodNo(),
+                            cashFlow.periodLabel(),
+                            cashFlow.yearLabel(),
+                            cashFlow.netCashFlow().setScale(2, RoundingMode.HALF_UP),
+                            BigDecimal.valueOf(discounted).setScale(2, RoundingMode.HALF_UP),
+                            BigDecimal.valueOf(cumulativeCashFlow).setScale(2, RoundingMode.HALF_UP)));
+        }
+
+        Double irr = solveIrr(amounts);
+        Double paybackPeriodYears = calculatePaybackPeriodYears(orderedCashFlows);
+
+        return new DcfResult(
+                BigDecimal.valueOf(npv).setScale(2, RoundingMode.HALF_UP),
+                irr == null ? null : round(irr, 6),
+                paybackPeriodYears == null ? null : round(paybackPeriodYears, 2),
+                projections);
+    }
+
+    public record DcfResult(
+            BigDecimal npv,
+            Double irr,
+            Double paybackPeriodYears,
+            List<ComputeResponse.CashFlowProjection> projections) {}
+
+    private Double solveIrr(double[] cashFlows) {
+        boolean hasPositive = false;
+        boolean hasNegative = false;
+        for (double cashFlow : cashFlows) {
+            if (cashFlow > 0) {
+                hasPositive = true;
+            }
+            if (cashFlow < 0) {
+                hasNegative = true;
+            }
+        }
+
+        if (!hasPositive || !hasNegative) {
+            return null;
+        }
+
+        double guess = 0.1;
+        for (int iteration = 0; iteration < 100; iteration++) {
+            double npv = 0.0;
+            double derivative = 0.0;
+
+            for (int period = 0; period < cashFlows.length; period++) {
+                double discountFactor = Math.pow(1.0 + guess, period);
+                npv += cashFlows[period] / discountFactor;
+
+                if (period > 0) {
+                    derivative -= period * cashFlows[period] / (discountFactor * (1.0 + guess));
+                }
+            }
+
+            if (Math.abs(npv) < 1e-9) {
+                return guess;
+            }
+
+            if (Math.abs(derivative) < 1e-9) {
+                return null;
+            }
+
+            double nextGuess = guess - (npv / derivative);
+            if (Double.isNaN(nextGuess) || Double.isInfinite(nextGuess) || nextGuess <= -0.9999) {
+                return null;
+            }
+
+            if (Math.abs(nextGuess - guess) < 1e-9) {
+                return nextGuess;
+            }
+
+            guess = nextGuess;
+        }
+
+        return guess;
+    }
+
+    private Double calculatePaybackPeriodYears(List<ComputeRequest.CashFlowInput> cashFlows) {
+        double cumulative = 0.0;
+        ComputeRequest.CashFlowInput previous = null;
+
+        for (ComputeRequest.CashFlowInput cashFlow : cashFlows) {
+            cumulative += cashFlow.netCashFlow().doubleValue();
+            if (cumulative >= 0.0) {
+                if (previous == null) {
+                    return 0.0;
+                }
+
+                double previousCumulative =
+                        cumulative - cashFlow.netCashFlow().doubleValue();
+                double amountInCurrentPeriod = cashFlow.netCashFlow().doubleValue();
+                if (amountInCurrentPeriod == 0.0) {
+                    return (double) cashFlow.periodNo();
+                }
+
+                double fraction = (0.0 - previousCumulative) / amountInCurrentPeriod;
+                return previous.periodNo() + fraction;
+            }
+
+            previous = cashFlow;
+        }
+
+        return null;
+    }
+
+    private static double round(double value, int scale) {
+        double factor = Math.pow(10.0, scale);
+        return Math.round(value * factor) / factor;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,9 +1,6 @@
 spring:
   application:
     name: finance-platform-backend
-spring:
-  application:
-    name: finance-platform-backend
 
 server:
   port: 8080

--- a/backend/src/test/java/com/costwise/service/AbcAllocationServiceTest.java
+++ b/backend/src/test/java/com/costwise/service/AbcAllocationServiceTest.java
@@ -1,0 +1,58 @@
+package com.costwise.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.costwise.api.dto.ComputeRequest;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AbcAllocationServiceTest {
+
+    private final AbcAllocationService service = new AbcAllocationService();
+
+    @Test
+    void allocatesCostPoolsAcrossDepartments() {
+        ComputeRequest request = sampleRequest();
+
+        AbcAllocationService.AbcResult result = service.allocate(request);
+
+        assertEquals(new BigDecimal("60000000.00"), result.totalAllocatedCost());
+        assertFalse(result.departmentAllocations().isEmpty());
+        assertEquals(new BigDecimal("25200000.00"), result.departmentAllocations().get(0).allocatedCost());
+        assertEquals(new BigDecimal("20400000.00"), result.departmentAllocations().get(1).allocatedCost());
+        assertEquals(new BigDecimal("14400000.00"), result.departmentAllocations().get(2).allocatedCost());
+    }
+
+    private static ComputeRequest sampleRequest() {
+        return new ComputeRequest(
+                "보험사 신규 사업 타당성 분석",
+                new BigDecimal("0.10"),
+                List.of(
+                        new ComputeRequest.DepartmentInput("prod", "상품전략본부"),
+                        new ComputeRequest.DepartmentInput("ops", "채널운영본부"),
+                        new ComputeRequest.DepartmentInput("data", "데이터플랫폼팀")),
+                List.of(
+                        new ComputeRequest.CostPoolInput(
+                                "인건비",
+                                new BigDecimal("48000000"),
+                                List.of(
+                                        new ComputeRequest.AllocationTargetInput("prod", "상품전략본부", new BigDecimal("0.40")),
+                                        new ComputeRequest.AllocationTargetInput("ops", "채널운영본부", new BigDecimal("0.35")),
+                                        new ComputeRequest.AllocationTargetInput("data", "데이터플랫폼팀", new BigDecimal("0.25")))),
+                        new ComputeRequest.CostPoolInput(
+                                "클라우드/인프라",
+                                new BigDecimal("12000000"),
+                                List.of(
+                                        new ComputeRequest.AllocationTargetInput("prod", "상품전략본부", new BigDecimal("0.50")),
+                                        new ComputeRequest.AllocationTargetInput("ops", "채널운영본부", new BigDecimal("0.30")),
+                                        new ComputeRequest.AllocationTargetInput("data", "데이터플랫폼팀", new BigDecimal("0.20"))))),
+                List.of(
+                        new ComputeRequest.CashFlowInput(0, "투자시점", "2026", new BigDecimal("-70000000")),
+                        new ComputeRequest.CashFlowInput(1, "1년차", "2027", new BigDecimal("25000000")),
+                        new ComputeRequest.CashFlowInput(2, "2년차", "2028", new BigDecimal("30000000")),
+                        new ComputeRequest.CashFlowInput(3, "3년차", "2029", new BigDecimal("32000000")),
+                        new ComputeRequest.CashFlowInput(4, "4년차", "2030", new BigDecimal("35000000"))));
+    }
+}

--- a/backend/src/test/java/com/costwise/service/DcfValuationServiceTest.java
+++ b/backend/src/test/java/com/costwise/service/DcfValuationServiceTest.java
@@ -1,0 +1,59 @@
+package com.costwise.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.costwise.api.dto.ComputeRequest;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DcfValuationServiceTest {
+
+    private final DcfValuationService service = new DcfValuationService();
+
+    @Test
+    void calculatesNpvIrrAndPaybackPeriod() {
+        DcfValuationService.DcfResult result =
+                service.evaluate(sampleRequest().cashFlows(), sampleRequest().discountRate());
+
+        assertEquals(new BigDecimal("25468205.72"), result.npv());
+        assertNotNull(result.irr());
+        assertTrue(result.irr() > 0.15 && result.irr() < 0.25);
+        assertNotNull(result.paybackPeriodYears());
+        assertTrue(result.paybackPeriodYears() > 2.3 && result.paybackPeriodYears() < 2.6);
+        assertEquals(5, result.projections().size());
+    }
+
+    private static ComputeRequest sampleRequest() {
+        return new ComputeRequest(
+                "보험사 신규 사업 타당성 분석",
+                new BigDecimal("0.10"),
+                List.of(
+                        new ComputeRequest.DepartmentInput("prod", "상품전략본부"),
+                        new ComputeRequest.DepartmentInput("ops", "채널운영본부"),
+                        new ComputeRequest.DepartmentInput("data", "데이터플랫폼팀")),
+                List.of(
+                        new ComputeRequest.CostPoolInput(
+                                "인건비",
+                                new BigDecimal("48000000"),
+                                List.of(
+                                        new ComputeRequest.AllocationTargetInput("prod", "상품전략본부", new BigDecimal("0.40")),
+                                        new ComputeRequest.AllocationTargetInput("ops", "채널운영본부", new BigDecimal("0.35")),
+                                        new ComputeRequest.AllocationTargetInput("data", "데이터플랫폼팀", new BigDecimal("0.25")))),
+                        new ComputeRequest.CostPoolInput(
+                                "클라우드/인프라",
+                                new BigDecimal("12000000"),
+                                List.of(
+                                        new ComputeRequest.AllocationTargetInput("prod", "상품전략본부", new BigDecimal("0.50")),
+                                        new ComputeRequest.AllocationTargetInput("ops", "채널운영본부", new BigDecimal("0.30")),
+                                        new ComputeRequest.AllocationTargetInput("data", "데이터플랫폼팀", new BigDecimal("0.20"))))),
+                List.of(
+                        new ComputeRequest.CashFlowInput(0, "투자시점", "2026", new BigDecimal("-70000000")),
+                        new ComputeRequest.CashFlowInput(1, "1년차", "2027", new BigDecimal("25000000")),
+                        new ComputeRequest.CashFlowInput(2, "2년차", "2028", new BigDecimal("30000000")),
+                        new ComputeRequest.CashFlowInput(3, "3년차", "2029", new BigDecimal("32000000")),
+                        new ComputeRequest.CashFlowInput(4, "4년차", "2030", new BigDecimal("35000000"))));
+    }
+}

--- a/docs/dev-logs/2026-04-20-backend-api-contract.md
+++ b/docs/dev-logs/2026-04-20-backend-api-contract.md
@@ -1,0 +1,40 @@
+# Backend API Contract Log
+
+## Scope
+
+- Issue: `#5 백엔드 계산 API 구현`
+- Branch: `feat/backend-api`
+- Worktree: `.worktrees/feat-backend-api`
+
+## Comparison
+
+### A. Compute-only API first
+
+- Add a `POST /api/compute` endpoint that calculates ABC allocation and DCF valuation from request payloads.
+- Keep persistence out of the first slice.
+
+### B. Full persistence API first
+
+- Add create/read/update endpoints for projects, scenarios, allocations, cash flows, approvals, and computed results at the same time.
+- Couple the backend directly to the database schema before the schema branch is complete.
+
+## Selected Option
+
+- Chose **A. Compute-only API first**.
+
+## Why This Option Won
+
+- It can be implemented and tested before the database branch merges.
+- The frontend can consume the contract immediately with mock or ad hoc payloads.
+- The calculation logic stays easy to verify in isolation.
+- The later persistence layer can reuse the same request/response shapes without redesigning the API.
+
+## Validation
+
+- Ran `./gradlew.bat test` in the backend worktree with a worktree-local `GRADLE_USER_HOME`.
+- All backend tests passed after aligning the expected DCF output with the implementation.
+
+## Notes
+
+- This slice intentionally leaves Supabase persistence for the next backend iteration.
+- Security and CORS remain placeholder-level and are expected to be refined in the security issue.


### PR DESCRIPTION
﻿## 요약
임원 중심의 의사결정 대시보드와 역할 전환형 상세 패널을 구현했습니다.

## 변경 사항
- ABC 원가배분과 DCF 평가를 한 화면에서 보여주는 대시보드 추가
- 기획자, 재무팀, 임원 역할 전환 탭 추가
- 접근성 스킵 링크, 감사 이력, 가정값 패널 정리
- 레이아웃 선택 이유를 dev-log에 기록

## 검증
- npm run lint 통과
- npm run build 통과

## 체크리스트
- [x] 한 대시보드와 한 상세 경로로 범위 제한
- [x] 접근성 기본 규칙 반영
- [x] visual companion 없이 텍스트 기반으로 진행

## 연결 이슈
- Closes #4
