### PR TITLE
[정리] 프론트 포맷 기준선 및 pre-commit 안정화

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,4 +9,4 @@ npm run format:check
 
 cd ..
 cd backend
-./gradlew check
+./gradlew --no-daemon check

--- a/docs/dev-logs/2026-04-21-frontend-format-baseline.md
+++ b/docs/dev-logs/2026-04-21-frontend-format-baseline.md
@@ -1,0 +1,42 @@
+# 2026-04-21 Frontend Format Baseline
+
+## 대상
+
+- 브랜치: `feat/frontend-format-baseline`
+- 범위: 프론트엔드 포맷 기준선 정리
+
+## A/B 비교
+
+### A. 기능 PR마다 `--no-verify`로 우회
+
+- 장점: 당장 빠르다.
+- 단점: 저장소 상태가 계속 누적되고, 훅 실패 원인을 매번 다시 해석해야 한다.
+
+### B. 프론트 전체를 현재 Prettier 규칙에 맞춰 한 번 정리
+
+- 장점: `npm run format:check`가 안정적으로 통과하고 기능 PR이 포맷 노이즈에서 벗어난다.
+- 단점: 포맷 차이만 반영하는 별도 PR이 필요하다.
+
+## 선택
+
+- `B`를 선택했다.
+- 이유: 기능 PR 범위를 유지하면서 훅 실패의 공통 원인을 제거하려면 포맷 정리를 독립 slice로 분리하는 편이 맞다.
+
+## 구현 요약
+
+- `frontend/` 전체에 `prettier --write .` 적용
+- 기존 포맷 불일치 파일 23개 정리
+- 현재 pre-commit 훅이 요구하는 `frontend`와 `backend` 검증을 모두 확인
+
+## 검증
+
+- `npm run format:check`
+- `npm run lint`
+- `npm run build`
+- `GRADLE_USER_HOME=C:\Users\ggg99\Desktop\CostWiseAI\.gradle-home .\gradlew.bat check`
+- 결과: 모두 성공
+
+## 남은 리스크
+
+- 새 worktree에서는 여전히 `frontend/node_modules` 설치가 선행돼야 한다.
+- 이 PR은 포맷 정리만 다루므로 기능 동작 변화는 없다.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,12 @@ import {
   type ProjectStatus,
   type Role
 } from './app/portfolioData';
-import { formatDateTime, formatKrwCompact, formatPercent, formatYears } from './app/format';
+import {
+  formatDateTime,
+  formatKrwCompact,
+  formatPercent,
+  formatYears
+} from './app/format';
 import { MetricCard } from './components/MetricCard';
 import { Panel } from './components/Panel';
 import { ProgressBar } from './components/ProgressBar';
@@ -31,7 +36,9 @@ export function App() {
   const [activeView, setActiveView] = useState<NavigationKey>('dashboard');
   const [activeTab, setActiveTab] = useState<DetailTabKey>('allocation');
   const [selectedHeadquarter, setSelectedHeadquarter] = useState('전체 본부');
-  const [portfolio, setPortfolio] = useState<PortfolioSummary>(defaultPortfolioSummary);
+  const [portfolio, setPortfolio] = useState<PortfolioSummary>(
+    defaultPortfolioSummary
+  );
   const [source, setSource] = useState<'api' | 'local'>('local');
   const [selectedProjectCode, setSelectedProjectCode] = useState(
     defaultPortfolioSummary.projects[0]?.code ?? ''
@@ -63,14 +70,19 @@ export function App() {
   }, [portfolio.projects, selectedHeadquarter]);
 
   useEffect(() => {
-    if (!filteredProjects.some((project) => project.code === selectedProjectCode)) {
-      setSelectedProjectCode(filteredProjects[0]?.code ?? portfolio.projects[0]?.code ?? '');
+    if (
+      !filteredProjects.some((project) => project.code === selectedProjectCode)
+    ) {
+      setSelectedProjectCode(
+        filteredProjects[0]?.code ?? portfolio.projects[0]?.code ?? ''
+      );
     }
   }, [filteredProjects, portfolio.projects, selectedProjectCode]);
 
   const selectedProject =
-    portfolio.projects.find((project) => project.code === selectedProjectCode) ??
-    portfolio.projects[0];
+    portfolio.projects.find(
+      (project) => project.code === selectedProjectCode
+    ) ?? portfolio.projects[0];
   const selectedDetail = selectedProject
     ? buildProjectDetail(selectedProject.code)
     : null;
@@ -80,16 +92,22 @@ export function App() {
   const maxHeadquarterInvestment = useMemo(
     () =>
       Math.max(
-        ...portfolio.headquarters.map((headquarter) => headquarter.totalInvestmentKrw)
+        ...portfolio.headquarters.map(
+          (headquarter) => headquarter.totalInvestmentKrw
+        )
       ),
     [portfolio.headquarters]
   );
   const selectedRank =
-    portfolio.projects.find((project) => project.code === selectedProjectCode)?.rank ?? '-';
+    portfolio.projects.find((project) => project.code === selectedProjectCode)
+      ?.rank ?? '-';
   const selectedTabLabel =
-    detailTabs.find((tab) => tab.key === activeTab)?.label ?? detailTabs[0].label;
+    detailTabs.find((tab) => tab.key === activeTab)?.label ??
+    detailTabs[0].label;
   const maxScenarioNpv = selectedDetail
-    ? Math.max(...selectedDetail.scenarioReturns.map((item) => Math.abs(item.npvKrw)))
+    ? Math.max(
+        ...selectedDetail.scenarioReturns.map((item) => Math.abs(item.npvKrw))
+      )
     : 1;
 
   return (
@@ -117,7 +135,11 @@ export function App() {
               onClick={() => setActiveView(item.key)}
             >
               <span className="nav__icon" aria-hidden="true">
-                {item.key === 'dashboard' ? '▦' : item.key === 'projects' ? '▤' : '◷'}
+                {item.key === 'dashboard'
+                  ? '▦'
+                  : item.key === 'projects'
+                    ? '▤'
+                    : '◷'}
               </span>
               <span>{item.label}</span>
             </button>
@@ -142,7 +164,9 @@ export function App() {
               className={`hq-filter ${selectedHeadquarter === headquarter.name ? 'hq-filter--active' : ''}`}
               onClick={() => setSelectedHeadquarter(headquarter.name)}
             >
-              <span className={`hq-filter__dot ${headquarterPalette[headquarter.name]}`} />
+              <span
+                className={`hq-filter__dot ${headquarterPalette[headquarter.name]}`}
+              />
               <span>{headquarter.name.replace('본부', '')}</span>
               <small>{headquarter.projectCount}</small>
             </button>
@@ -162,7 +186,9 @@ export function App() {
           </div>
           <div className="sidebar__summary-card">
             <span>예상 수익</span>
-            <strong>{formatKrwCompact(portfolio.overview.totalExpectedRevenueKrw)}</strong>
+            <strong>
+              {formatKrwCompact(portfolio.overview.totalExpectedRevenueKrw)}
+            </strong>
             <small>전사 포트폴리오 기준 기대 수익</small>
           </div>
         </section>
@@ -209,7 +235,9 @@ export function App() {
               <div className="hero-strip__status-stack">
                 <span
                   className={`status-pill status-pill--${
-                    selectedProject ? riskToneMap[selectedProject.risk] : 'active'
+                    selectedProject
+                      ? riskToneMap[selectedProject.risk]
+                      : 'active'
                   }`}
                 >
                   {selectedProject ? selectedProject.status : portfolio.status}
@@ -255,7 +283,9 @@ export function App() {
             />
             <MetricCard
               label="배분원가"
-              value={formatKrwCompact(selectedDetail?.allocation.allocatedCostKrw ?? 0)}
+              value={formatKrwCompact(
+                selectedDetail?.allocation.allocatedCostKrw ?? 0
+              )}
               detail="선택 프로젝트 기준 ABC 배부"
               tone="warning"
             />
@@ -294,32 +324,45 @@ export function App() {
               >
                 <div className="headquarter-grid">
                   {portfolio.headquarters.map((headquarter) => (
-                    <article key={headquarter.code} className="headquarter-card">
+                    <article
+                      key={headquarter.code}
+                      className="headquarter-card"
+                    >
                       <div className="headquarter-card__header">
                         <div>
                           <div className="headquarter-card__title">
-                            <span className={`hq-filter__dot ${headquarterPalette[headquarter.name]}`} />
+                            <span
+                              className={`hq-filter__dot ${headquarterPalette[headquarter.name]}`}
+                            />
                             <strong>{headquarter.name}</strong>
                           </div>
                           <span>{headquarter.projectCount}개 프로젝트</span>
                         </div>
-                        <span className={`status-pill status-pill--${riskToneMap[headquarter.risk]}`}>
+                        <span
+                          className={`status-pill status-pill--${riskToneMap[headquarter.risk]}`}
+                        >
                           {headquarter.risk}
                         </span>
                       </div>
                       <div className="headquarter-card__metrics">
                         <div>
                           <span>총 투자액</span>
-                          <strong>{formatKrwCompact(headquarter.totalInvestmentKrw)}</strong>
+                          <strong>
+                            {formatKrwCompact(headquarter.totalInvestmentKrw)}
+                          </strong>
                         </div>
                         <div>
                           <span>평균 NPV</span>
-                          <strong>{formatKrwCompact(headquarter.averageNpvKrw)}</strong>
+                          <strong>
+                            {formatKrwCompact(headquarter.averageNpvKrw)}
+                          </strong>
                         </div>
                       </div>
                       <ProgressBar
                         label="투자 비중"
-                        value={Math.round(headquarter.totalInvestmentKrw / 10000)}
+                        value={Math.round(
+                          headquarter.totalInvestmentKrw / 10000
+                        )}
                         max={Math.round(maxHeadquarterInvestment / 10000)}
                         tone={
                           headquarter.risk === '높음'
@@ -382,7 +425,11 @@ export function App() {
                         {filteredProjects.map((project) => (
                           <tr
                             key={project.code}
-                            className={project.code === selectedProjectCode ? 'data-table__row--selected' : ''}
+                            className={
+                              project.code === selectedProjectCode
+                                ? 'data-table__row--selected'
+                                : ''
+                            }
                             onClick={() => setSelectedProjectCode(project.code)}
                             role="button"
                             tabIndex={0}
@@ -403,7 +450,9 @@ export function App() {
                             <td>{project.headquarter}</td>
                             <td>{project.assetCategory}</td>
                             <td>
-                              <span className={`status-pill status-pill--${statusTone(project.status)}`}>
+                              <span
+                                className={`status-pill status-pill--${statusTone(project.status)}`}
+                              >
                                 {project.status}
                               </span>
                             </td>
@@ -430,25 +479,48 @@ export function App() {
               >
                 {selectedProject && selectedDetail ? (
                   <div className="detail-shell">
-                    <section className="project-spotlight" aria-label="선택 프로젝트 요약">
+                    <section
+                      className="project-spotlight"
+                      aria-label="선택 프로젝트 요약"
+                    >
                       <div className="project-spotlight__header">
                         <div>
-                          <span className="project-spotlight__code">{selectedProject.code}</span>
+                          <span className="project-spotlight__code">
+                            {selectedProject.code}
+                          </span>
                           <strong>{selectedProject.name}</strong>
                         </div>
-                        <span className={`status-pill status-pill--${riskToneMap[selectedProject.risk]}`}>
+                        <span
+                          className={`status-pill status-pill--${riskToneMap[selectedProject.risk]}`}
+                        >
                           {selectedProject.risk}
                         </span>
                       </div>
                       <div className="project-spotlight__band">
-                        <InfoTile label="우선순위" value={`${selectedRank}위`} />
-                        <InfoTile label="자산군" value={selectedDetail.assetCategory} />
-                        <InfoTile label="책임 PM" value={selectedDetail.manager} />
-                        <InfoTile label="현재 단계" value={selectedDetail.workflow.currentStage} />
+                        <InfoTile
+                          label="우선순위"
+                          value={`${selectedRank}위`}
+                        />
+                        <InfoTile
+                          label="자산군"
+                          value={selectedDetail.assetCategory}
+                        />
+                        <InfoTile
+                          label="책임 PM"
+                          value={selectedDetail.manager}
+                        />
+                        <InfoTile
+                          label="현재 단계"
+                          value={selectedDetail.workflow.currentStage}
+                        />
                       </div>
                     </section>
 
-                    <div className="detail-tabs" role="tablist" aria-label="상세 탭">
+                    <div
+                      className="detail-tabs"
+                      role="tablist"
+                      aria-label="상세 탭"
+                    >
                       {detailTabs.map((tab) => (
                         <button
                           key={tab.key}
@@ -464,20 +536,64 @@ export function App() {
                     {activeTab === 'allocation' ? (
                       <div className="detail-stack">
                         <div className="detail-kpis">
-                          <InfoTile label="인력 원가" value={formatKrwCompact(selectedDetail.allocation.personnelCostKrw)} />
-                          <InfoTile label="프로젝트 원가" value={formatKrwCompact(selectedDetail.allocation.projectCostKrw)} />
-                          <InfoTile label="본부 공통원가" value={formatKrwCompact(selectedDetail.allocation.headquarterCostKrw)} />
-                          <InfoTile label="전사 공통원가" value={formatKrwCompact(selectedDetail.allocation.enterpriseCostKrw)} />
+                          <InfoTile
+                            label="인력 원가"
+                            value={formatKrwCompact(
+                              selectedDetail.allocation.personnelCostKrw
+                            )}
+                          />
+                          <InfoTile
+                            label="프로젝트 원가"
+                            value={formatKrwCompact(
+                              selectedDetail.allocation.projectCostKrw
+                            )}
+                          />
+                          <InfoTile
+                            label="본부 공통원가"
+                            value={formatKrwCompact(
+                              selectedDetail.allocation.headquarterCostKrw
+                            )}
+                          />
+                          <InfoTile
+                            label="전사 공통원가"
+                            value={formatKrwCompact(
+                              selectedDetail.allocation.enterpriseCostKrw
+                            )}
+                          />
                         </div>
                         <div className="callout callout--accent">
                           <strong>내부대체가액</strong>
-                          <span>{formatKrwCompact(selectedDetail.allocation.internalTransferPriceKrw)}</span>
+                          <span>
+                            {formatKrwCompact(
+                              selectedDetail.allocation.internalTransferPriceKrw
+                            )}
+                          </span>
                         </div>
                         <div className="detail-grid">
-                          <InfoTile label="표준원가" value={formatKrwCompact(selectedDetail.allocation.standardCostKrw)} />
-                          <InfoTile label="배분원가" value={formatKrwCompact(selectedDetail.allocation.allocatedCostKrw)} />
-                          <InfoTile label="원가 효율 차이" value={formatKrwCompact(selectedDetail.allocation.efficiencyGapKrw)} />
-                          <InfoTile label="성과 요인 차이" value={formatKrwCompact(selectedDetail.allocation.performanceGapKrw)} />
+                          <InfoTile
+                            label="표준원가"
+                            value={formatKrwCompact(
+                              selectedDetail.allocation.standardCostKrw
+                            )}
+                          />
+                          <InfoTile
+                            label="배분원가"
+                            value={formatKrwCompact(
+                              selectedDetail.allocation.allocatedCostKrw
+                            )}
+                          />
+                          <InfoTile
+                            label="원가 효율 차이"
+                            value={formatKrwCompact(
+                              selectedDetail.allocation.efficiencyGapKrw
+                            )}
+                          />
+                          <InfoTile
+                            label="성과 요인 차이"
+                            value={formatKrwCompact(
+                              selectedDetail.allocation.performanceGapKrw
+                            )}
+                          />
                         </div>
                       </div>
                     ) : null}
@@ -485,17 +601,38 @@ export function App() {
                     {activeTab === 'valuation' ? (
                       <div className="detail-stack">
                         <div className="detail-kpis">
-                          <InfoTile label="공정가치" value={formatKrwCompact(selectedDetail.valuation.fairValueKrw)} />
-                          <InfoTile label="NPV" value={formatKrwCompact(selectedProject.npvKrw)} />
-                          <InfoTile label="IRR" value={formatPercent(selectedProject.irr)} />
-                          <InfoTile label="회수기간" value={formatYears(selectedProject.paybackYears)} />
+                          <InfoTile
+                            label="공정가치"
+                            value={formatKrwCompact(
+                              selectedDetail.valuation.fairValueKrw
+                            )}
+                          />
+                          <InfoTile
+                            label="NPV"
+                            value={formatKrwCompact(selectedProject.npvKrw)}
+                          />
+                          <InfoTile
+                            label="IRR"
+                            value={formatPercent(selectedProject.irr)}
+                          />
+                          <InfoTile
+                            label="회수기간"
+                            value={formatYears(selectedProject.paybackYears)}
+                          />
                         </div>
                         <div className="scenario-panel">
                           {selectedDetail.scenarioReturns.map((scenario) => (
-                            <div key={scenario.label} className="scenario-panel__item">
+                            <div
+                              key={scenario.label}
+                              className="scenario-panel__item"
+                            >
                               <span>{scenario.label}</span>
-                              <strong>{formatKrwCompact(scenario.npvKrw)}</strong>
-                              <small>확률 {formatPercent(scenario.probability)}</small>
+                              <strong>
+                                {formatKrwCompact(scenario.npvKrw)}
+                              </strong>
+                              <small>
+                                확률 {formatPercent(scenario.probability)}
+                              </small>
                             </div>
                           ))}
                         </div>
@@ -514,12 +651,38 @@ export function App() {
                           </strong>
                         </div>
                         <div className="detail-grid">
-                          <InfoTile label="VaR (95%)" value={formatKrwCompact(selectedDetail.valuation.var95Krw)} />
-                          <InfoTile label="VaR (99%)" value={formatKrwCompact(selectedDetail.valuation.var99Krw)} />
-                          <InfoTile label="CVaR" value={formatKrwCompact(selectedDetail.valuation.cvar95Krw)} />
-                          <InfoTile label="신용등급" value={selectedDetail.valuation.creditGrade} />
-                          <InfoTile label="Duration" value={`${selectedDetail.valuation.duration}년`} />
-                          <InfoTile label="Convexity" value={selectedDetail.valuation.convexity.toFixed(2)} />
+                          <InfoTile
+                            label="VaR (95%)"
+                            value={formatKrwCompact(
+                              selectedDetail.valuation.var95Krw
+                            )}
+                          />
+                          <InfoTile
+                            label="VaR (99%)"
+                            value={formatKrwCompact(
+                              selectedDetail.valuation.var99Krw
+                            )}
+                          />
+                          <InfoTile
+                            label="CVaR"
+                            value={formatKrwCompact(
+                              selectedDetail.valuation.cvar95Krw
+                            )}
+                          />
+                          <InfoTile
+                            label="신용등급"
+                            value={selectedDetail.valuation.creditGrade}
+                          />
+                          <InfoTile
+                            label="Duration"
+                            value={`${selectedDetail.valuation.duration}년`}
+                          />
+                          <InfoTile
+                            label="Convexity"
+                            value={selectedDetail.valuation.convexity.toFixed(
+                              2
+                            )}
+                          />
                         </div>
                         <div className="distribution-card">
                           <div className="distribution-card__header">
@@ -528,13 +691,20 @@ export function App() {
                           </div>
                           <div className="distribution-chart">
                             {selectedDetail.scenarioReturns.map((scenario) => (
-                              <div key={scenario.label} className="distribution-chart__item">
+                              <div
+                                key={scenario.label}
+                                className="distribution-chart__item"
+                              >
                                 <div
                                   className="distribution-chart__bar"
                                   style={{
                                     height: `${Math.max(
                                       18,
-                                      Math.round((Math.abs(scenario.npvKrw) / maxScenarioNpv) * 180)
+                                      Math.round(
+                                        (Math.abs(scenario.npvKrw) /
+                                          maxScenarioNpv) *
+                                          180
+                                      )
                                     )}px`
                                   }}
                                 />
@@ -546,10 +716,12 @@ export function App() {
                         </div>
                         <div className="risk-method">
                           <strong>신용평가 리스크 점수</strong>
-                          <span>{selectedDetail.valuation.creditRiskScore} / 100</span>
+                          <span>
+                            {selectedDetail.valuation.creditRiskScore} / 100
+                          </span>
                           <p>
-                            기준 시나리오 NPV, 변동성, 자산군별 민감도, 상태 리스크를
-                            결합한 내부 평가 점수입니다.
+                            기준 시나리오 NPV, 변동성, 자산군별 민감도, 상태
+                            리스크를 결합한 내부 평가 점수입니다.
                           </p>
                         </div>
                       </div>
@@ -572,13 +744,21 @@ export function App() {
                           ))}
                         </div>
                         <div className="detail-grid">
-                          <InfoTile label="프로젝트 오너" value={selectedDetail.workflow.owner} />
-                          <InfoTile label="재무 검토" value={selectedDetail.workflow.financeReviewer} />
+                          <InfoTile
+                            label="프로젝트 오너"
+                            value={selectedDetail.workflow.owner}
+                          />
+                          <InfoTile
+                            label="재무 검토"
+                            value={selectedDetail.workflow.financeReviewer}
+                          />
                         </div>
                         <div className="workflow-note">
                           <strong>임원 코멘트</strong>
                           <p>{selectedDetail.workflow.executiveComment}</p>
-                          <small>다음 단계 · {selectedDetail.workflow.nextStep}</small>
+                          <small>
+                            다음 단계 · {selectedDetail.workflow.nextStep}
+                          </small>
                         </div>
                       </div>
                     ) : null}
@@ -586,10 +766,17 @@ export function App() {
                 ) : null}
               </Panel>
 
-              <Panel title={`역할별 검토 패널 · ${selectedRole}`} subtitle="같은 포트폴리오를 다른 책임 관점에서 봅니다.">
+              <Panel
+                title={`역할별 검토 패널 · ${selectedRole}`}
+                subtitle="같은 포트폴리오를 다른 책임 관점에서 봅니다."
+              >
                 <div className="insight-card">
-                  <p className="insight-card__headline">{selectedInsight.headline}</p>
-                  <p className="insight-card__summary">{selectedInsight.summary}</p>
+                  <p className="insight-card__headline">
+                    {selectedInsight.headline}
+                  </p>
+                  <p className="insight-card__summary">
+                    {selectedInsight.summary}
+                  </p>
                   <dl className="insight-grid">
                     <div>
                       <dt>검토 초점</dt>
@@ -611,7 +798,10 @@ export function App() {
                 </div>
               </Panel>
 
-              <Panel title="가정값 및 감사" subtitle="포트폴리오 가정값과 최근 변경 이력을 함께 유지합니다.">
+              <Panel
+                title="가정값 및 감사"
+                subtitle="포트폴리오 가정값과 최근 변경 이력을 함께 유지합니다."
+              >
                 <div className="assumption-list">
                   {portfolio.assumptions.map((item) => (
                     <div key={item.label} className="assumption-list__item">
@@ -622,7 +812,10 @@ export function App() {
                 </div>
                 <div className="audit-inline">
                   {portfolio.auditEvents.slice(-2).map((item) => (
-                    <div key={`${item.actor}-${item.at}`} className="audit-inline__item">
+                    <div
+                      key={`${item.actor}-${item.at}`}
+                      className="audit-inline__item"
+                    >
                       <strong>{item.actor}</strong>
                       <span>{item.action}</span>
                       <small>{formatDateTime(item.at)}</small>

--- a/frontend/src/app/data.ts
+++ b/frontend/src/app/data.ts
@@ -191,7 +191,8 @@ export const roleInsights: Record<Role, RoleInsight> = {
     summary:
       '신규 사업이 어떤 고객 문제를 풀고, 어떤 부서 자원을 쓰며, 어떤 가정을 전제로 성립하는지 확인합니다.',
     decisionFocus: '사업 범위, 실행 시점, 기능 우선순위',
-    riskWatch: '가정값이 빠진 상태로 승인을 요청하면 DCF 결과가 과대평가될 수 있습니다.',
+    riskWatch:
+      '가정값이 빠진 상태로 승인을 요청하면 DCF 결과가 과대평가될 수 있습니다.',
     nextAction: '가정값 수정 후 재계산 요청'
   },
   재무팀: {

--- a/frontend/src/app/format.ts
+++ b/frontend/src/app/format.ts
@@ -45,4 +45,3 @@ export function formatDateTime(iso: string) {
     timeStyle: 'short'
   }).format(date);
 }
-

--- a/frontend/src/app/portfolioData.ts
+++ b/frontend/src/app/portfolioData.ts
@@ -131,26 +131,266 @@ type ProjectSeed = {
 };
 
 const projectSeeds: ProjectSeed[] = [
-  { code: 'UND-01', name: '암보험 신상품 출시', headquarter: '언더라이팅본부', investmentKrw: 6_500_000_000, expectedRevenueKrw: 11_200_000_000, npvKrw: 2_100_000_000, irr: 0.182, paybackYears: 2.8, status: '승인', risk: '중간', assetCategory: '프로젝트' },
-  { code: 'UND-02', name: '인수심사 자동화', headquarter: '언더라이팅본부', investmentKrw: 4_200_000_000, expectedRevenueKrw: 8_100_000_000, npvKrw: 1_700_000_000, irr: 0.171, paybackYears: 3.1, status: '조건부 진행', risk: '낮음', assetCategory: '파생상품' },
-  { code: 'UND-03', name: '위험요율 재설계', headquarter: '언더라이팅본부', investmentKrw: 3_100_000_000, expectedRevenueKrw: 5_900_000_000, npvKrw: 900_000_000, irr: 0.129, paybackYears: 3.8, status: '검토중', risk: '중간', assetCategory: '채권' },
-  { code: 'UND-04', name: '사전심사 대시보드', headquarter: '언더라이팅본부', investmentKrw: 2_800_000_000, expectedRevenueKrw: 4_700_000_000, npvKrw: -400_000_000, irr: 0.094, paybackYears: 4.6, status: '보류', risk: '높음', assetCategory: '주식' },
-  { code: 'PROD-01', name: '디지털 건강보험', headquarter: '상품개발본부', investmentKrw: 5_400_000_000, expectedRevenueKrw: 9_800_000_000, npvKrw: 2_400_000_000, irr: 0.194, paybackYears: 2.5, status: '승인', risk: '중간', assetCategory: '프로젝트' },
-  { code: 'PROD-02', name: '가족보험 패키지', headquarter: '상품개발본부', investmentKrw: 4_600_000_000, expectedRevenueKrw: 8_300_000_000, npvKrw: 1_500_000_000, irr: 0.161, paybackYears: 3.0, status: '조건부 진행', risk: '낮음', assetCategory: '주식' },
-  { code: 'PROD-03', name: '특약 정비', headquarter: '상품개발본부', investmentKrw: 3_000_000_000, expectedRevenueKrw: 4_900_000_000, npvKrw: 300_000_000, irr: 0.112, paybackYears: 4.2, status: '검토중', risk: '중간', assetCategory: '채권' },
-  { code: 'PROD-04', name: '상품약관 자동화', headquarter: '상품개발본부', investmentKrw: 2_500_000_000, expectedRevenueKrw: 4_100_000_000, npvKrw: -700_000_000, irr: 0.089, paybackYears: 4.8, status: '보류', risk: '높음', assetCategory: '파생상품' },
-  { code: 'SALES-01', name: 'GA 영업지원 포털', headquarter: '영업본부', investmentKrw: 4_900_000_000, expectedRevenueKrw: 9_500_000_000, npvKrw: 1_900_000_000, irr: 0.168, paybackYears: 2.9, status: '승인', risk: '중간', assetCategory: '프로젝트' },
-  { code: 'SALES-02', name: '설계사 리드분배', headquarter: '영업본부', investmentKrw: 3_800_000_000, expectedRevenueKrw: 7_200_000_000, npvKrw: 1_100_000_000, irr: 0.143, paybackYears: 3.4, status: '조건부 진행', risk: '낮음', assetCategory: '주식' },
-  { code: 'SALES-03', name: '모바일 견적 고도화', headquarter: '영업본부', investmentKrw: 3_100_000_000, expectedRevenueKrw: 5_600_000_000, npvKrw: 200_000_000, irr: 0.108, paybackYears: 4.1, status: '검토중', risk: '중간', assetCategory: '채권' },
-  { code: 'SALES-04', name: '채널 수익성 분석', headquarter: '영업본부', investmentKrw: 2_700_000_000, expectedRevenueKrw: 4_300_000_000, npvKrw: -900_000_000, irr: 0.081, paybackYears: 5.0, status: '보류', risk: '높음', assetCategory: '파생상품' },
-  { code: 'IT-01', name: '디지털 플랫폼 구축', headquarter: 'IT본부', investmentKrw: 7_800_000_000, expectedRevenueKrw: 13_600_000_000, npvKrw: 3_500_000_000, irr: 0.207, paybackYears: 2.3, status: '승인', risk: '중간', assetCategory: '프로젝트' },
-  { code: 'IT-02', name: '마이데이터 연계', headquarter: 'IT본부', investmentKrw: 5_900_000_000, expectedRevenueKrw: 10_700_000_000, npvKrw: 2_000_000_000, irr: 0.176, paybackYears: 2.8, status: '조건부 진행', risk: '낮음', assetCategory: '주식' },
-  { code: 'IT-03', name: '데이터허브 확장', headquarter: 'IT본부', investmentKrw: 4_300_000_000, expectedRevenueKrw: 7_400_000_000, npvKrw: 800_000_000, irr: 0.131, paybackYears: 3.7, status: '검토중', risk: '중간', assetCategory: '채권' },
-  { code: 'IT-04', name: '콜센터 고도화', headquarter: 'IT본부', investmentKrw: 3_900_000_000, expectedRevenueKrw: 6_200_000_000, npvKrw: -1_100_000_000, irr: 0.079, paybackYears: 5.2, status: '보류', risk: '높음', assetCategory: '파생상품' },
-  { code: 'CORP-01', name: '원가배분 체계개편', headquarter: '경영지원본부', investmentKrw: 2_900_000_000, expectedRevenueKrw: 5_300_000_000, npvKrw: 600_000_000, irr: 0.122, paybackYears: 3.9, status: '검토중', risk: '낮음', assetCategory: '프로젝트' },
-  { code: 'CORP-02', name: '감사로그 표준화', headquarter: '경영지원본부', investmentKrw: 2_400_000_000, expectedRevenueKrw: 4_500_000_000, npvKrw: 400_000_000, irr: 0.117, paybackYears: 4.0, status: '조건부 진행', risk: '낮음', assetCategory: '채권' },
-  { code: 'CORP-03', name: '성과관리 대시보드', headquarter: '경영지원본부', investmentKrw: 3_200_000_000, expectedRevenueKrw: 5_100_000_000, npvKrw: -300_000_000, irr: 0.097, paybackYears: 4.4, status: '검토중', risk: '중간', assetCategory: '주식' },
-  { code: 'CORP-04', name: '권한통제 재설계', headquarter: '경영지원본부', investmentKrw: 2_100_000_000, expectedRevenueKrw: 3_700_000_000, npvKrw: -1_200_000_000, irr: 0.074, paybackYears: 5.6, status: '보류', risk: '높음', assetCategory: '파생상품' }
+  {
+    code: 'UND-01',
+    name: '암보험 신상품 출시',
+    headquarter: '언더라이팅본부',
+    investmentKrw: 6_500_000_000,
+    expectedRevenueKrw: 11_200_000_000,
+    npvKrw: 2_100_000_000,
+    irr: 0.182,
+    paybackYears: 2.8,
+    status: '승인',
+    risk: '중간',
+    assetCategory: '프로젝트'
+  },
+  {
+    code: 'UND-02',
+    name: '인수심사 자동화',
+    headquarter: '언더라이팅본부',
+    investmentKrw: 4_200_000_000,
+    expectedRevenueKrw: 8_100_000_000,
+    npvKrw: 1_700_000_000,
+    irr: 0.171,
+    paybackYears: 3.1,
+    status: '조건부 진행',
+    risk: '낮음',
+    assetCategory: '파생상품'
+  },
+  {
+    code: 'UND-03',
+    name: '위험요율 재설계',
+    headquarter: '언더라이팅본부',
+    investmentKrw: 3_100_000_000,
+    expectedRevenueKrw: 5_900_000_000,
+    npvKrw: 900_000_000,
+    irr: 0.129,
+    paybackYears: 3.8,
+    status: '검토중',
+    risk: '중간',
+    assetCategory: '채권'
+  },
+  {
+    code: 'UND-04',
+    name: '사전심사 대시보드',
+    headquarter: '언더라이팅본부',
+    investmentKrw: 2_800_000_000,
+    expectedRevenueKrw: 4_700_000_000,
+    npvKrw: -400_000_000,
+    irr: 0.094,
+    paybackYears: 4.6,
+    status: '보류',
+    risk: '높음',
+    assetCategory: '주식'
+  },
+  {
+    code: 'PROD-01',
+    name: '디지털 건강보험',
+    headquarter: '상품개발본부',
+    investmentKrw: 5_400_000_000,
+    expectedRevenueKrw: 9_800_000_000,
+    npvKrw: 2_400_000_000,
+    irr: 0.194,
+    paybackYears: 2.5,
+    status: '승인',
+    risk: '중간',
+    assetCategory: '프로젝트'
+  },
+  {
+    code: 'PROD-02',
+    name: '가족보험 패키지',
+    headquarter: '상품개발본부',
+    investmentKrw: 4_600_000_000,
+    expectedRevenueKrw: 8_300_000_000,
+    npvKrw: 1_500_000_000,
+    irr: 0.161,
+    paybackYears: 3.0,
+    status: '조건부 진행',
+    risk: '낮음',
+    assetCategory: '주식'
+  },
+  {
+    code: 'PROD-03',
+    name: '특약 정비',
+    headquarter: '상품개발본부',
+    investmentKrw: 3_000_000_000,
+    expectedRevenueKrw: 4_900_000_000,
+    npvKrw: 300_000_000,
+    irr: 0.112,
+    paybackYears: 4.2,
+    status: '검토중',
+    risk: '중간',
+    assetCategory: '채권'
+  },
+  {
+    code: 'PROD-04',
+    name: '상품약관 자동화',
+    headquarter: '상품개발본부',
+    investmentKrw: 2_500_000_000,
+    expectedRevenueKrw: 4_100_000_000,
+    npvKrw: -700_000_000,
+    irr: 0.089,
+    paybackYears: 4.8,
+    status: '보류',
+    risk: '높음',
+    assetCategory: '파생상품'
+  },
+  {
+    code: 'SALES-01',
+    name: 'GA 영업지원 포털',
+    headquarter: '영업본부',
+    investmentKrw: 4_900_000_000,
+    expectedRevenueKrw: 9_500_000_000,
+    npvKrw: 1_900_000_000,
+    irr: 0.168,
+    paybackYears: 2.9,
+    status: '승인',
+    risk: '중간',
+    assetCategory: '프로젝트'
+  },
+  {
+    code: 'SALES-02',
+    name: '설계사 리드분배',
+    headquarter: '영업본부',
+    investmentKrw: 3_800_000_000,
+    expectedRevenueKrw: 7_200_000_000,
+    npvKrw: 1_100_000_000,
+    irr: 0.143,
+    paybackYears: 3.4,
+    status: '조건부 진행',
+    risk: '낮음',
+    assetCategory: '주식'
+  },
+  {
+    code: 'SALES-03',
+    name: '모바일 견적 고도화',
+    headquarter: '영업본부',
+    investmentKrw: 3_100_000_000,
+    expectedRevenueKrw: 5_600_000_000,
+    npvKrw: 200_000_000,
+    irr: 0.108,
+    paybackYears: 4.1,
+    status: '검토중',
+    risk: '중간',
+    assetCategory: '채권'
+  },
+  {
+    code: 'SALES-04',
+    name: '채널 수익성 분석',
+    headquarter: '영업본부',
+    investmentKrw: 2_700_000_000,
+    expectedRevenueKrw: 4_300_000_000,
+    npvKrw: -900_000_000,
+    irr: 0.081,
+    paybackYears: 5.0,
+    status: '보류',
+    risk: '높음',
+    assetCategory: '파생상품'
+  },
+  {
+    code: 'IT-01',
+    name: '디지털 플랫폼 구축',
+    headquarter: 'IT본부',
+    investmentKrw: 7_800_000_000,
+    expectedRevenueKrw: 13_600_000_000,
+    npvKrw: 3_500_000_000,
+    irr: 0.207,
+    paybackYears: 2.3,
+    status: '승인',
+    risk: '중간',
+    assetCategory: '프로젝트'
+  },
+  {
+    code: 'IT-02',
+    name: '마이데이터 연계',
+    headquarter: 'IT본부',
+    investmentKrw: 5_900_000_000,
+    expectedRevenueKrw: 10_700_000_000,
+    npvKrw: 2_000_000_000,
+    irr: 0.176,
+    paybackYears: 2.8,
+    status: '조건부 진행',
+    risk: '낮음',
+    assetCategory: '주식'
+  },
+  {
+    code: 'IT-03',
+    name: '데이터허브 확장',
+    headquarter: 'IT본부',
+    investmentKrw: 4_300_000_000,
+    expectedRevenueKrw: 7_400_000_000,
+    npvKrw: 800_000_000,
+    irr: 0.131,
+    paybackYears: 3.7,
+    status: '검토중',
+    risk: '중간',
+    assetCategory: '채권'
+  },
+  {
+    code: 'IT-04',
+    name: '콜센터 고도화',
+    headquarter: 'IT본부',
+    investmentKrw: 3_900_000_000,
+    expectedRevenueKrw: 6_200_000_000,
+    npvKrw: -1_100_000_000,
+    irr: 0.079,
+    paybackYears: 5.2,
+    status: '보류',
+    risk: '높음',
+    assetCategory: '파생상품'
+  },
+  {
+    code: 'CORP-01',
+    name: '원가배분 체계개편',
+    headquarter: '경영지원본부',
+    investmentKrw: 2_900_000_000,
+    expectedRevenueKrw: 5_300_000_000,
+    npvKrw: 600_000_000,
+    irr: 0.122,
+    paybackYears: 3.9,
+    status: '검토중',
+    risk: '낮음',
+    assetCategory: '프로젝트'
+  },
+  {
+    code: 'CORP-02',
+    name: '감사로그 표준화',
+    headquarter: '경영지원본부',
+    investmentKrw: 2_400_000_000,
+    expectedRevenueKrw: 4_500_000_000,
+    npvKrw: 400_000_000,
+    irr: 0.117,
+    paybackYears: 4.0,
+    status: '조건부 진행',
+    risk: '낮음',
+    assetCategory: '채권'
+  },
+  {
+    code: 'CORP-03',
+    name: '성과관리 대시보드',
+    headquarter: '경영지원본부',
+    investmentKrw: 3_200_000_000,
+    expectedRevenueKrw: 5_100_000_000,
+    npvKrw: -300_000_000,
+    irr: 0.097,
+    paybackYears: 4.4,
+    status: '검토중',
+    risk: '중간',
+    assetCategory: '주식'
+  },
+  {
+    code: 'CORP-04',
+    name: '권한통제 재설계',
+    headquarter: '경영지원본부',
+    investmentKrw: 2_100_000_000,
+    expectedRevenueKrw: 3_700_000_000,
+    npvKrw: -1_200_000_000,
+    irr: 0.074,
+    paybackYears: 5.6,
+    status: '보류',
+    risk: '높음',
+    assetCategory: '파생상품'
+  }
 ];
 
 export const navigationItems = [
@@ -174,7 +414,8 @@ export const headquarterPalette: Record<string, string> = {
   경영지원본부: 'hq-chip--rose'
 };
 
-export const defaultPortfolioSummary: PortfolioSummary = buildPortfolioSummary();
+export const defaultPortfolioSummary: PortfolioSummary =
+  buildPortfolioSummary();
 
 export const roleInsights: Record<Role, RoleInsight> = {
   원가담당자: {
@@ -212,7 +453,8 @@ export const roleInsights: Record<Role, RoleInsight> = {
 };
 
 export const apiBaseUrl =
-  import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, '') ?? 'http://localhost:8080';
+  import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, '') ??
+  'http://localhost:8080';
 
 export async function loadPortfolioSummary(): Promise<{
   summary: PortfolioSummary;
@@ -247,7 +489,9 @@ export function buildDecisionSignals(summary: PortfolioSummary) {
 
 function buildPortfolioSummary(): PortfolioSummary {
   const headquarters = buildHeadquartersSummary();
-  const sortedProjects = [...projectSeeds].sort((left, right) => right.npvKrw - left.npvKrw);
+  const sortedProjects = [...projectSeeds].sort(
+    (left, right) => right.npvKrw - left.npvKrw
+  );
   const projects = sortedProjects.map((seed, index) => ({
     rank: index + 1,
     code: seed.code,
@@ -263,19 +507,27 @@ function buildPortfolioSummary(): PortfolioSummary {
     assetCategory: seed.assetCategory
   }));
 
-  const totalInvestmentKrw = projectSeeds.reduce((sum, project) => sum + project.investmentKrw, 0);
+  const totalInvestmentKrw = projectSeeds.reduce(
+    (sum, project) => sum + project.investmentKrw,
+    0
+  );
   const totalExpectedRevenueKrw = projectSeeds.reduce(
     (sum, project) => sum + project.expectedRevenueKrw,
     0
   );
   const averageNpvKrw = Math.round(
-    projectSeeds.reduce((sum, project) => sum + project.npvKrw, 0) / projectSeeds.length
+    projectSeeds.reduce((sum, project) => sum + project.npvKrw, 0) /
+      projectSeeds.length
   );
   const averageIrr =
-    projectSeeds.reduce((sum, project) => sum + project.irr, 0) / projectSeeds.length;
+    projectSeeds.reduce((sum, project) => sum + project.irr, 0) /
+    projectSeeds.length;
   const averagePaybackYears =
-    projectSeeds.reduce((sum, project) => sum + project.paybackYears, 0) / projectSeeds.length;
-  const approvedCount = projectSeeds.filter((project) => project.status === '승인').length;
+    projectSeeds.reduce((sum, project) => sum + project.paybackYears, 0) /
+    projectSeeds.length;
+  const approvedCount = projectSeeds.filter(
+    (project) => project.status === '승인'
+  ).length;
   const conditionalCount = projectSeeds.filter(
     (project) => project.status === '조건부 진행'
   ).length;
@@ -334,9 +586,12 @@ function buildPortfolioSummary(): PortfolioSummary {
 }
 
 export function buildProjectDetail(projectCode: string): ProjectDetail {
-  const seedIndex = projectSeeds.findIndex((project) => project.code === projectCode);
+  const seedIndex = projectSeeds.findIndex(
+    (project) => project.code === projectCode
+  );
   const seed =
-    projectSeeds.find((project) => project.code === projectCode) ?? projectSeeds[0];
+    projectSeeds.find((project) => project.code === projectCode) ??
+    projectSeeds[0];
   const managerByHeadquarter: Record<string, string> = {
     언더라이팅본부: '박하늘 PM',
     상품개발본부: '이수민 PM',
@@ -364,7 +619,9 @@ export function buildProjectDetail(projectCode: string): ProjectDetail {
   const var99Krw = Math.round(seed.npvKrw - volatility * 2.33);
   const cvar95Krw = Math.round(seed.npvKrw - volatility * 2.06);
   const duration = Number((1.8 + seed.paybackYears * 0.46).toFixed(2));
-  const convexity = Number((duration * 1.38 + (seed.risk === '높음' ? 1.7 : 0.8)).toFixed(2));
+  const convexity = Number(
+    (duration * 1.38 + (seed.risk === '높음' ? 1.7 : 0.8)).toFixed(2)
+  );
   const creditRiskScore = Math.max(
     24,
     Math.min(
@@ -405,12 +662,26 @@ export function buildProjectDetail(projectCode: string): ProjectDetail {
       convexity,
       creditRiskScore,
       creditGrade:
-        creditRiskScore >= 85 ? 'AA' : creditRiskScore >= 75 ? 'A' : creditRiskScore >= 65 ? 'BBB' : 'BB'
+        creditRiskScore >= 85
+          ? 'AA'
+          : creditRiskScore >= 75
+            ? 'A'
+            : creditRiskScore >= 65
+              ? 'BBB'
+              : 'BB'
     },
     scenarioReturns: [
-      { label: '낙관', npvKrw: Math.round(seed.npvKrw * 1.42), probability: 0.25 },
+      {
+        label: '낙관',
+        npvKrw: Math.round(seed.npvKrw * 1.42),
+        probability: 0.25
+      },
       { label: '기준', npvKrw: seed.npvKrw, probability: 0.5 },
-      { label: '비관', npvKrw: Math.round(seed.npvKrw * 0.58 - investmentBase * 0.07), probability: 0.25 }
+      {
+        label: '비관',
+        npvKrw: Math.round(seed.npvKrw * 0.58 - investmentBase * 0.07),
+        probability: 0.25
+      }
     ],
     workflow: {
       currentStage:
@@ -443,17 +714,29 @@ function buildHeadquartersSummary(): HeadquartersSummary[] {
   ];
 }
 
-function buildHeadquarter(code: string, name: string, risk: RiskLevel): HeadquartersSummary {
-  const projects = projectSeeds.filter((project) => project.code.startsWith(code));
+function buildHeadquarter(
+  code: string,
+  name: string,
+  risk: RiskLevel
+): HeadquartersSummary {
+  const projects = projectSeeds.filter((project) =>
+    project.code.startsWith(code)
+  );
   const projectCount = projects.length;
-  const totalInvestmentKrw = projects.reduce((sum, project) => sum + project.investmentKrw, 0);
+  const totalInvestmentKrw = projects.reduce(
+    (sum, project) => sum + project.investmentKrw,
+    0
+  );
   const totalExpectedRevenueKrw = projects.reduce(
     (sum, project) => sum + project.expectedRevenueKrw,
     0
   );
-  const averageNpvKrw = Math.round(projects.reduce((sum, project) => sum + project.npvKrw, 0) / projectCount);
+  const averageNpvKrw = Math.round(
+    projects.reduce((sum, project) => sum + project.npvKrw, 0) / projectCount
+  );
   const priorityProject =
-    projects.slice().sort((left, right) => right.npvKrw - left.npvKrw)[0]?.name ?? '프로젝트 없음';
+    projects.slice().sort((left, right) => right.npvKrw - left.npvKrw)[0]
+      ?.name ?? '프로젝트 없음';
 
   return {
     code,

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -19,10 +19,19 @@
   --shadow: 0 26px 52px rgba(92, 108, 145, 0.12);
   --shadow-soft: 0 12px 28px rgba(92, 108, 145, 0.08);
   --page-gradient:
-    radial-gradient(circle at top left, rgba(79, 103, 246, 0.1), transparent 28%),
-    radial-gradient(circle at bottom right, rgba(47, 182, 166, 0.08), transparent 20%),
+    radial-gradient(
+      circle at top left,
+      rgba(79, 103, 246, 0.1),
+      transparent 28%
+    ),
+    radial-gradient(
+      circle at bottom right,
+      rgba(47, 182, 166, 0.08),
+      transparent 20%
+    ),
     linear-gradient(180deg, #eef2fb, #edf2fb 38%, #f5f7fc 100%);
-  font-family: 'SUIT Variable', 'Pretendard Variable', 'Pretendard', 'Apple SD Gothic Neo',
+  font-family:
+    'SUIT Variable', 'Pretendard Variable', 'Pretendard', 'Apple SD Gothic Neo',
     'Noto Sans KR', sans-serif;
 }
 
@@ -79,7 +88,11 @@ textarea {
   align-content: start;
   padding: 26px 20px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(248, 250, 255, 0.78)),
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.85),
+      rgba(248, 250, 255, 0.78)
+    ),
     radial-gradient(circle at top, rgba(79, 103, 246, 0.08), transparent 36%);
   border-right: 1px solid var(--border);
   backdrop-filter: blur(22px);
@@ -161,7 +174,11 @@ textarea {
 
 .nav__item--active,
 .hq-filter--active {
-  background: linear-gradient(180deg, rgba(238, 242, 255, 0.96), rgba(247, 249, 255, 0.96));
+  background: linear-gradient(
+    180deg,
+    rgba(238, 242, 255, 0.96),
+    rgba(247, 249, 255, 0.96)
+  );
   border-color: rgba(79, 103, 246, 0.24);
   box-shadow:
     inset 3px 0 0 var(--accent),
@@ -386,8 +403,11 @@ textarea {
   width: 100%;
   padding: 16px 18px;
   border-radius: 20px;
-  background:
-    linear-gradient(180deg, rgba(248, 250, 255, 0.98), rgba(255, 255, 255, 0.98));
+  background: linear-gradient(
+    180deg,
+    rgba(248, 250, 255, 0.98),
+    rgba(255, 255, 255, 0.98)
+  );
   border: 1px solid rgba(79, 103, 246, 0.14);
   text-align: left;
 }
@@ -435,15 +455,27 @@ textarea {
 }
 
 .metric-card--primary {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(247, 249, 255, 0.96));
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.96),
+    rgba(247, 249, 255, 0.96)
+  );
 }
 
 .metric-card--success {
-  background: linear-gradient(180deg, rgba(247, 255, 252, 0.98), rgba(255, 255, 255, 0.98));
+  background: linear-gradient(
+    180deg,
+    rgba(247, 255, 252, 0.98),
+    rgba(255, 255, 255, 0.98)
+  );
 }
 
 .metric-card--warning {
-  background: linear-gradient(180deg, rgba(255, 250, 242, 0.98), rgba(255, 255, 255, 0.98));
+  background: linear-gradient(
+    180deg,
+    rgba(255, 250, 242, 0.98),
+    rgba(255, 255, 255, 0.98)
+  );
 }
 
 .metric-card__label {
@@ -564,8 +596,11 @@ textarea {
   gap: 14px;
   padding: 18px;
   border-radius: 22px;
-  background:
-    linear-gradient(180deg, rgba(247, 249, 255, 0.94), rgba(255, 255, 255, 0.94));
+  background: linear-gradient(
+    180deg,
+    rgba(247, 249, 255, 0.94),
+    rgba(255, 255, 255, 0.94)
+  );
   border: 1px solid rgba(113, 129, 160, 0.12);
 }
 
@@ -747,8 +782,11 @@ textarea {
   gap: 14px;
   padding: 18px;
   border-radius: 22px;
-  background:
-    linear-gradient(135deg, rgba(241, 244, 255, 0.98), rgba(255, 255, 255, 0.98));
+  background: linear-gradient(
+    135deg,
+    rgba(241, 244, 255, 0.98),
+    rgba(255, 255, 255, 0.98)
+  );
   border: 1px solid rgba(79, 103, 246, 0.14);
 }
 
@@ -852,7 +890,11 @@ textarea {
 }
 
 .distribution-card {
-  background: linear-gradient(180deg, rgba(247, 249, 255, 0.98), rgba(255, 255, 255, 0.98));
+  background: linear-gradient(
+    180deg,
+    rgba(247, 249, 255, 0.98),
+    rgba(255, 255, 255, 0.98)
+  );
   border: 1px solid rgba(79, 103, 246, 0.12);
 }
 
@@ -886,7 +928,11 @@ textarea {
   width: 100%;
   max-width: 72px;
   border-radius: 999px 999px 16px 16px;
-  background: linear-gradient(180deg, rgba(79, 103, 246, 0.14), rgba(79, 103, 246, 0.8));
+  background: linear-gradient(
+    180deg,
+    rgba(79, 103, 246, 0.14),
+    rgba(79, 103, 246, 0.8)
+  );
   box-shadow: inset 0 0 0 1px rgba(79, 103, 246, 0.12);
 }
 


### PR DESCRIPTION
﻿## 요약

프론트엔드 포맷 기준선을 정리하고 pre-commit 훅의 Gradle 실행을 `--no-daemon`으로 안정화했습니다.

## 변경 내용

- `frontend/` 전체에 Prettier 포맷을 적용했습니다.
- 기존 `format:check` 실패 파일들을 정리했습니다.
- `.githooks/pre-commit`의 백엔드 검사를 `./gradlew --no-daemon check`로 변경했습니다.
- `docs/dev-logs/`에 비교안과 검증 결과를 기록했습니다.

## 이유

기능 PR과 무관하게 저장소 전역 포맷 불일치와 Gradle 훅 실행 문제가 겹쳐 `--no-verify` 우회가 필요했습니다. 이 PR은 그 공통 원인을 별도 slice로 정리해 기능 PR 범위를 깨끗하게 유지하기 위한 정리 작업입니다.

## 검증

- [x] 관련 테스트를 실행했습니다.
- [ ] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
- [x] 인접한 흐름에서 회귀가 없는지 확인했습니다.

## 스크린샷 또는 로그

- `npm run format:check`
- `npm run lint`
- `npm run build`
- `GRADLE_USER_HOME=C:\Users\ggg99\Desktop\CostWiseAI\.gradle-home .\gradlew.bat check`
- 결과: 모두 성공
- 추가 확인: pre-commit hook 활성 상태에서 일반 `git commit` 성공

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [ ] 후속 작업이 필요하면 별도 이슈로 분리했습니다.

## 브랜치

- [x] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
- [x] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.
