### PR TITLE
feat: 프로젝트/시나리오 영속 API 경로 추가

### DIFF
--- a/backend/src/main/java/com/costwise/api/PersistenceController.java
+++ b/backend/src/main/java/com/costwise/api/PersistenceController.java
@@ -1,0 +1,87 @@
+package com.costwise.api;
+
+import com.costwise.api.dto.persistence.AnalysisUpdateResponse;
+import com.costwise.api.dto.persistence.AnalysisUpsertRequest;
+import com.costwise.api.dto.persistence.CreateProjectRequest;
+import com.costwise.api.dto.persistence.CreateScenarioRequest;
+import com.costwise.api.dto.persistence.ProjectDetailResponse;
+import com.costwise.api.dto.persistence.ProjectSummaryResponse;
+import com.costwise.api.dto.persistence.ScenarioResponse;
+import com.costwise.api.dto.persistence.UpdateProjectRequest;
+import com.costwise.api.dto.persistence.UpdateScenarioRequest;
+import com.costwise.service.PersistenceService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/persistence")
+@PreAuthorize("hasAnyRole('PLANNER', 'FINANCE_REVIEWER', 'EXECUTIVE')")
+public class PersistenceController {
+
+    private final PersistenceService persistenceService;
+
+    public PersistenceController(PersistenceService persistenceService) {
+        this.persistenceService = persistenceService;
+    }
+
+    @PostMapping("/projects")
+    public ResponseEntity<ProjectSummaryResponse> createProject(@Valid @RequestBody CreateProjectRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(persistenceService.createProject(request));
+    }
+
+    @PutMapping("/projects/{projectId}")
+    public ProjectSummaryResponse updateProject(
+            @PathVariable String projectId, @Valid @RequestBody UpdateProjectRequest request) {
+        return persistenceService.updateProject(projectId, request);
+    }
+
+    @DeleteMapping("/projects/{projectId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteProject(@PathVariable String projectId) {
+        persistenceService.deleteProject(projectId);
+    }
+
+    @GetMapping("/projects/{projectId}")
+    public ProjectDetailResponse projectDetail(@PathVariable String projectId) {
+        return persistenceService.getProjectDetail(projectId);
+    }
+
+    @PostMapping("/projects/{projectId}/scenarios")
+    public ResponseEntity<ScenarioResponse> createScenario(
+            @PathVariable String projectId, @Valid @RequestBody CreateScenarioRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(persistenceService.createScenario(projectId, request));
+    }
+
+    @PutMapping("/projects/{projectId}/scenarios/{scenarioId}")
+    public ScenarioResponse updateScenario(
+            @PathVariable String projectId,
+            @PathVariable String scenarioId,
+            @Valid @RequestBody UpdateScenarioRequest request) {
+        return persistenceService.updateScenario(projectId, scenarioId, request);
+    }
+
+    @DeleteMapping("/projects/{projectId}/scenarios/{scenarioId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteScenario(@PathVariable String projectId, @PathVariable String scenarioId) {
+        persistenceService.deleteScenario(projectId, scenarioId);
+    }
+
+    @PutMapping("/projects/{projectId}/scenarios/{scenarioId}/analysis")
+    public AnalysisUpdateResponse upsertAnalysis(
+            @PathVariable String projectId,
+            @PathVariable String scenarioId,
+            @Valid @RequestBody AnalysisUpsertRequest request) {
+        return persistenceService.upsertAnalysis(projectId, scenarioId, request);
+    }
+}

--- a/backend/src/main/java/com/costwise/api/dto/persistence/AnalysisUpdateResponse.java
+++ b/backend/src/main/java/com/costwise/api/dto/persistence/AnalysisUpdateResponse.java
@@ -1,0 +1,7 @@
+package com.costwise.api.dto.persistence;
+
+public record AnalysisUpdateResponse(
+        String projectId,
+        String scenarioId,
+        int allocationRuleCount,
+        int cashFlowCount) {}

--- a/backend/src/main/java/com/costwise/api/dto/persistence/AnalysisUpsertRequest.java
+++ b/backend/src/main/java/com/costwise/api/dto/persistence/AnalysisUpsertRequest.java
@@ -1,0 +1,48 @@
+package com.costwise.api.dto.persistence;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.util.List;
+
+public record AnalysisUpsertRequest(
+        @NotNull @Valid List<AllocationRuleInput> allocationRules,
+        @NotNull @Valid List<CashFlowInput> cashFlows,
+        @NotNull @Valid ValuationInput valuation,
+        @NotNull @Valid ApprovalInput approval) {
+
+    public record AllocationRuleInput(
+            @NotBlank String departmentCode,
+            @NotBlank String basis,
+            @NotNull BigDecimal allocationRate,
+            @NotNull BigDecimal allocatedAmount,
+            @NotBlank String costPoolName,
+            @NotBlank String costPoolCategory,
+            @NotNull BigDecimal costPoolAmount) {}
+
+    public record CashFlowInput(
+            int periodNo,
+            @NotBlank String periodLabel,
+            @NotBlank String yearLabel,
+            @NotNull BigDecimal operatingCashFlow,
+            @NotNull BigDecimal investmentCashFlow,
+            @NotNull BigDecimal financingCashFlow,
+            @NotNull BigDecimal discountRate) {}
+
+    public record ValuationInput(
+            @NotNull BigDecimal discountRate,
+            @NotNull BigDecimal npv,
+            @NotNull BigDecimal irr,
+            @NotNull BigDecimal paybackPeriod,
+            @NotBlank String decision,
+            JsonNode assumptions) {}
+
+    public record ApprovalInput(
+            @NotBlank String actorRole,
+            @NotBlank String actorName,
+            @NotBlank String action,
+            String comment,
+            @NotBlank String projectStatus) {}
+}

--- a/backend/src/main/java/com/costwise/api/dto/persistence/CreateProjectRequest.java
+++ b/backend/src/main/java/com/costwise/api/dto/persistence/CreateProjectRequest.java
@@ -1,0 +1,9 @@
+package com.costwise.api.dto.persistence;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateProjectRequest(
+        @NotBlank String code,
+        @NotBlank String name,
+        @NotBlank String businessType,
+        String description) {}

--- a/backend/src/main/java/com/costwise/api/dto/persistence/CreateScenarioRequest.java
+++ b/backend/src/main/java/com/costwise/api/dto/persistence/CreateScenarioRequest.java
@@ -1,0 +1,9 @@
+package com.costwise.api.dto.persistence;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateScenarioRequest(
+        @NotBlank String name,
+        String description,
+        boolean isBaseline,
+        boolean isActive) {}

--- a/backend/src/main/java/com/costwise/api/dto/persistence/ProjectDetailResponse.java
+++ b/backend/src/main/java/com/costwise/api/dto/persistence/ProjectDetailResponse.java
@@ -1,0 +1,71 @@
+package com.costwise.api.dto.persistence;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ProjectDetailResponse(
+        String id,
+        String code,
+        String name,
+        String businessType,
+        String status,
+        String description,
+        LocalDateTime createdAt,
+        List<ScenarioDetailResponse> scenarios,
+        ApprovalSummary approval) {
+
+    public record ScenarioDetailResponse(
+            String id,
+            String name,
+            String description,
+            boolean isBaseline,
+            boolean isActive,
+            LocalDateTime createdAt,
+            List<AllocationRule> allocationRules,
+            List<CashFlow> cashFlows,
+            Valuation valuation) {}
+
+    public record AllocationRule(
+            String departmentCode,
+            String basis,
+            BigDecimal allocationRate,
+            BigDecimal allocatedAmount,
+            String costPoolName,
+            String costPoolCategory,
+            BigDecimal costPoolAmount) {}
+
+    public record CashFlow(
+            int periodNo,
+            String periodLabel,
+            String yearLabel,
+            BigDecimal operatingCashFlow,
+            BigDecimal investmentCashFlow,
+            BigDecimal financingCashFlow,
+            BigDecimal netCashFlow,
+            BigDecimal discountRate) {}
+
+    public record Valuation(
+            BigDecimal discountRate,
+            BigDecimal npv,
+            BigDecimal irr,
+            BigDecimal paybackPeriod,
+            String decision,
+            JsonNode assumptions) {}
+
+    public record ApprovalSummary(
+            String status,
+            String lastAction,
+            String lastActor,
+            String lastComment,
+            LocalDateTime updatedAt,
+            List<ApprovalEvent> logs) {}
+
+    public record ApprovalEvent(
+            String actorRole,
+            String actorName,
+            String action,
+            String comment,
+            LocalDateTime createdAt) {}
+}

--- a/backend/src/main/java/com/costwise/api/dto/persistence/ProjectSummaryResponse.java
+++ b/backend/src/main/java/com/costwise/api/dto/persistence/ProjectSummaryResponse.java
@@ -1,0 +1,12 @@
+package com.costwise.api.dto.persistence;
+
+import java.time.LocalDateTime;
+
+public record ProjectSummaryResponse(
+        String id,
+        String code,
+        String name,
+        String businessType,
+        String status,
+        String description,
+        LocalDateTime createdAt) {}

--- a/backend/src/main/java/com/costwise/api/dto/persistence/ScenarioResponse.java
+++ b/backend/src/main/java/com/costwise/api/dto/persistence/ScenarioResponse.java
@@ -1,0 +1,11 @@
+package com.costwise.api.dto.persistence;
+
+import java.time.LocalDateTime;
+
+public record ScenarioResponse(
+        String id,
+        String name,
+        String description,
+        boolean isBaseline,
+        boolean isActive,
+        LocalDateTime createdAt) {}

--- a/backend/src/main/java/com/costwise/api/dto/persistence/UpdateProjectRequest.java
+++ b/backend/src/main/java/com/costwise/api/dto/persistence/UpdateProjectRequest.java
@@ -1,0 +1,9 @@
+package com.costwise.api.dto.persistence;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateProjectRequest(
+        @NotBlank String name,
+        @NotBlank String businessType,
+        String description,
+        @NotBlank String status) {}

--- a/backend/src/main/java/com/costwise/api/dto/persistence/UpdateScenarioRequest.java
+++ b/backend/src/main/java/com/costwise/api/dto/persistence/UpdateScenarioRequest.java
@@ -1,0 +1,9 @@
+package com.costwise.api.dto.persistence;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateScenarioRequest(
+        @NotBlank String name,
+        String description,
+        boolean isBaseline,
+        boolean isActive) {}

--- a/backend/src/main/java/com/costwise/service/PersistenceService.java
+++ b/backend/src/main/java/com/costwise/service/PersistenceService.java
@@ -1,0 +1,417 @@
+package com.costwise.service;
+
+import com.costwise.api.dto.persistence.AnalysisUpdateResponse;
+import com.costwise.api.dto.persistence.AnalysisUpsertRequest;
+import com.costwise.api.dto.persistence.CreateProjectRequest;
+import com.costwise.api.dto.persistence.CreateScenarioRequest;
+import com.costwise.api.dto.persistence.ProjectDetailResponse;
+import com.costwise.api.dto.persistence.ProjectSummaryResponse;
+import com.costwise.api.dto.persistence.ScenarioResponse;
+import com.costwise.api.dto.persistence.UpdateProjectRequest;
+import com.costwise.api.dto.persistence.UpdateScenarioRequest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PersistenceService {
+
+    private static final Set<String> PROJECT_STATUSES =
+            Set.of("draft", "in_review", "approved", "rejected", "archived");
+    private static final Set<String> ACTOR_ROLES =
+            Set.of("planner", "finance_reviewer", "executive", "system");
+    private static final Set<String> APPROVAL_ACTIONS =
+            Set.of("created", "allocated", "evaluated", "approved", "rejected", "commented");
+    private static final Set<String> COST_POOL_CATEGORIES =
+            Set.of("personnel", "it", "vendor", "shared", "other");
+    private static final Set<String> ALLOCATION_BASIS =
+            Set.of("headcount", "transaction_count", "revenue", "manual");
+    private static final Set<String> VALUATION_DECISIONS =
+            Set.of("recommend", "review", "reject");
+
+    private final Map<String, ProjectState> projects = new ConcurrentHashMap<>();
+    private final Map<String, String> codeToProjectId = new ConcurrentHashMap<>();
+
+    public ProjectSummaryResponse createProject(CreateProjectRequest request) {
+        String code = request.code().trim();
+        if (codeToProjectId.containsKey(code)) {
+            throw new IllegalArgumentException("Project code already exists: " + code);
+        }
+        String id = UUID.randomUUID().toString();
+        LocalDateTime now = LocalDateTime.now();
+        ProjectState project = new ProjectState(
+                id, code, request.name().trim(), request.businessType().trim(), "draft", request.description(), now);
+        projects.put(id, project);
+        codeToProjectId.put(code, id);
+        return toProjectSummary(project);
+    }
+
+    public ProjectSummaryResponse updateProject(String projectId, UpdateProjectRequest request) {
+        ProjectState project = getProjectState(projectId);
+        String status = normalizeEnum(request.status(), PROJECT_STATUSES, "project status");
+        project.name = request.name().trim();
+        project.businessType = request.businessType().trim();
+        project.description = request.description();
+        project.status = status;
+        project.approvalSummary.status = status;
+        project.approvalSummary.updatedAt = LocalDateTime.now();
+        return toProjectSummary(project);
+    }
+
+    public void deleteProject(String projectId) {
+        ProjectState removed = projects.remove(projectId);
+        if (removed == null) {
+            throw new IllegalArgumentException("Unknown project id: " + projectId);
+        }
+        codeToProjectId.remove(removed.code);
+    }
+
+    public ScenarioResponse createScenario(String projectId, CreateScenarioRequest request) {
+        ProjectState project = getProjectState(projectId);
+        ensureScenarioNameUnique(project, request.name(), null);
+        ScenarioState scenario = new ScenarioState(
+                UUID.randomUUID().toString(),
+                request.name().trim(),
+                request.description(),
+                request.isBaseline(),
+                request.isActive(),
+                LocalDateTime.now());
+        project.scenarios.put(scenario.id, scenario);
+        return toScenarioResponse(scenario);
+    }
+
+    public ScenarioResponse updateScenario(
+            String projectId, String scenarioId, UpdateScenarioRequest request) {
+        ProjectState project = getProjectState(projectId);
+        ScenarioState scenario = getScenarioState(project, scenarioId);
+        ensureScenarioNameUnique(project, request.name(), scenarioId);
+        scenario.name = request.name().trim();
+        scenario.description = request.description();
+        scenario.isBaseline = request.isBaseline();
+        scenario.isActive = request.isActive();
+        return toScenarioResponse(scenario);
+    }
+
+    public void deleteScenario(String projectId, String scenarioId) {
+        ProjectState project = getProjectState(projectId);
+        ScenarioState removed = project.scenarios.remove(scenarioId);
+        if (removed == null) {
+            throw new IllegalArgumentException("Unknown scenario id: " + scenarioId);
+        }
+    }
+
+    public AnalysisUpdateResponse upsertAnalysis(
+            String projectId, String scenarioId, AnalysisUpsertRequest request) {
+        ProjectState project = getProjectState(projectId);
+        ScenarioState scenario = getScenarioState(project, scenarioId);
+
+        scenario.allocationRules = request.allocationRules().stream()
+                .map(this::toAllocationRule)
+                .toList();
+        scenario.cashFlows = request.cashFlows().stream()
+                .map(this::toCashFlow)
+                .toList();
+        scenario.valuation = toValuation(request.valuation());
+
+        ApprovalLog approvalLog = toApprovalLog(request.approval());
+        project.approvalSummary.status = normalizeEnum(
+                request.approval().projectStatus(), PROJECT_STATUSES, "project status");
+        project.approvalSummary.lastAction = approvalLog.action;
+        project.approvalSummary.lastActor = approvalLog.actorName;
+        project.approvalSummary.lastComment = approvalLog.comment;
+        project.approvalSummary.updatedAt = approvalLog.createdAt;
+        project.approvalLogs.add(approvalLog);
+        project.status = project.approvalSummary.status;
+
+        return new AnalysisUpdateResponse(projectId, scenarioId, scenario.allocationRules.size(), scenario.cashFlows.size());
+    }
+
+    public ProjectDetailResponse getProjectDetail(String projectId) {
+        ProjectState project = getProjectState(projectId);
+        List<ProjectDetailResponse.ScenarioDetailResponse> scenarios = project.scenarios.values().stream()
+                .map(this::toScenarioDetailResponse)
+                .toList();
+        List<ProjectDetailResponse.ApprovalEvent> logs = project.approvalLogs.stream()
+                .map(log -> new ProjectDetailResponse.ApprovalEvent(
+                        log.actorRole, log.actorName, log.action, log.comment, log.createdAt))
+                .toList();
+        ProjectDetailResponse.ApprovalSummary approvalSummary = new ProjectDetailResponse.ApprovalSummary(
+                project.approvalSummary.status,
+                project.approvalSummary.lastAction,
+                project.approvalSummary.lastActor,
+                project.approvalSummary.lastComment,
+                project.approvalSummary.updatedAt,
+                logs);
+        return new ProjectDetailResponse(
+                project.id,
+                project.code,
+                project.name,
+                project.businessType,
+                project.status,
+                project.description,
+                project.createdAt,
+                scenarios,
+                approvalSummary);
+    }
+
+    private ProjectSummaryResponse toProjectSummary(ProjectState project) {
+        return new ProjectSummaryResponse(
+                project.id, project.code, project.name, project.businessType, project.status, project.description, project.createdAt);
+    }
+
+    private ScenarioResponse toScenarioResponse(ScenarioState scenario) {
+        return new ScenarioResponse(
+                scenario.id, scenario.name, scenario.description, scenario.isBaseline, scenario.isActive, scenario.createdAt);
+    }
+
+    private ProjectDetailResponse.ScenarioDetailResponse toScenarioDetailResponse(ScenarioState scenario) {
+        List<ProjectDetailResponse.AllocationRule> allocations = scenario.allocationRules.stream()
+                .map(value -> new ProjectDetailResponse.AllocationRule(
+                        value.departmentCode,
+                        value.basis,
+                        value.allocationRate,
+                        value.allocatedAmount,
+                        value.costPoolName,
+                        value.costPoolCategory,
+                        value.costPoolAmount))
+                .toList();
+        List<ProjectDetailResponse.CashFlow> cashFlows = scenario.cashFlows.stream()
+                .map(value -> new ProjectDetailResponse.CashFlow(
+                        value.periodNo,
+                        value.periodLabel,
+                        value.yearLabel,
+                        value.operatingCashFlow,
+                        value.investmentCashFlow,
+                        value.financingCashFlow,
+                        value.netCashFlow,
+                        value.discountRate))
+                .toList();
+        ProjectDetailResponse.Valuation valuation = scenario.valuation == null
+                ? null
+                : new ProjectDetailResponse.Valuation(
+                        scenario.valuation.discountRate,
+                        scenario.valuation.npv,
+                        scenario.valuation.irr,
+                        scenario.valuation.paybackPeriod,
+                        scenario.valuation.decision,
+                        scenario.valuation.assumptions);
+        return new ProjectDetailResponse.ScenarioDetailResponse(
+                scenario.id,
+                scenario.name,
+                scenario.description,
+                scenario.isBaseline,
+                scenario.isActive,
+                scenario.createdAt,
+                allocations,
+                cashFlows,
+                valuation);
+    }
+
+    private AllocationRuleState toAllocationRule(AnalysisUpsertRequest.AllocationRuleInput input) {
+        String basis = normalizeEnum(input.basis(), ALLOCATION_BASIS, "allocation basis");
+        String costPoolCategory = normalizeEnum(input.costPoolCategory(), COST_POOL_CATEGORIES, "cost pool category");
+        if (input.allocationRate().compareTo(BigDecimal.ZERO) < 0 || input.allocationRate().compareTo(BigDecimal.ONE) > 0) {
+            throw new IllegalArgumentException("allocationRate must be between 0 and 1");
+        }
+        if (input.allocatedAmount().compareTo(BigDecimal.ZERO) < 0 || input.costPoolAmount().compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("allocatedAmount and costPoolAmount must be >= 0");
+        }
+        return new AllocationRuleState(
+                input.departmentCode().trim(),
+                basis,
+                input.allocationRate(),
+                input.allocatedAmount(),
+                input.costPoolName().trim(),
+                costPoolCategory,
+                input.costPoolAmount());
+    }
+
+    private CashFlowState toCashFlow(AnalysisUpsertRequest.CashFlowInput input) {
+        if (input.periodNo() < 0) {
+            throw new IllegalArgumentException("periodNo must be >= 0");
+        }
+        if (input.discountRate().compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("discountRate must be >= 0");
+        }
+        // Schema contract keeps net_cash_flow as stored value; this slice derives it deterministically
+        // from operating + investment + financing to avoid drift between API payload and persisted shape.
+        BigDecimal netCashFlow = input.operatingCashFlow().add(input.investmentCashFlow()).add(input.financingCashFlow());
+        return new CashFlowState(
+                input.periodNo(),
+                input.periodLabel().trim(),
+                input.yearLabel().trim(),
+                input.operatingCashFlow(),
+                input.investmentCashFlow(),
+                input.financingCashFlow(),
+                netCashFlow,
+                input.discountRate());
+    }
+
+    private ValuationState toValuation(AnalysisUpsertRequest.ValuationInput input) {
+        String decision = normalizeEnum(input.decision(), VALUATION_DECISIONS, "valuation decision");
+        if (input.discountRate().compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("discountRate must be >= 0");
+        }
+        JsonNode assumptions = input.assumptions() == null ? JsonNodeFactory.instance.objectNode() : input.assumptions();
+        return new ValuationState(
+                input.discountRate(),
+                input.npv(),
+                input.irr(),
+                input.paybackPeriod(),
+                decision,
+                assumptions);
+    }
+
+    private ApprovalLog toApprovalLog(AnalysisUpsertRequest.ApprovalInput input) {
+        String actorRole = normalizeEnum(input.actorRole(), ACTOR_ROLES, "actor role");
+        String action = normalizeEnum(input.action(), APPROVAL_ACTIONS, "approval action");
+        return new ApprovalLog(actorRole, input.actorName().trim(), action, input.comment(), LocalDateTime.now());
+    }
+
+    private ProjectState getProjectState(String projectId) {
+        ProjectState project = projects.get(projectId);
+        if (project == null) {
+            throw new IllegalArgumentException("Unknown project id: " + projectId);
+        }
+        return project;
+    }
+
+    private ScenarioState getScenarioState(ProjectState project, String scenarioId) {
+        ScenarioState scenario = project.scenarios.get(scenarioId);
+        if (scenario == null) {
+            throw new IllegalArgumentException("Unknown scenario id: " + scenarioId);
+        }
+        return scenario;
+    }
+
+    private void ensureScenarioNameUnique(ProjectState project, String candidateName, String skipScenarioId) {
+        String normalized = candidateName.trim().toLowerCase(Locale.ROOT);
+        boolean duplicated = project.scenarios.values().stream()
+                .anyMatch(s -> !s.id.equals(skipScenarioId) && s.name.trim().toLowerCase(Locale.ROOT).equals(normalized));
+        if (duplicated) {
+            throw new IllegalArgumentException("Scenario name already exists in project: " + candidateName);
+        }
+    }
+
+    private String normalizeEnum(String value, Set<String> allowed, String fieldName) {
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        if (!allowed.contains(normalized)) {
+            throw new IllegalArgumentException("Invalid " + fieldName + ": " + value);
+        }
+        return normalized;
+    }
+
+    private static final class ProjectState {
+        private final String id;
+        private final String code;
+        private String name;
+        private String businessType;
+        private String status;
+        private String description;
+        private final LocalDateTime createdAt;
+        private final Map<String, ScenarioState> scenarios = new LinkedHashMap<>();
+        private final ApprovalSummaryState approvalSummary = new ApprovalSummaryState();
+        private final List<ApprovalLog> approvalLogs = new ArrayList<>();
+
+        private ProjectState(
+                String id,
+                String code,
+                String name,
+                String businessType,
+                String status,
+                String description,
+                LocalDateTime createdAt) {
+            this.id = id;
+            this.code = code;
+            this.name = name;
+            this.businessType = businessType;
+            this.status = status;
+            this.description = description;
+            this.createdAt = createdAt;
+            this.approvalSummary.status = status;
+            this.approvalSummary.lastAction = "created";
+            this.approvalSummary.lastActor = "system";
+            this.approvalSummary.lastComment = "project created";
+            this.approvalSummary.updatedAt = createdAt;
+        }
+    }
+
+    private static final class ScenarioState {
+        private final String id;
+        private String name;
+        private String description;
+        private boolean isBaseline;
+        private boolean isActive;
+        private final LocalDateTime createdAt;
+        private List<AllocationRuleState> allocationRules = List.of();
+        private List<CashFlowState> cashFlows = List.of();
+        private ValuationState valuation;
+
+        private ScenarioState(
+                String id,
+                String name,
+                String description,
+                boolean isBaseline,
+                boolean isActive,
+                LocalDateTime createdAt) {
+            this.id = id;
+            this.name = name;
+            this.description = description;
+            this.isBaseline = isBaseline;
+            this.isActive = isActive;
+            this.createdAt = createdAt;
+        }
+    }
+
+    private record AllocationRuleState(
+            String departmentCode,
+            String basis,
+            BigDecimal allocationRate,
+            BigDecimal allocatedAmount,
+            String costPoolName,
+            String costPoolCategory,
+            BigDecimal costPoolAmount) {}
+
+    private record CashFlowState(
+            int periodNo,
+            String periodLabel,
+            String yearLabel,
+            BigDecimal operatingCashFlow,
+            BigDecimal investmentCashFlow,
+            BigDecimal financingCashFlow,
+            BigDecimal netCashFlow,
+            BigDecimal discountRate) {}
+
+    private record ValuationState(
+            BigDecimal discountRate,
+            BigDecimal npv,
+            BigDecimal irr,
+            BigDecimal paybackPeriod,
+            String decision,
+            JsonNode assumptions) {}
+
+    private static final class ApprovalSummaryState {
+        private String status;
+        private String lastAction;
+        private String lastActor;
+        private String lastComment;
+        private LocalDateTime updatedAt;
+    }
+
+    private record ApprovalLog(
+            String actorRole,
+            String actorName,
+            String action,
+            String comment,
+            LocalDateTime createdAt) {}
+}

--- a/backend/src/test/java/com/costwise/api/JsonFieldReader.java
+++ b/backend/src/test/java/com/costwise/api/JsonFieldReader.java
@@ -1,0 +1,20 @@
+package com.costwise.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+final class JsonFieldReader {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private JsonFieldReader() {}
+
+    static String read(String json, String fieldName) throws Exception {
+        JsonNode root = OBJECT_MAPPER.readTree(json);
+        JsonNode field = root.get(fieldName);
+        if (field == null || field.isNull()) {
+            throw new IllegalArgumentException("Missing field: " + fieldName);
+        }
+        return field.asText();
+    }
+}

--- a/backend/src/test/java/com/costwise/api/PersistenceControllerTest.java
+++ b/backend/src/test/java/com/costwise/api/PersistenceControllerTest.java
@@ -1,0 +1,211 @@
+package com.costwise.api;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(properties = {
+    "app.security.jwt.issuer-uri=https://example.supabase.co/auth/v1",
+    "app.security.jwt.audience=authenticated",
+    "app.security.jwt.secret-base64=c3VwYWJhc2UtYmVhcmVyLXRlc3Qtc2VjcmV0LXN1cHBvcnQ="
+})
+@AutoConfigureMockMvc
+class PersistenceControllerTest {
+
+    private static final String ISSUER = "https://example.supabase.co/auth/v1";
+    private static final String AUDIENCE = "authenticated";
+    private static final String SECRET_BASE64 = "c3VwYWJhc2UtYmVhcmVyLXRlc3Qtc2VjcmV0LXN1cHBvcnQ=";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void projectScenarioCrudAndAnalysisPersistenceFlow() throws Exception {
+        Instant now = Instant.now();
+        String authHeader = bearerToken(token("planner", ISSUER, AUDIENCE, now, now.plusSeconds(3600)));
+
+        MvcResult createProjectResult = mockMvc.perform(post("/api/persistence/projects")
+                        .header("Authorization", authHeader)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "code": "PJT-TEST-01",
+                                  "name": "테스트 프로젝트",
+                                  "businessType": "new_business",
+                                  "description": "persistence flow test"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.code").value("PJT-TEST-01"))
+                .andReturn();
+
+        String projectId = JsonFieldReader.read(createProjectResult.getResponse().getContentAsString(), "id");
+
+        MvcResult createScenarioResult = mockMvc.perform(post("/api/persistence/projects/{projectId}/scenarios", projectId)
+                        .header("Authorization", authHeader)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "Base",
+                                  "description": "기준 시나리오",
+                                  "isBaseline": true,
+                                  "isActive": true
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andReturn();
+
+        String scenarioId = JsonFieldReader.read(createScenarioResult.getResponse().getContentAsString(), "id");
+
+        mockMvc.perform(put("/api/persistence/projects/{projectId}/scenarios/{scenarioId}/analysis", projectId, scenarioId)
+                        .header("Authorization", authHeader)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "allocationRules": [
+                                    {
+                                      "departmentCode": "D-001",
+                                      "basis": "manual",
+                                      "allocationRate": 1.0,
+                                      "allocatedAmount": 1000000,
+                                      "costPoolName": "공통비",
+                                      "costPoolCategory": "shared",
+                                      "costPoolAmount": 1000000
+                                    }
+                                  ],
+                                  "cashFlows": [
+                                    {
+                                      "periodNo": 0,
+                                      "periodLabel": "현재",
+                                      "yearLabel": "2026",
+                                      "operatingCashFlow": 500000,
+                                      "investmentCashFlow": -200000,
+                                      "financingCashFlow": 0,
+                                      "discountRate": 0.08
+                                    }
+                                  ],
+                                  "valuation": {
+                                    "discountRate": 0.08,
+                                    "npv": 300000,
+                                    "irr": 0.12,
+                                    "paybackPeriod": 2.5,
+                                    "decision": "recommend",
+                                    "assumptions": {
+                                      "growthRate": 0.03
+                                    }
+                                  },
+                                  "approval": {
+                                    "actorRole": "planner",
+                                    "actorName": "plan-user",
+                                    "action": "allocated",
+                                    "comment": "분석 반영",
+                                    "projectStatus": "in_review"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allocationRuleCount").value(1))
+                .andExpect(jsonPath("$.cashFlowCount").value(1));
+
+        mockMvc.perform(get("/api/persistence/projects/{projectId}", projectId)
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(projectId))
+                .andExpect(jsonPath("$.status").value("in_review"))
+                .andExpect(jsonPath("$.scenarios[0].id").value(scenarioId))
+                .andExpect(jsonPath("$.scenarios[0].valuation.decision").value("recommend"))
+                .andExpect(jsonPath("$.approval.status").value("in_review"));
+    }
+
+    @Test
+    void deleteScenarioRemovesItFromProjectDetail() throws Exception {
+        Instant now = Instant.now();
+        String authHeader = bearerToken(token("planner", ISSUER, AUDIENCE, now, now.plusSeconds(3600)));
+
+        MvcResult createProjectResult = mockMvc.perform(post("/api/persistence/projects")
+                        .header("Authorization", authHeader)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "code": "PJT-TEST-02",
+                                  "name": "삭제 테스트 프로젝트",
+                                  "businessType": "new_business",
+                                  "description": "delete scenario test"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String projectId = JsonFieldReader.read(createProjectResult.getResponse().getContentAsString(), "id");
+
+        MvcResult createScenarioResult = mockMvc.perform(post("/api/persistence/projects/{projectId}/scenarios", projectId)
+                        .header("Authorization", authHeader)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "삭제 대상 시나리오",
+                                  "description": "삭제 전용",
+                                  "isBaseline": false,
+                                  "isActive": true
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String scenarioId = JsonFieldReader.read(createScenarioResult.getResponse().getContentAsString(), "id");
+
+        mockMvc.perform(delete("/api/persistence/projects/{projectId}/scenarios/{scenarioId}", projectId, scenarioId)
+                        .header("Authorization", authHeader))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/persistence/projects/{projectId}", projectId)
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scenarios.length()").value(0));
+    }
+
+    private String bearerToken(String token) {
+        return "Bearer " + token;
+    }
+
+    private String token(String role, String issuer, String audience, Instant issuedAt, Instant expiresAt) {
+        SecretKey secretKey = new SecretKeySpec(Base64.getDecoder().decode(SECRET_BASE64), "HmacSHA256");
+        JwtEncoder encoder = new NimbusJwtEncoder(new ImmutableSecret<>(secretKey));
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .issuer(issuer)
+                .subject("user-123")
+                .audience(List.of(audience))
+                .issuedAt(issuedAt)
+                .expiresAt(expiresAt)
+                .claim("email", role + "@example.com")
+                .claim("role", role)
+                .build();
+        return encoder.encode(JwtEncoderParameters.from(JwsHeader.with(MacAlgorithm.HS256).build(), claims))
+                .getTokenValue();
+    }
+}


### PR DESCRIPTION
## 요약
- 프로젝트/시나리오 저장 경로를 위한 백엔드 API를 추가했습니다.
- 분석 결과(배분/현금흐름/가치평가)와 승인 상태를 프로젝트 상세 응답과 연결했습니다.
- API 흐름을 검증하는 통합 테스트를 추가했습니다.

## 변경 사항
- `PersistenceController` 추가 (`/api/persistence/**`)
- `PersistenceService` 추가 (프로젝트/시나리오/분석/승인 상태 처리)
- persistence DTO 세트 추가
- `PersistenceControllerTest`, `JsonFieldReader` 추가

## 검증
- `./gradlew.bat test --tests com.costwise.api.PersistenceControllerTest` 통과
- `./gradlew.bat check` 통과

## 이슈
- Closes #28