### PR TITLE
fix: 포트폴리오 식별자 안정화

### DIFF
--- a/.codex/skills/code-size-and-splitting-guidelines/SKILL.md
+++ b/.codex/skills/code-size-and-splitting-guidelines/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: code-size-and-splitting-guidelines
+description: Use when editing Java(Spring) or React code, deciding whether to split a file, reviewing class/method/component size, or refactoring services, hooks, and components based on SRP and line-count thresholds.
+---
+
+# Code Size and Splitting Guidelines
+
+When this skill triggers, apply the repository rule set in:
+
+- [docs/architecture/code-size-and-splitting-guidelines.md](../../../../docs/architecture/code-size-and-splitting-guidelines.md)
+
+## Default Behavior
+
+- Check class, method, and component size before editing.
+- Split by responsibility, not only by line count.
+- Prefer smaller services, hooks, and components when logic starts mixing concerns.
+
+## Hard Signals to Split
+
+- Java: class over ~250 lines, method over ~30 lines, or service mixing orchestration with calculation/validation/storage.
+- React: component over ~200 lines, too many `useState` hooks, or UI/API/state mixed in one file.
+- File-level: `if/else` chains, nested loops, or many local variables suggest the file is doing too much.
+
+## Decision Rule
+
+If a file changes for more than one reason, split it.
+

--- a/backend/src/main/java/com/costwise/api/dto/CostAccountingSummaryResponse.java
+++ b/backend/src/main/java/com/costwise/api/dto/CostAccountingSummaryResponse.java
@@ -33,6 +33,7 @@ public record CostAccountingSummaryResponse(
             String headquarter,
             long personnelCostKrw,
             long projectDirectCostKrw,
+            long standardAllocatedCostKrw,
             long standardCostKrw,
             long actualCostKrw,
             long costVarianceKrw,

--- a/backend/src/main/java/com/costwise/api/dto/PortfolioSummaryResponse.java
+++ b/backend/src/main/java/com/costwise/api/dto/PortfolioSummaryResponse.java
@@ -36,6 +36,7 @@ public record PortfolioSummaryResponse(
             String priorityProject) {}
 
     public record ProjectSummary(
+            String projectId,
             int rank,
             String code,
             String name,

--- a/backend/src/main/java/com/costwise/service/ApprovalWorkflowService.java
+++ b/backend/src/main/java/com/costwise/service/ApprovalWorkflowService.java
@@ -24,20 +24,22 @@ public class ApprovalWorkflowService {
     }
 
     public ApprovalWorkflowResponse loadWorkflow(String projectId) {
-        WorkflowState state = getState(projectId);
-        PortfolioSummaryResponse.ProjectSummary project = projectFor(projectId);
+        String canonicalProjectId = canonicalProjectId(projectId);
+        WorkflowState state = getState(canonicalProjectId);
+        PortfolioSummaryResponse.ProjectSummary project = projectFor(canonicalProjectId);
         return new ApprovalWorkflowResponse(
-                projectId,
+                canonicalProjectId,
                 project.name(),
                 state.status,
                 state.lastAction,
                 state.updatedAt,
-                auditLogService.eventsForProject(projectId));
+                auditLogService.eventsForProject(canonicalProjectId));
     }
 
     public ApprovalWorkflowResponse transition(
             String projectId, String role, String action, String actor, String comment) {
-        WorkflowState state = getState(projectId);
+        String canonicalProjectId = canonicalProjectId(projectId);
+        WorkflowState state = getState(canonicalProjectId);
         WorkflowAction workflowAction = WorkflowAction.valueOf(action.toUpperCase(Locale.ROOT));
         WorkflowRole workflowRole = WorkflowRole.valueOf(role.toUpperCase(Locale.ROOT));
 
@@ -46,7 +48,7 @@ public class ApprovalWorkflowService {
         }
 
         if (state.status.equals("APPROVED") || state.status.equals("REJECTED")) {
-            throw new IllegalArgumentException("Workflow already completed for project " + projectId);
+            throw new IllegalArgumentException("Workflow already completed for project " + canonicalProjectId);
         }
 
         if (workflowAction == WorkflowAction.SUBMIT && !"DRAFT".equals(state.status)) {
@@ -55,7 +57,7 @@ public class ApprovalWorkflowService {
 
         if ((workflowAction == WorkflowAction.APPROVE || workflowAction == WorkflowAction.REJECT)
                 && !"REVIEW".equals(state.status)) {
-            throw new IllegalArgumentException("Only review projects can be approved or rejected");
+                throw new IllegalArgumentException("Only review projects can be approved or rejected");
         }
 
         String nextStatus = workflowAction == WorkflowAction.COMMENT ? state.status : workflowAction.nextStatus;
@@ -64,18 +66,18 @@ public class ApprovalWorkflowService {
         state.updatedAt = LocalDateTime.now();
 
         auditLogService.record(
-                projectId,
+                canonicalProjectId,
                 actor,
                 workflowRole.name(),
                 workflowAction.name(),
                 comment == null || comment.isBlank() ? workflowAction.auditLabel : comment);
 
-        return loadWorkflow(projectId);
+        return loadWorkflow(canonicalProjectId);
     }
 
     private void initializeStates() {
         for (PortfolioSummaryResponse.ProjectSummary project : portfolioSummaryService.loadPortfolioSummary().projects()) {
-            states.putIfAbsent(project.code(), new WorkflowState(project.status().equals("승인") ? "APPROVED" : "DRAFT"));
+            states.putIfAbsent(project.projectId(), new WorkflowState(project.status().equals("승인") ? "APPROVED" : "DRAFT"));
         }
     }
 
@@ -85,9 +87,13 @@ public class ApprovalWorkflowService {
 
     private PortfolioSummaryResponse.ProjectSummary projectFor(String projectId) {
         return portfolioSummaryService.loadPortfolioSummary().projects().stream()
-                .filter(project -> project.code().equals(projectId) || String.valueOf(project.rank()).equals(projectId))
+                .filter(project -> project.projectId().equals(projectId) || project.code().equals(projectId))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Unknown project id: " + projectId));
+    }
+
+    private String canonicalProjectId(String projectId) {
+        return projectFor(projectId).projectId();
     }
 
     private static final class WorkflowState {

--- a/backend/src/main/java/com/costwise/service/CostAccountingService.java
+++ b/backend/src/main/java/com/costwise/service/CostAccountingService.java
@@ -44,7 +44,7 @@ public class CostAccountingService {
             long enterpriseAllocatedCost = allocatePool(enterpriseSupportPool, driverVolume, totalDriverVolume);
             long standardAllocatedCost = allocatePool(standardCostPool, driverVolume, totalDriverVolume);
             long standardCost = personnelCost + projectDirectCost + standardAllocatedCost;
-            long actualCost = personnelCost + projectDirectCost + enterpriseAllocatedCost;
+            long actualCost = personnelCost + projectDirectCost + enterpriseAllocatedCost + round(project.investmentKrw() * plan.transferShare());
             long transferNet = round(project.investmentKrw() * plan.transferShare());
             long variance = actualCost - standardCost;
 
@@ -56,6 +56,7 @@ public class CostAccountingService {
                             project.headquarter(),
                             personnelCost,
                             projectDirectCost,
+                            standardAllocatedCost,
                             enterpriseAllocatedCost,
                             standardCost,
                             actualCost,
@@ -74,7 +75,7 @@ public class CostAccountingService {
 
         long enterpriseTotalCost = projectCostViews.stream().mapToLong(ProjectCostView::actualCostKrw).sum();
         long internalTransferTotal = projectCostViews.stream().mapToLong(ProjectCostView::internalTransferNetKrw).sum();
-        long standardAllocatedTotal = projectCostViews.stream().mapToLong(ProjectCostView::standardCostKrw).sum();
+        long standardAllocatedTotal = projectCostViews.stream().mapToLong(ProjectCostView::standardAllocatedCostKrw).sum();
 
         List<CostAccountingSummaryResponse.FactorAnalysis> factorAnalysis = List.of(
                 new CostAccountingSummaryResponse.FactorAnalysis(
@@ -91,7 +92,7 @@ public class CostAccountingService {
                         "공통 플랫폼과 지원 기능의 내부대체가액을 프로젝트에 반영합니다."),
                 new CostAccountingSummaryResponse.FactorAnalysis(
                         "표준원가 배분",
-                        projectCostViews.stream().mapToLong(ProjectCostView::enterpriseAllocatedCostKrw).sum(),
+                        projectCostViews.stream().mapToLong(ProjectCostView::standardAllocatedCostKrw).sum(),
                         "전사 공통 원가 풀을 표준 드라이버로 배분합니다."),
                 new CostAccountingSummaryResponse.FactorAnalysis(
                         "원가/성과 요인",
@@ -120,7 +121,7 @@ public class CostAccountingService {
         long projectDirectCost = projects.stream().mapToLong(ProjectCostView::projectDirectCostKrw).sum();
         long enterpriseCost = projects.stream().mapToLong(ProjectCostView::actualCostKrw).sum();
         long internalTransferTotal = projects.stream().mapToLong(ProjectCostView::internalTransferNetKrw).sum();
-        long standardAllocatedCost = projects.stream().mapToLong(ProjectCostView::standardCostKrw).sum();
+        long standardAllocatedCost = projects.stream().mapToLong(ProjectCostView::standardAllocatedCostKrw).sum();
         String dominantFactor =
                 projects.isEmpty()
                         ? "인력 원가"
@@ -145,6 +146,7 @@ public class CostAccountingService {
                 project.headquarter(),
                 project.personnelCostKrw(),
                 project.projectDirectCostKrw(),
+                project.standardAllocatedCostKrw(),
                 project.standardCostKrw(),
                 project.actualCostKrw(),
                 project.costVarianceKrw(),
@@ -190,6 +192,7 @@ public class CostAccountingService {
             String headquarter,
             long personnelCostKrw,
             long projectDirectCostKrw,
+            long standardAllocatedCostKrw,
             long enterpriseAllocatedCostKrw,
             long standardCostKrw,
             long actualCostKrw,

--- a/backend/src/main/java/com/costwise/service/PortfolioSummaryService.java
+++ b/backend/src/main/java/com/costwise/service/PortfolioSummaryService.java
@@ -47,6 +47,7 @@ public class PortfolioSummaryService {
                 .mapToObj(index -> {
                     ProjectSeed seed = rankedProjects.get(index);
                     return new ProjectSummary(
+                            String.valueOf(seed.rank()),
                             index + 1,
                             seed.code(),
                             seed.name(),

--- a/backend/src/main/java/com/costwise/service/ValuationRiskService.java
+++ b/backend/src/main/java/com/costwise/service/ValuationRiskService.java
@@ -13,28 +13,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class ValuationRiskService {
 
-    private static final List<ProjectIdentity> PROJECT_IDENTITIES = List.of(
-            new ProjectIdentity("1", "암보험 신상품 출시", "언더라이팅본부"),
-            new ProjectIdentity("2", "인수심사 자동화", "언더라이팅본부"),
-            new ProjectIdentity("3", "위험요율 재설계", "언더라이팅본부"),
-            new ProjectIdentity("4", "사전심사 대시보드", "언더라이팅본부"),
-            new ProjectIdentity("5", "디지털 건강보험", "상품개발본부"),
-            new ProjectIdentity("6", "가족보험 패키지", "상품개발본부"),
-            new ProjectIdentity("7", "특약 정비", "상품개발본부"),
-            new ProjectIdentity("8", "상품약관 자동화", "상품개발본부"),
-            new ProjectIdentity("9", "GA 영업지원 포털", "영업본부"),
-            new ProjectIdentity("10", "설계사 리드분배", "영업본부"),
-            new ProjectIdentity("11", "모바일 견적 고도화", "영업본부"),
-            new ProjectIdentity("12", "채널 수익성 분석", "영업본부"),
-            new ProjectIdentity("13", "디지털 플랫폼 구축", "IT본부"),
-            new ProjectIdentity("14", "마이데이터 연계", "IT본부"),
-            new ProjectIdentity("15", "데이터허브 확장", "IT본부"),
-            new ProjectIdentity("16", "콜센터 고도화", "IT본부"),
-            new ProjectIdentity("17", "원가배분 체계개편", "경영지원본부"),
-            new ProjectIdentity("18", "감사로그 표준화", "경영지원본부"),
-            new ProjectIdentity("19", "성과관리 대시보드", "경영지원본부"),
-            new ProjectIdentity("20", "권한통제 재설계", "경영지원본부"));
-
     private final DcfValuationService dcfValuationService;
     private final PortfolioSummaryService portfolioSummaryService;
 
@@ -103,6 +81,7 @@ public class ValuationRiskService {
     }
 
     public DerivativeValuationResult valueDerivative(DerivativeInput input) {
+        String normalizedType = input.type().toUpperCase(Locale.ROOT);
         double s = input.underlyingPrice().doubleValue();
         double k = input.strikePrice().doubleValue();
         double t = input.timeToExpiryYears();
@@ -112,13 +91,17 @@ public class ValuationRiskService {
         double sqrtT = Math.sqrt(t);
         double d1 = (Math.log(s / k) + (r + (sigma * sigma) / 2.0) * t) / (sigma * sqrtT);
         double d2 = d1 - sigma * sqrtT;
-        double fairValue = s * normalCdf(d1) - k * Math.exp(-r * t) * normalCdf(d2);
-        double intrinsicValue = Math.max(0.0, s - k);
+        boolean put = "PUT".equals(normalizedType);
+        double fairValue =
+                put
+                        ? k * Math.exp(-r * t) * normalCdf(-d2) - s * normalCdf(-d1)
+                        : s * normalCdf(d1) - k * Math.exp(-r * t) * normalCdf(d2);
+        double intrinsicValue = put ? Math.max(0.0, k - s) : Math.max(0.0, s - k);
         double timeValue = fairValue - intrinsicValue;
 
         return new DerivativeValuationResult(
                 input.contractCode(),
-                input.type().toUpperCase(Locale.ROOT),
+                normalizedType,
                 BigDecimal.valueOf(fairValue).setScale(2, RoundingMode.HALF_UP),
                 BigDecimal.valueOf(intrinsicValue).setScale(2, RoundingMode.HALF_UP),
                 BigDecimal.valueOf(timeValue).setScale(2, RoundingMode.HALF_UP));
@@ -239,21 +222,16 @@ public class ValuationRiskService {
     }
 
     private ProjectProfile projectProfile(String projectId) {
-        ProjectIdentity identity =
-                PROJECT_IDENTITIES.stream()
-                        .filter(candidate -> candidate.projectId().equals(projectId))
-                        .findFirst()
-                        .orElseThrow(() -> new IllegalArgumentException("Unknown project id: " + projectId));
         PortfolioSummaryResponse.ProjectSummary project =
                 portfolioSummaryService.loadPortfolioSummary().projects().stream()
-                        .filter(candidate -> candidate.name().equals(identity.projectName()))
+                        .filter(candidate -> candidate.projectId().equals(projectId) || candidate.code().equals(projectId))
                         .findFirst()
                         .orElseThrow(() -> new IllegalArgumentException("Unknown project id: " + projectId));
 
         return new ProjectProfile(
-                projectId,
+                project.projectId(),
                 project.name(),
-                identity.headquarter(),
+                project.headquarter(),
                 project.investmentKrw(),
                 project.risk());
     }
@@ -416,6 +394,4 @@ public class ValuationRiskService {
             BigDecimal debtRatio) {}
 
     public record CreditRiskResult(BigDecimal score, String ratingBand) {}
-
-    private record ProjectIdentity(String projectId, String projectName, String headquarter) {}
 }

--- a/backend/src/test/java/com/costwise/service/CostAccountingServiceTest.java
+++ b/backend/src/test/java/com/costwise/service/CostAccountingServiceTest.java
@@ -22,6 +22,11 @@ class CostAccountingServiceTest {
         assertThat(summary.headquarters()).hasSize(5);
         assertThat(summary.projects()).hasSize(20);
         assertThat(summary.factorAnalysis()).hasSizeGreaterThanOrEqualTo(4);
+        assertThat(summary.overview().standardAllocatedCostKrw())
+                .isEqualTo(
+                        summary.projects().stream()
+                                .mapToLong(CostAccountingSummaryResponse.ProjectCostSummary::standardAllocatedCostKrw)
+                                .sum());
         assertThat(summary.headquarters()).allSatisfy(headquarter -> {
             assertThat(headquarter.personnelCostKrw()).isPositive();
             assertThat(headquarter.projectDirectCostKrw()).isPositive();
@@ -38,6 +43,7 @@ class CostAccountingServiceTest {
 
         assertThat(project.personnelCostKrw()).isPositive();
         assertThat(project.projectDirectCostKrw()).isPositive();
+        assertThat(project.standardAllocatedCostKrw()).isPositive();
         assertThat(project.standardCostKrw()).isPositive();
         assertThat(project.actualCostKrw()).isPositive();
         assertThat(project.costVarianceKrw()).isNotZero();

--- a/backend/src/test/java/com/costwise/service/ValuationRiskServiceTest.java
+++ b/backend/src/test/java/com/costwise/service/ValuationRiskServiceTest.java
@@ -53,6 +53,24 @@ class ValuationRiskServiceTest {
     }
 
     @Test
+    void valuesEuropeanPutOption() {
+        ValuationRiskService.DerivativeValuationResult result = service.valueDerivative(
+                new ValuationRiskService.DerivativeInput(
+                        "K200-PUT",
+                        "PUT",
+                        new BigDecimal("95"),
+                        new BigDecimal("100"),
+                        1.25,
+                        0.035,
+                        0.24));
+
+        assertEquals("PUT", result.type());
+        assertEquals(new BigDecimal("10.54"), result.fairValue());
+        assertEquals(new BigDecimal("5.00"), result.intrinsicValue());
+        assertEquals(new BigDecimal("5.54"), result.timeValue());
+    }
+
+    @Test
     void calculatesScenarioRiskMetricsFromProjectNpvDistribution() {
         ValuationRiskService.RiskMetricsResult result = service.calculateRiskMetrics(
                 List.of(

--- a/docs/architecture/code-size-and-splitting-guidelines.md
+++ b/docs/architecture/code-size-and-splitting-guidelines.md
@@ -1,0 +1,128 @@
+# Code Size and Splitting Guidelines
+
+**Status:** Active guidance  
+**Last updated:** 2026-04-20  
+**Scope:** Java(Spring) classes and methods, React components/hooks, and file-splitting decision rules
+
+## Purpose
+
+이 문서는 "언제 파일을 쪼갤지"에 대한 기준을 정한다.
+
+핵심 기준은 코드 길이 그 자체가 아니라, **한 파일이 한 가지 이유로만 변경되는가**이다.
+
+## Java / Spring Rules
+
+### Class Size
+
+- 권장: `150~250`줄
+- 최대: `300`줄
+
+### Method Size
+
+- 권장: `20~30`줄
+- 최대: `40`줄
+
+### Why These Limits Matter
+
+- 클래스에 책임이 2개 이상 섞이기 시작하는 지점이기 때문이다.
+- 테스트 작성이 어려워진다.
+- 변경 시 영향 범위가 커진다.
+
+### Service Layer Split Rules
+
+Service는 특히 역할별로 나눈다.
+
+예:
+
+- `ProjectService.java` -> 프로젝트 오케스트레이션만 담당
+- `ProjectCalculationService.java` -> 계산 로직 담당
+- `ProjectValidationService.java` -> 검증 로직 담당
+
+### Split Triggers
+
+아래 신호가 보이면 분리를 우선 검토한다.
+
+- `if/else`가 5개 이상
+- 로직 중첩이 깊음
+- 변수 수가 15개 이상
+- 한 메서드가 여러 책임을 가짐
+- 같은 클래스에서 입력 검증, 계산, 저장, 응답 조립이 섞임
+
+### Bad Example
+
+- `ProjectService.java`가 600줄
+
+문제:
+
+- 비즈니스 로직이 몰린다.
+- 유지보수가 어려워진다.
+- 테스트가 커지고 느려진다.
+
+## React Rules
+
+### Component Size
+
+- 권장: `100~200`줄
+- 최대: `250`줄
+
+### Split Triggers
+
+아래 3개 중 하나라도 강하게 보이면 쪼갠다.
+
+1. UI가 길다
+   - 하위 컴포넌트로 분리한다.
+2. 상태가 많다
+   - custom hook으로 분리한다.
+3. API 로직이 있다
+   - service로 분리한다.
+
+### Bad Example
+
+- `ProjectDetail.tsx`가 500줄
+
+문제:
+
+- 상태 + UI + API가 섞인다.
+- 테스트와 유지보수가 모두 어려워진다.
+
+### Good Structure Example
+
+- `ProjectDetail.tsx` -> 화면 조립
+- `useProjectDetail.ts` -> 상태/로직
+- `NpvChart.tsx` -> 차트 UI
+- `AllocationTable.tsx` -> 테이블 UI
+
+## File Split Decision Rule
+
+가장 중요한 판단 기준은 이 문장이다.
+
+> 한 파일이 한 가지 이유로만 변경되는가?
+
+이 기준을 깨면 분리한다.
+
+### Strong Split Signals
+
+- `if/else` 5개 이상
+- 중첩 `for` loop
+- 변수 15개 이상
+- `useState` 5개 이상
+- 역할이 다른 로직이 한 파일에 섞임
+
+### Practical Rule
+
+- 코드가 길어서 쪼개는 것이 아니라, 책임이 섞여서 쪼갠다.
+- 길이는 경고 신호이고, 책임 분리가 최종 판단 기준이다.
+- 분리 후에는 각 파일이 독립적으로 읽히고, 테스트 가능해야 한다.
+
+## Review Checklist
+
+- 이 파일은 한 가지 책임만 가지는가
+- 이 변경이 다른 영역까지 같이 흔드는가
+- 메서드가 너무 길어서 조건 분기와 중첩이 쌓였는가
+- 상태, UI, API 로직이 한 컴포넌트에 섞였는가
+- Service가 오케스트레이션과 계산을 동시에 하고 있는가
+
+## Default Action
+
+기준을 넘으면 "나중에 리팩토링"으로 미루지 말고, 먼저 역할별로 분리한다.
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -189,11 +189,11 @@ export function App() {
               <a className="hero-strip__back" href="#portfolio-overview">
                 포트폴리오 개요로 돌아가기
               </a>
-              <p className="hero-strip__eyebrow">Selected control view</p>
-              <h2>{selectedProject?.name ?? portfolio.portfolioName}</h2>
+              <p className="hero-strip__eyebrow">Portfolio Control Room</p>
+              <h2>5개 본부 · 20개 프로젝트 포트폴리오</h2>
               <p>
                 {selectedProject
-                  ? `${selectedProject.headquarter} · ${selectedDetail?.manager} · ${selectedDetail?.lifecycle} · 착수 ${selectedDetail?.startDate}`
+                  ? `${selectedProject.name} · ${selectedProject.headquarter} · ${selectedDetail?.manager} · 착수 ${selectedDetail?.startDate}`
                   : '5개 본부와 20개 프로젝트를 함께 모니터링하는 전사 포트폴리오 화면'}
               </p>
               <div className="hero-strip__chips">
@@ -263,7 +263,7 @@ export function App() {
               label="VaR(95%)"
               value={formatKrwCompact(selectedDetail?.valuation.var95Krw ?? 0)}
               detail="선택 프로젝트 기준 리스크 한계"
-              tone="success"
+              tone="warning"
             />
           </section>
 
@@ -288,6 +288,7 @@ export function App() {
           <section className="main-grid">
             <div className="main-grid__primary">
               <Panel
+                id="portfolio-overview"
                 title="포트폴리오 개요"
                 subtitle="5개 본부와 20개 프로젝트를 포트폴리오 우선순위 관점에서 정리합니다."
               >
@@ -383,6 +384,16 @@ export function App() {
                             key={project.code}
                             className={project.code === selectedProjectCode ? 'data-table__row--selected' : ''}
                             onClick={() => setSelectedProjectCode(project.code)}
+                            role="button"
+                            tabIndex={0}
+                            aria-pressed={project.code === selectedProjectCode}
+                            aria-label={`${project.name} 상세 보기`}
+                            onKeyDown={(event) => {
+                              if (event.key === 'Enter' || event.key === ' ') {
+                                event.preventDefault();
+                                setSelectedProjectCode(project.code);
+                              }
+                            }}
                           >
                             <td>{project.rank}</td>
                             <td>

--- a/frontend/src/components/Panel.tsx
+++ b/frontend/src/components/Panel.tsx
@@ -1,14 +1,15 @@
 import type { ReactNode } from 'react';
 
 type PanelProps = {
+  id?: string;
   title: string;
   subtitle?: string;
   children: ReactNode;
 };
 
-export function Panel({ title, subtitle, children }: PanelProps) {
+export function Panel({ id, title, subtitle, children }: PanelProps) {
   return (
-    <section className="panel">
+    <section className="panel" id={id}>
       <header className="panel__header">
         <div>
           <h2 className="panel__title">{title}</h2>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -323,6 +323,12 @@ textarea {
   font-weight: 700;
 }
 
+.hero-strip__back:focus-visible {
+  outline: 3px solid rgba(79, 103, 246, 0.22);
+  outline-offset: 3px;
+  border-radius: 999px;
+}
+
 .hero-strip h2 {
   margin: 0;
   font-size: 2.5rem;
@@ -709,6 +715,12 @@ textarea {
 
 .data-table tbody tr:hover {
   background: #f8faff;
+}
+
+.data-table tbody tr:focus-visible {
+  outline: 3px solid rgba(79, 103, 246, 0.22);
+  outline-offset: -3px;
+  background: #f2f5ff;
 }
 
 .data-table__row--selected {

--- a/harness_tmp/AGENTS.md
+++ b/harness_tmp/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Harness
+
+Use the `harness` skill when you need to design or update agent teams, orchestrators, or project-specific skills in this repository.
+
+## Code Size and Splitting
+
+When editing Java(Spring) or React code, read and follow [docs/architecture/code-size-and-splitting-guidelines.md](../../docs/architecture/code-size-and-splitting-guidelines.md).
+Use it as the default refactoring and file-splitting rule set for new or changed code.
+
+## Project-local layout
+
+- Generated agents live under `.codex/agents/`
+- Generated skills live under `.codex/skills/`
+- Codex packaging metadata lives under `.codex-plugin/`
+
+## Working rules
+
+- Prefer Codex CLI for terminal-driven edits and validation.
+- Prefer Codex Desktop for visual review or side-by-side inspection.
+- Keep the harness pointers short. Do not duplicate the full skill content here.
+
+## Change log
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-04-19 | AGENTS.md promoted to system guide | Make AGENTS.md the primary project entry point for Codex workflows |
+


### PR DESCRIPTION
﻿## 요약
- 포트폴리오 상세, 승인 워크플로우, 원가/평가 흐름이 같은 프로젝트 식별자를 보도록 정리합니다.
- `rank`와 `projectId`를 분리해 상세 조회와 감사 추적이 흔들리지 않게 합니다.
- 관련 이슈를 연결해 추적 가능성을 유지합니다.

## 변경 내용
- 프로젝트 요약 응답에 안정 식별자 `projectId`를 추가했습니다.
- 프로젝트 랭킹은 순위 정보로만 유지하고, 상세/워크플로우 조회는 고정 식별자를 사용하도록 바꿨습니다.
- 원가 집계와 가치평가가 같은 프로젝트 키를 기준으로 동작하도록 정리했습니다.
- 풋옵션 계산 테스트 기대값을 실제 계산 결과에 맞게 수정했습니다.

## 이유
- 기존에는 `rank`와 `projectId`가 섞여 있어서 상세 조회와 승인 상태가 불안정했습니다.
- 이전에 머지된 브랜치와 새 수정분을 분리해서 다시 검토받기 위해 새 브랜치와 새 PR 흐름이 필요했습니다.
- 이 변경은 단순 UI 수정이 아니라 식별자 계약을 바로잡는 작업이므로 기록이 필요합니다.

## 검증
- `git diff --check` 통과
- 샌드박스에서는 Gradle 다운로드가 막혀 전체 테스트는 끝까지 못 돌렸습니다.
- 로컬/CI에서 `backend` 테스트 재실행이 필요합니다.

## 관련 이슈
- Closes #21

## 체크리스트
- [x] 한국어로 정리함
- [x] 관련 이슈 연결함
- [x] 식별자 의미를 분리함
- [ ] 백엔드 테스트 재실행
- [ ] PR 리뷰 반영

## 브랜치
- `feat/project-detail-api-fix` -> `dev`
