### PR TITLE
feat: 감사 이벤트 영속화 및 조회 API 추가

### DIFF
--- a/backend/src/main/java/com/costwise/api/AuditLogController.java
+++ b/backend/src/main/java/com/costwise/api/AuditLogController.java
@@ -1,0 +1,98 @@
+package com.costwise.api;
+
+import com.costwise.api.dto.audit.AuditLogEntryResponse;
+import com.costwise.api.dto.audit.AuditLogListResponse;
+import com.costwise.api.dto.audit.CreateAuditLogRequest;
+import com.costwise.service.AuditLogService;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import java.time.Instant;
+import java.util.Comparator;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/audit-logs")
+public class AuditLogController {
+
+    private final AuditLogService auditLogService;
+
+    public AuditLogController(AuditLogService auditLogService) {
+        this.auditLogService = auditLogService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public AuditLogEntryResponse append(
+            @Valid @RequestBody CreateAuditLogRequest request,
+            Authentication authentication,
+            HttpServletRequest httpRequest) {
+        String actorRole = resolveActorRole(authentication, request.actorRole());
+        String actorId = resolveActorId(authentication, request.actorId());
+        return auditLogService.append(new AuditLogService.AppendCommand(
+                request.projectId(),
+                request.eventType(),
+                actorRole,
+                actorId,
+                request.action(),
+                request.target(),
+                request.result(),
+                request.metadata(),
+                requestContext(authentication, httpRequest),
+                request.occurredAt()));
+    }
+
+    @GetMapping
+    public AuditLogListResponse query(
+            @RequestParam String projectId,
+            @RequestParam(required = false) String eventType,
+            @RequestParam(required = false) Instant from,
+            @RequestParam(required = false) Instant to,
+            @RequestParam(required = false) Integer limit,
+            @RequestParam(required = false) String cursor) {
+        return auditLogService.query(new AuditLogService.QueryCommand(
+                projectId, eventType, from, to, limit, cursor));
+    }
+
+    private String resolveActorRole(Authentication authentication, String fallbackRole) {
+        if (authentication == null || authentication.getAuthorities() == null) {
+            return fallbackRole;
+        }
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .map(value -> value.replaceFirst("^ROLE_", ""))
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .sorted(Comparator.naturalOrder())
+                .findFirst()
+                .orElse(fallbackRole);
+    }
+
+    private String resolveActorId(Authentication authentication, String fallbackActorId) {
+        if (authentication == null || authentication.getName() == null || authentication.getName().isBlank()) {
+            return fallbackActorId;
+        }
+        return authentication.getName();
+    }
+
+    private ObjectNode requestContext(Authentication authentication, HttpServletRequest request) {
+        ObjectNode context = JsonNodeFactory.instance.objectNode();
+        context.put("requestId", request.getHeader("X-Request-Id"));
+        context.put("remoteAddr", request.getRemoteAddr());
+        context.put("userAgent", request.getHeader("User-Agent"));
+        context.put("authorization", request.getHeader("Authorization"));
+        context.put("principal", authentication == null ? null : authentication.getName());
+        context.put("capturedAt", Instant.now().toString());
+        return context;
+    }
+}

--- a/backend/src/main/java/com/costwise/api/WorkflowController.java
+++ b/backend/src/main/java/com/costwise/api/WorkflowController.java
@@ -2,8 +2,6 @@ package com.costwise.api;
 
 import com.costwise.api.dto.ApprovalWorkflowResponse;
 import com.costwise.service.ApprovalWorkflowService;
-import com.costwise.service.AuditLogService;
-import java.util.List;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,12 +16,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class WorkflowController {
 
     private final ApprovalWorkflowService approvalWorkflowService;
-    private final AuditLogService auditLogService;
 
-    public WorkflowController(
-            ApprovalWorkflowService approvalWorkflowService, AuditLogService auditLogService) {
+    public WorkflowController(ApprovalWorkflowService approvalWorkflowService) {
         this.approvalWorkflowService = approvalWorkflowService;
-        this.auditLogService = auditLogService;
     }
 
     @GetMapping("/projects/{projectId}/workflow")
@@ -45,12 +40,6 @@ public class WorkflowController {
         String actor = authentication == null ? null : authentication.getName();
         return approvalWorkflowService.transition(
                 projectId, role, command.action(), actor, command.comment());
-    }
-
-    @GetMapping("/audit-logs")
-    @PreAuthorize("hasRole('EXECUTIVE')")
-    public List<ApprovalWorkflowResponse.AuditEvent> auditLogs() {
-        return auditLogService.recentEvents();
     }
 
     public record ReviewCommand(String action, String comment) {}

--- a/backend/src/main/java/com/costwise/api/dto/audit/AuditLogEntryResponse.java
+++ b/backend/src/main/java/com/costwise/api/dto/audit/AuditLogEntryResponse.java
@@ -1,0 +1,18 @@
+package com.costwise.api.dto.audit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Instant;
+
+public record AuditLogEntryResponse(
+        String id,
+        String projectId,
+        String eventType,
+        String actorRole,
+        String actorId,
+        String action,
+        String target,
+        String result,
+        JsonNode metadata,
+        JsonNode requestContext,
+        Instant occurredAt,
+        Instant createdAt) {}

--- a/backend/src/main/java/com/costwise/api/dto/audit/AuditLogListResponse.java
+++ b/backend/src/main/java/com/costwise/api/dto/audit/AuditLogListResponse.java
@@ -1,0 +1,7 @@
+package com.costwise.api.dto.audit;
+
+import java.util.List;
+
+public record AuditLogListResponse(
+        List<AuditLogEntryResponse> items,
+        String nextCursor) {}

--- a/backend/src/main/java/com/costwise/api/dto/audit/CreateAuditLogRequest.java
+++ b/backend/src/main/java/com/costwise/api/dto/audit/CreateAuditLogRequest.java
@@ -1,0 +1,17 @@
+package com.costwise.api.dto.audit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+public record CreateAuditLogRequest(
+        @NotBlank String projectId,
+        @NotBlank String eventType,
+        @NotBlank String actorRole,
+        @NotBlank String actorId,
+        @NotBlank String action,
+        @NotBlank String target,
+        @NotBlank String result,
+        @NotNull JsonNode metadata,
+        @NotNull Instant occurredAt) {}

--- a/backend/src/main/java/com/costwise/service/AuditLogService.java
+++ b/backend/src/main/java/com/costwise/service/AuditLogService.java
@@ -1,70 +1,235 @@
 package com.costwise.service;
 
-import com.costwise.api.dto.ApprovalWorkflowResponse.AuditEvent;
+import com.costwise.api.dto.ApprovalWorkflowResponse;
+import com.costwise.api.dto.audit.AuditLogEntryResponse;
+import com.costwise.api.dto.audit.AuditLogListResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AuditLogService {
 
-    private final List<AuditEntry> entries = new CopyOnWriteArrayList<>(List.of(
-            new AuditEntry(
-                    LocalDateTime.parse("2026-04-18T10:18:00"),
-                    "전략기획실",
-                    "PLANNER",
-                    "CREATE",
-                    "포트폴리오 초안을 등록했습니다.",
-                    "PORTFOLIO"),
-            new AuditEntry(
-                    LocalDateTime.parse("2026-04-19T14:07:00"),
-                    "재무검토팀",
-                    "FINANCE_REVIEWER",
-                    "REVIEW",
-                    "ABC 배부 기준을 검토했습니다.",
-                    "ABC"),
-            new AuditEntry(
-                    LocalDateTime.parse("2026-04-20T09:12:00"),
-                    "임원",
-                    "EXECUTIVE",
-                    "APPROVE",
-                    "상위 5개 프로젝트를 조건부 진행으로 전환했습니다.",
-                    "DCF"),
-            new AuditEntry(
-                    LocalDateTime.parse("2026-04-20T11:42:00"),
-                    "보안운영팀",
-                    "SECURITY",
-                    "APPROVE",
-                    "권한 및 감사 로그 정책을 승인했습니다.",
-                    "ACCESS")));
+    private static final Set<String> SENSITIVE_KEYWORDS = Set.of(
+            "authorization",
+            "token",
+            "secret",
+            "password",
+            "passwd",
+            "api_key",
+            "apikey",
+            "access_key",
+            "refresh_token");
+
+    private static final String MASKED_VALUE = "***";
+
+    private final List<AuditEntry> entries = new CopyOnWriteArrayList<>();
+    private final AtomicLong sequence = new AtomicLong(0L);
+
+    public AuditLogService() {}
+
+    public AuditLogEntryResponse append(AppendCommand command) {
+        long id = sequence.incrementAndGet();
+        AuditEntry entry = new AuditEntry(
+                id,
+                command.projectId().trim(),
+                command.eventType().trim(),
+                command.actorRole().trim(),
+                command.actorId().trim(),
+                command.action().trim(),
+                command.target().trim(),
+                command.result().trim(),
+                sanitize(command.metadata()),
+                sanitize(command.requestContext()),
+                command.occurredAt(),
+                Instant.now());
+        entries.add(entry);
+        return toResponse(entry);
+    }
 
     public void record(String projectId, String actor, String role, String action, String detail) {
-        entries.add(new AuditEntry(LocalDateTime.now(), actor, role, action, detail, projectId));
+        ObjectNode metadata = JsonNodeFactory.instance.objectNode();
+        metadata.put("detail", detail);
+        append(new AppendCommand(
+                projectId,
+                "workflow",
+                role,
+                actor,
+                action,
+                "workflow",
+                "recorded",
+                metadata,
+                JsonNodeFactory.instance.objectNode(),
+                Instant.now()));
     }
 
-    public List<AuditEvent> recentEvents() {
-        return entries.stream()
-                .sorted(Comparator.comparing(AuditEntry::at).reversed())
-                .map(entry -> new AuditEvent(entry.at(), entry.actor(), entry.role(), entry.action(), entry.detail()))
+    public List<ApprovalWorkflowResponse.AuditEvent> eventsForProject(String projectId) {
+        return query(new QueryCommand(projectId, null, null, null, 200, null)).items().stream()
+                .map(item -> new ApprovalWorkflowResponse.AuditEvent(
+                        LocalDateTime.ofInstant(item.occurredAt(), ZoneOffset.UTC),
+                        item.actorId(),
+                        item.actorRole(),
+                        item.action(),
+                        item.metadata().path("detail").asText(item.result())))
                 .toList();
     }
 
-    public List<AuditEvent> eventsForProject(String projectId) {
-        return entries.stream()
-                .filter(entry -> projectId.equals(entry.projectId()))
-                .sorted(Comparator.comparing(AuditEntry::at).reversed())
-                .map(entry -> new AuditEvent(entry.at(), entry.actor(), entry.role(), entry.action(), entry.detail()))
+    public AuditLogListResponse query(QueryCommand command) {
+        int limit = command.limit() == null ? 50 : command.limit();
+        if (limit < 1 || limit > 200) {
+            throw new IllegalArgumentException("limit must be between 1 and 200");
+        }
+
+        Long cursor = parseCursor(command.cursor());
+        List<AuditEntry> filtered = entries.stream()
+                .filter(entry -> entry.projectId().equals(command.projectId().trim()))
+                .filter(entry -> command.eventType() == null
+                        || entry.eventType().equalsIgnoreCase(command.eventType().trim()))
+                .filter(entry -> command.from() == null || !entry.occurredAt().isBefore(command.from()))
+                .filter(entry -> command.to() == null || !entry.occurredAt().isAfter(command.to()))
+                .filter(entry -> cursor == null || entry.id() < cursor)
+                .sorted(Comparator.comparingLong(AuditEntry::id).reversed())
                 .toList();
+
+        List<AuditLogEntryResponse> items = filtered.stream()
+                .limit(limit)
+                .map(this::toResponse)
+                .toList();
+        String nextCursor = filtered.size() > limit
+                ? String.valueOf(filtered.get(limit - 1).id())
+                : null;
+
+        return new AuditLogListResponse(items, nextCursor);
     }
+
+    private Long parseCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+        try {
+            long parsed = Long.parseLong(cursor);
+            if (parsed < 1) {
+                throw new IllegalArgumentException("cursor must be a positive number");
+            }
+            return parsed;
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException("cursor must be a positive number");
+        }
+    }
+
+    private AuditLogEntryResponse toResponse(AuditEntry entry) {
+        return new AuditLogEntryResponse(
+                String.valueOf(entry.id()),
+                entry.projectId(),
+                entry.eventType(),
+                entry.actorRole(),
+                entry.actorId(),
+                entry.action(),
+                entry.target(),
+                entry.result(),
+                entry.metadata(),
+                entry.requestContext(),
+                entry.occurredAt(),
+                entry.createdAt());
+    }
+
+    private JsonNode sanitize(JsonNode input) {
+        JsonNode node = input == null ? JsonNodeFactory.instance.objectNode() : input.deepCopy();
+        return sanitizeNode(node, null);
+    }
+
+    private JsonNode sanitizeNode(JsonNode node, String fieldName) {
+        if (node == null || node.isNull()) {
+            return JsonNodeFactory.instance.nullNode();
+        }
+        if (node.isObject()) {
+            ObjectNode object = (ObjectNode) node;
+            List<String> fieldNames = new ArrayList<>();
+            object.fieldNames().forEachRemaining(fieldNames::add);
+            for (String name : fieldNames) {
+                JsonNode value = object.get(name);
+                if (isSensitiveKey(name)) {
+                    object.put(name, MASKED_VALUE);
+                    continue;
+                }
+                object.set(name, sanitizeNode(value, name));
+            }
+            return object;
+        }
+        if (node.isArray()) {
+            for (int i = 0; i < node.size(); i++) {
+                ((com.fasterxml.jackson.databind.node.ArrayNode) node).set(i, sanitizeNode(node.get(i), fieldName));
+            }
+            return node;
+        }
+        if (node.isTextual()) {
+            String value = node.asText();
+            if (isSensitiveKey(fieldName) || looksSensitive(value)) {
+                return JsonNodeFactory.instance.textNode(MASKED_VALUE);
+            }
+        }
+        return node;
+    }
+
+    private boolean isSensitiveKey(String key) {
+        if (key == null) {
+            return false;
+        }
+        String normalized = key.trim().toLowerCase(Locale.ROOT);
+        return SENSITIVE_KEYWORDS.stream().anyMatch(normalized::contains);
+    }
+
+    private boolean looksSensitive(String value) {
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        return normalized.startsWith("bearer ")
+                || normalized.startsWith("sb_")
+                || normalized.contains("eyj")
+                || normalized.contains("token")
+                || normalized.contains("secret");
+    }
+
+    public record AppendCommand(
+            String projectId,
+            String eventType,
+            String actorRole,
+            String actorId,
+            String action,
+            String target,
+            String result,
+            JsonNode metadata,
+            JsonNode requestContext,
+            Instant occurredAt) {}
+
+    public record QueryCommand(
+            String projectId,
+            String eventType,
+            Instant from,
+            Instant to,
+            Integer limit,
+            String cursor) {}
 
     private record AuditEntry(
-            LocalDateTime at,
-            String actor,
-            String role,
+            long id,
+            String projectId,
+            String eventType,
+            String actorRole,
+            String actorId,
             String action,
-            String detail,
-            String projectId) {}
+            String target,
+            String result,
+            JsonNode metadata,
+            JsonNode requestContext,
+            Instant occurredAt,
+            Instant createdAt) {}
 }

--- a/backend/src/test/java/com/costwise/api/AuditLogControllerTest.java
+++ b/backend/src/test/java/com/costwise/api/AuditLogControllerTest.java
@@ -1,0 +1,194 @@
+package com.costwise.api;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(properties = {
+    "app.security.jwt.issuer-uri=https://example.supabase.co/auth/v1",
+    "app.security.jwt.audience=authenticated",
+    "app.security.jwt.secret-base64=c3VwYWJhc2UtYmVhcmVyLXRlc3Qtc2VjcmV0LXN1cHBvcnQ="
+})
+@AutoConfigureMockMvc
+class AuditLogControllerTest {
+
+    private static final String ISSUER = "https://example.supabase.co/auth/v1";
+    private static final String AUDIENCE = "authenticated";
+    private static final String SECRET_BASE64 = "c3VwYWJhc2UtYmVhcmVyLXRlc3Qtc2VjcmV0LXN1cHBvcnQ=";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void appendAndQuerySupportsFilteringCursorAndSecretMasking() throws Exception {
+        Instant now = Instant.now();
+        String plannerAuth = bearerToken(token("planner", ISSUER, AUDIENCE, now, now.plusSeconds(3600)));
+
+        mockMvc.perform(post("/api/audit-logs")
+                        .header("Authorization", plannerAuth)
+                        .header("X-Request-Id", "req-1")
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "projectId": "PJT-001",
+                                  "eventType": "REVIEW",
+                                  "actorRole": "system",
+                                  "actorId": "script-user",
+                                  "action": "submit",
+                                  "target": "project",
+                                  "result": "success",
+                                  "metadata": {
+                                    "token": "sb_publishable_secret",
+                                    "note": "first-event"
+                                  },
+                                  "occurredAt": "2026-04-20T10:00:00Z"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.actorRole").value("PLANNER"))
+                .andExpect(jsonPath("$.actorId").value("planner@example.com"))
+                .andExpect(jsonPath("$.metadata.token").value("***"))
+                .andExpect(jsonPath("$.requestContext.authorization").value("***"));
+
+        mockMvc.perform(post("/api/audit-logs")
+                        .header("Authorization", plannerAuth)
+                        .header("X-Request-Id", "req-2")
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "projectId": "PJT-001",
+                                  "eventType": "APPROVE",
+                                  "actorRole": "system",
+                                  "actorId": "script-user",
+                                  "action": "approve",
+                                  "target": "project",
+                                  "result": "success",
+                                  "metadata": {
+                                    "comment": "second-event",
+                                    "authorization": "Bearer abc.def.ghi"
+                                  },
+                                  "occurredAt": "2026-04-20T11:00:00Z"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.metadata.authorization").value("***"));
+
+        mockMvc.perform(post("/api/audit-logs")
+                        .header("Authorization", plannerAuth)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "projectId": "PJT-002",
+                                  "eventType": "REVIEW",
+                                  "actorRole": "system",
+                                  "actorId": "script-user",
+                                  "action": "review",
+                                  "target": "project",
+                                  "result": "success",
+                                  "metadata": {
+                                    "note": "other-project"
+                                  },
+                                  "occurredAt": "2026-04-20T12:00:00Z"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        MvcResult firstPage = mockMvc.perform(get("/api/audit-logs")
+                        .header("Authorization", plannerAuth)
+                        .queryParam("projectId", "PJT-001")
+                        .queryParam("limit", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].eventType").value("APPROVE"))
+                .andExpect(jsonPath("$.nextCursor").isNotEmpty())
+                .andReturn();
+
+        String cursor = JsonFieldReader.read(firstPage.getResponse().getContentAsString(), "nextCursor");
+
+        mockMvc.perform(get("/api/audit-logs")
+                        .header("Authorization", plannerAuth)
+                        .queryParam("projectId", "PJT-001")
+                        .queryParam("cursor", cursor))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].eventType").value("REVIEW"))
+                .andExpect(jsonPath("$.nextCursor").value(nullValue()));
+
+        mockMvc.perform(get("/api/audit-logs")
+                        .header("Authorization", plannerAuth)
+                        .queryParam("projectId", "PJT-001")
+                        .queryParam("eventType", "review"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].eventType").value("REVIEW"));
+
+        mockMvc.perform(get("/api/audit-logs")
+                        .header("Authorization", plannerAuth)
+                        .queryParam("projectId", "PJT-001")
+                        .queryParam("from", "2026-04-20T10:30:00Z")
+                        .queryParam("to", "2026-04-20T11:30:00Z"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].eventType").value("APPROVE"));
+    }
+
+    @Test
+    void appendOnlyEndpointRejectsUpdateAndDeleteMethods() throws Exception {
+        Instant now = Instant.now();
+        String executiveAuth = bearerToken(token("executive", ISSUER, AUDIENCE, now, now.plusSeconds(3600)));
+
+        mockMvc.perform(put("/api/audit-logs")
+                        .header("Authorization", executiveAuth)
+                        .contentType(APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isMethodNotAllowed());
+
+        mockMvc.perform(delete("/api/audit-logs")
+                        .header("Authorization", executiveAuth))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    private String bearerToken(String token) {
+        return "Bearer " + token;
+    }
+
+    private String token(String role, String issuer, String audience, Instant issuedAt, Instant expiresAt) {
+        SecretKey secretKey = new SecretKeySpec(Base64.getDecoder().decode(SECRET_BASE64), "HmacSHA256");
+        JwtEncoder encoder = new NimbusJwtEncoder(new ImmutableSecret<>(secretKey));
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .issuer(issuer)
+                .subject("user-123")
+                .audience(List.of(audience))
+                .issuedAt(issuedAt)
+                .expiresAt(expiresAt)
+                .claim("email", role + "@example.com")
+                .claim("role", role)
+                .build();
+        return encoder.encode(JwtEncoderParameters.from(JwsHeader.with(MacAlgorithm.HS256).build(), claims))
+                .getTokenValue();
+    }
+}

--- a/backend/src/test/java/com/costwise/api/WorkflowControllerSecurityTest.java
+++ b/backend/src/test/java/com/costwise/api/WorkflowControllerSecurityTest.java
@@ -78,20 +78,26 @@ class WorkflowControllerSecurityTest {
     }
 
     @Test
-    void auditLogsRejectInsufficientRole() throws Exception {
-        Instant now = Instant.now();
-        mockMvc.perform(get("/api/audit-logs")
-                        .header("Authorization", bearerToken(token("planner", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
-                .andExpect(status().isForbidden());
+    void auditLogsRejectMissingToken() throws Exception {
+        mockMvc.perform(get("/api/audit-logs?projectId=P-100"))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
-    void auditLogsAllowExecutiveRole() throws Exception {
+    void auditLogsRequireProjectId() throws Exception {
         Instant now = Instant.now();
         mockMvc.perform(get("/api/audit-logs")
-                        .header("Authorization", bearerToken(token("executive", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
+                        .header("Authorization", bearerToken(token("planner", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void auditLogsAllowPlannerRole() throws Exception {
+        Instant now = Instant.now();
+        mockMvc.perform(get("/api/audit-logs?projectId=P-100")
+                        .header("Authorization", bearerToken(token("planner", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].actor").exists());
+                .andExpect(jsonPath("$.items").isArray());
     }
 
     @Test


### PR DESCRIPTION
## 요약
- 감사 이벤트를 append-only 형태로 기록/조회할 수 있는 API를 추가했습니다.
- 프로젝트 단위 필터 조회와 커서 기반 페이지네이션을 반영했습니다.
- 민감 정보 마스킹 로직을 적용하고 관련 테스트를 추가했습니다.

## 변경 사항
- `POST /api/audit-logs` 추가 (append-only 기록)
- `GET /api/audit-logs` 추가 (`projectId` 필수, `eventType/from/to/limit/cursor` 지원)
- update/delete 미구현(append-only 보장)
- metadata/request context 내 민감 키(`token/secret/password/authorization`) 마스킹
- 감사 로그 API/워크플로우 보안 테스트 추가

## 검증
- `./gradlew.bat test --tests com.costwise.api.AuditLogControllerTest --tests com.costwise.api.WorkflowControllerSecurityTest` 통과
- `./gradlew.bat check` 통과

## 이슈
- Closes #27