### PR TITLE
feat: 운영 보안 헤더 및 CORS 정책 구체화

### DIFF
--- a/backend/src/main/java/com/costwise/config/SecurityConfig.java
+++ b/backend/src/main/java/com/costwise/config/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.costwise.config;
 
 import com.costwise.security.JwtSecurityProperties;
 import com.costwise.security.SupabaseJwtAuthenticationConverter;
-import java.util.List;
 import javax.crypto.SecretKey;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +12,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
@@ -22,6 +22,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -29,19 +30,22 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableMethodSecurity
-@EnableConfigurationProperties(JwtSecurityProperties.class)
+@EnableConfigurationProperties({JwtSecurityProperties.class, SecurityPolicyProperties.class})
 public class SecurityConfig {
 
     private static final String INVALID_AUDIENCE_ERROR = "invalid_token";
 
     private final JwtSecurityProperties jwtSecurityProperties;
     private final SupabaseJwtAuthenticationConverter jwtAuthenticationConverter;
+    private final SecurityPolicyProperties securityPolicyProperties;
 
     public SecurityConfig(
             JwtSecurityProperties jwtSecurityProperties,
-            SupabaseJwtAuthenticationConverter jwtAuthenticationConverter) {
+            SupabaseJwtAuthenticationConverter jwtAuthenticationConverter,
+            SecurityPolicyProperties securityPolicyProperties) {
         this.jwtSecurityProperties = jwtSecurityProperties;
         this.jwtAuthenticationConverter = jwtAuthenticationConverter;
+        this.securityPolicyProperties = securityPolicyProperties;
     }
 
     @Bean
@@ -62,6 +66,15 @@ public class SecurityConfig {
     SecurityFilterChain securityFilterChain(HttpSecurity http, JwtDecoder jwtDecoder) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable);
         http.cors(Customizer.withDefaults());
+        http.headers(headers -> {
+            headers.contentSecurityPolicy(csp -> csp.policyDirectives(securityPolicyProperties.contentSecurityPolicy()));
+            headers.referrerPolicy(referrer -> referrer.policy(
+                    ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN));
+            headers.frameOptions(frame -> frame.deny());
+            if (securityPolicyProperties.hstsEnabled()) {
+                headers.httpStrictTransportSecurity(hsts -> hsts.includeSubDomains(true).maxAgeInSeconds(31536000));
+            }
+        });
         http.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
         http.formLogin(AbstractHttpConfigurer::disable);
         http.httpBasic(AbstractHttpConfigurer::disable);
@@ -76,25 +89,29 @@ public class SecurityConfig {
                         .jwtAuthenticationConverter(jwtAuthenticationConverter)));
         http.authorizeHttpRequests(
                 auth -> auth
-                        .requestMatchers(
-                                "/api/health",
+                        .requestMatchers("/api/health",
                                 "/api/dashboard",
                                 "/api/portfolio/summary",
                                 "/api/cost-accounting/summary",
                                 "/api/valuation-risk/projects/**",
-                                "/api/compute",
-                                "/actuator/health",
-                                "/actuator/info",
-                                "/v3/api-docs",
-                                "/v3/api-docs/**",
-                                "/v3/api-docs.yaml",
-                                "/swagger-ui.html",
-                                "/swagger-ui/**")
+                                "/api/compute")
                         .permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/info")
+                        .permitAll()
+                        .requestMatchers("/actuator/**")
+                        .access((authentication, context) ->
+                                new AuthorizationDecision(securityPolicyProperties.actuatorAllPublic()))
                         .requestMatchers("/api/projects/*/workflow", "/api/projects/*/review").authenticated()
                         .requestMatchers("/api/audit-logs").authenticated()
                         .requestMatchers(HttpMethod.OPTIONS, "/**")
                         .permitAll()
+                        .requestMatchers("/v3/api-docs",
+                                "/v3/api-docs/**",
+                                "/v3/api-docs.yaml",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**")
+                        .access((authentication, context) ->
+                                new AuthorizationDecision(securityPolicyProperties.docsPublic()))
                         .anyRequest()
                         .authenticated());
         return http.build();
@@ -102,12 +119,14 @@ public class SecurityConfig {
 
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
+        SecurityPolicyProperties.Cors cors = securityPolicyProperties.cors();
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(
-                List.of("http://localhost:5173", "http://127.0.0.1:5173", "https://*.pages.dev"));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("*"));
-        configuration.setExposedHeaders(List.of("Location"));
+        configuration.setAllowedOrigins(cors.allowedOrigins());
+        configuration.setAllowedMethods(cors.allowedMethods());
+        configuration.setAllowedHeaders(cors.allowedHeaders());
+        configuration.setExposedHeaders(cors.exposedHeaders());
+        configuration.setAllowCredentials(false);
+        configuration.setMaxAge(cors.maxAgeSeconds());
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/backend/src/main/java/com/costwise/config/SecurityPolicyProperties.java
+++ b/backend/src/main/java/com/costwise/config/SecurityPolicyProperties.java
@@ -1,0 +1,20 @@
+package com.costwise.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.security")
+public record SecurityPolicyProperties(
+        boolean docsPublic,
+        boolean actuatorAllPublic,
+        boolean hstsEnabled,
+        Cors cors,
+        String contentSecurityPolicy) {
+
+    public record Cors(
+            List<String> allowedOrigins,
+            List<String> allowedMethods,
+            List<String> allowedHeaders,
+            List<String> exposedHeaders,
+            long maxAgeSeconds) {}
+}

--- a/backend/src/main/java/com/costwise/config/SupabaseJdbcUrlConverter.java
+++ b/backend/src/main/java/com/costwise/config/SupabaseJdbcUrlConverter.java
@@ -1,0 +1,35 @@
+package com.costwise.config;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public final class SupabaseJdbcUrlConverter {
+
+    private SupabaseJdbcUrlConverter() {}
+
+    public static JdbcConnection convert(String databaseUrl) {
+        URI uri = parse(databaseUrl);
+        if (!"postgresql".equalsIgnoreCase(uri.getScheme())) {
+            throw new IllegalArgumentException("Only postgresql:// URLs are supported for Supabase");
+        }
+
+        String userInfo = uri.getUserInfo();
+        if (userInfo == null || !userInfo.contains(":")) {
+            throw new IllegalArgumentException("Supabase URL must include username and password");
+        }
+
+        String[] credentials = userInfo.split(":", 2);
+        String jdbcUrl = "jdbc:postgresql://" + uri.getHost() + ":" + uri.getPort() + uri.getPath();
+        return new JdbcConnection(jdbcUrl, credentials[0], credentials[1]);
+    }
+
+    private static URI parse(String databaseUrl) {
+        try {
+            return new URI(databaseUrl);
+        } catch (URISyntaxException exception) {
+            throw new IllegalArgumentException("Invalid Supabase database URL", exception);
+        }
+    }
+
+    public record JdbcConnection(String jdbcUrl, String username, String password) {}
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,9 +12,62 @@ app:
       issuer-uri: ${SUPABASE_JWT_ISSUER_URI:https://example.supabase.co/auth/v1}
       audience: ${SUPABASE_JWT_AUDIENCE:authenticated}
       secret-base64: ${SUPABASE_JWT_SECRET_BASE64:ZmFrZS1zdXBhYmFzZS1zZWNyZXQtbXVzdC1iZS1vdmVycmlkZQ==}
+    # Assumption: production runs behind HTTPS termination and should enable HSTS.
+    hsts-enabled: ${APP_SECURITY_HSTS_ENABLED:false}
+    docs-public: ${APP_SECURITY_DOCS_PUBLIC:false}
+    actuator-all-public: ${APP_SECURITY_ACTUATOR_ALL_PUBLIC:false}
+    cors:
+      # Comma-separated allowlist. Example:
+      # APP_SECURITY_CORS_ALLOWED_ORIGINS=https://costwiseai.pages.dev,https://app.example.com
+      allowed-origins: ${APP_SECURITY_CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173}
+      allowed-methods: ${APP_SECURITY_CORS_ALLOWED_METHODS:GET,POST,PUT,PATCH,DELETE,OPTIONS}
+      allowed-headers: ${APP_SECURITY_CORS_ALLOWED_HEADERS:Authorization,Content-Type,Accept,Origin}
+      exposed-headers: ${APP_SECURITY_CORS_EXPOSED_HEADERS:Location}
+      max-age-seconds: ${APP_SECURITY_CORS_MAX_AGE_SECONDS:3600}
+    content-security-policy: ${APP_SECURITY_CONTENT_SECURITY_POLICY:default-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'}
+
+  persistence:
+    # Supabase URL format:
+    # postgresql://postgres:[YOUR-PASSWORD]@db.hlddhounxffxvqgvwajl.supabase.co:5432/postgres
+    # Use SUPABASE_DATABASE_URL and convert to JDBC when wiring an actual DataSource.
+    supabase-url: ${SUPABASE_DATABASE_URL:}
+    jdbc-url: ${SUPABASE_JDBC_URL:}
+    username: ${SUPABASE_DB_USERNAME:}
+    password: ${SUPABASE_DB_PASSWORD:}
+    # Assumption: Supabase managed Postgres uses SSL in production.
+    ssl-mode: ${SUPABASE_DB_SSLMODE:require}
 
 management:
   endpoints:
     web:
       exposure:
         include: health,info
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+app:
+  security:
+    docs-public: true
+    actuator-all-public: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+app:
+  security:
+    docs-public: false
+    actuator-all-public: false
+    hsts-enabled: true

--- a/backend/src/test/java/com/costwise/config/DevDocsAccessPolicyTest.java
+++ b/backend/src/test/java/com/costwise/config/DevDocsAccessPolicyTest.java
@@ -1,0 +1,29 @@
+package com.costwise.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+    "app.security.jwt.issuer-uri=https://example.supabase.co/auth/v1",
+    "app.security.jwt.audience=authenticated",
+    "app.security.jwt.secret-base64=c3VwYWJhc2UtYmVhcmVyLXRlc3Qtc2VjcmV0LXN1cHBvcnQ=",
+    "app.security.docs-public=true"
+})
+@AutoConfigureMockMvc
+class DevDocsAccessPolicyTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void allowsApiDocsWhenDocsArePublic() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/com/costwise/config/SecurityPolicyConfigTest.java
+++ b/backend/src/test/java/com/costwise/config/SecurityPolicyConfigTest.java
@@ -1,0 +1,59 @@
+package com.costwise.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+    "app.security.jwt.issuer-uri=https://example.supabase.co/auth/v1",
+    "app.security.jwt.audience=authenticated",
+    "app.security.jwt.secret-base64=c3VwYWJhc2UtYmVhcmVyLXRlc3Qtc2VjcmV0LXN1cHBvcnQ=",
+    "app.security.docs-public=false",
+    "app.security.cors.allowed-origins=http://localhost:5173,https://costwiseai.pages.dev"
+})
+@AutoConfigureMockMvc
+class SecurityPolicyConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void includesBaselineSecurityHeadersOnPublicApi() throws Exception {
+        mockMvc.perform(get("/api/health"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Content-Security-Policy"))
+                .andExpect(header().exists("Referrer-Policy"))
+                .andExpect(header().string("X-Frame-Options", "DENY"))
+                .andExpect(header().string("X-Content-Type-Options", "nosniff"));
+    }
+
+    @Test
+    void allowsCorsPreflightForConfiguredOrigin() throws Exception {
+        mockMvc.perform(options("/api/health")
+                        .header("Origin", "http://localhost:5173")
+                        .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:5173"));
+    }
+
+    @Test
+    void rejectsCorsPreflightForUnconfiguredOrigin() throws Exception {
+        mockMvc.perform(options("/api/health")
+                        .header("Origin", "https://evil.example.com")
+                        .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void blocksApiDocsWhenDocsAreNotPublic() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/backend/src/test/java/com/costwise/config/SupabaseJdbcUrlConverterTest.java
+++ b/backend/src/test/java/com/costwise/config/SupabaseJdbcUrlConverterTest.java
@@ -1,0 +1,26 @@
+package com.costwise.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class SupabaseJdbcUrlConverterTest {
+
+    @Test
+    void convertsSupabasePostgresqlUrlToJdbcUrlAndExtractsCredentials() {
+        SupabaseJdbcUrlConverter.JdbcConnection connection = SupabaseJdbcUrlConverter.convert(
+                "postgresql://postgres:secret@db.hlddhounxffxvqgvwajl.supabase.co:5432/postgres");
+
+        assertThat(connection.jdbcUrl())
+                .isEqualTo("jdbc:postgresql://db.hlddhounxffxvqgvwajl.supabase.co:5432/postgres");
+        assertThat(connection.username()).isEqualTo("postgres");
+        assertThat(connection.password()).isEqualTo("secret");
+    }
+
+    @Test
+    void rejectsInvalidScheme() {
+        assertThatThrownBy(() -> SupabaseJdbcUrlConverter.convert("https://example.com"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## 요약
- 운영 환경 기준 보안 헤더(CSP, Referrer-Policy, Frame-Options, HSTS) 기본값을 명시적으로 적용했습니다.
- CORS 허용 origin/method/header 정책을 프로퍼티 기반 allowlist로 구체화했습니다.
- dev/prod 프로파일에 따라 docs/actuator 노출 정책을 분리했습니다.
- Supabase Postgres URL을 JDBC로 변환하는 설정 유틸과 테스트를 추가했습니다.

## 변경 사항
- `SecurityConfig`에 보안 헤더/CORS/엔드포인트 접근 정책 반영
- `SecurityPolicyProperties` 추가
- `SupabaseJdbcUrlConverter` 추가
- `application.yml`에 security/cors/persistence 설정 및 dev/prod 분기 반영
- 보안 정책/URL 변환 테스트 3종 추가

## 검증
- `./gradlew.bat check` 통과
- `./gradlew.bat test --tests com.costwise.config.SecurityPolicyConfigTest --tests com.costwise.config.DevDocsAccessPolicyTest --tests com.costwise.config.SupabaseJdbcUrlConverterTest` 통과

## 이슈
- Closes #29