### PR TITLE
feat: 상세 탭 그래프/시각 자료 강화

### DIFF
--- a/docs/dev-logs/2026-04-21-detail-visualization.md
+++ b/docs/dev-logs/2026-04-21-detail-visualization.md
@@ -1,0 +1,41 @@
+# 2026-04-21 Detail Visualization 강화
+
+## 대상 이슈
+- #39 `[후속] 상세 탭 그래프/시각 자료 강화`
+
+## 작업 범위
+- Frontend only
+- 파일:
+  - `frontend/src/App.tsx`
+  - `frontend/src/styles/global.css`
+
+## A/B 비교
+- A안: 기존 카드 구조 유지 + 기존 막대 높이/텍스트만 부분 수정
+  - 장점: 변경량이 적고 리스크가 낮음
+  - 단점: hover 없이 이해 가능한 설명력 개선 폭이 제한적
+- B안: 탭별 공통 의사결정 차트(`DecisionBarChart`)와 요약(`DecisionSummary`) 구조 도입
+  - 장점: 라벨/주석/요약을 한 화면에서 일관 제공, 비색상 cue(패턴) 적용이 쉬움
+  - 단점: 컴포넌트/스타일 변경량 증가
+
+## 선택안
+- B안 채택
+- 선택 근거:
+  - 이슈의 핵심 수용 기준(의사결정형 차트, hover 없는 이해, 비색상 cue)을 직접 충족
+  - Allocation/Valuation/Risk 탭을 동일한 시각 문법으로 통일 가능
+
+## 구현 요약
+- `App.tsx`
+  - 데이터 비율 기반 바 차트 생성 로직 추가
+  - `DecisionBarChart` / `DecisionSummary` 컴포넌트 추가
+  - Allocation/Valuation/Risk 탭에 공통 차트+요약 구조 적용
+- `global.css`
+  - 차트 행 레이아웃, 요약 카드, 패턴 cue(솔리드/스트라이프/도트) 스타일 추가
+  - 모바일 구간에서 차트 row 단일 컬럼 전환
+
+## 검증
+- `npm run lint` 통과
+- `npm run build` 통과
+
+## 잔여 리스크
+- CSS 기반 커스텀 차트이므로 데이터 포인트 증가 시 밀집도 대응(스크롤/그룹화) 후속 필요
+- 일부 요약 문구는 규칙 기반 정적 생성이라, 백엔드 분석 규칙 변경 시 동기화 점검 필요

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -8,6 +8,7 @@ Use this directory to record comparison results, branch/worktree choices, and im
 - `docs/dev-logs/2026-04-21-precommit-scope-split.md`
 - `docs/dev-logs/2026-04-21-cockpit-readability.md`
 - `docs/dev-logs/2026-04-21-audit-db-persistence.md`
+- `docs/dev-logs/2026-04-21-detail-visualization.md`
 
 ## Required Before PR
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type KeyboardEvent } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties, type KeyboardEvent } from 'react';
 import {
   buildDecisionSignals,
   buildProjectDetail,
@@ -178,6 +178,76 @@ export function App() {
     selectedDetail && riskDownsideScenario
       ? Math.abs(selectedDetail.valuation.var95Krw - riskDownsideScenario.npvKrw)
       : 0;
+  const valuationGap =
+    Math.abs((valuationExpectedCase?.npvKrw ?? 0) - (riskDownsideScenario?.npvKrw ?? 0));
+  const allocationDecisionBars = selectedDetail
+    ? buildDecisionBars([
+        {
+          key: 'project',
+          label: '프로젝트 직접원가',
+          value: selectedDetail.allocation.projectCostKrw,
+          formattedValue: formatKrwCompact(selectedDetail.allocation.projectCostKrw),
+          cue: 'solid',
+          annotation: '투입 원가의 기준점'
+        },
+        {
+          key: 'personnel',
+          label: '인력원가',
+          value: selectedDetail.allocation.personnelCostKrw,
+          formattedValue: formatKrwCompact(selectedDetail.allocation.personnelCostKrw),
+          cue: 'stripe',
+          annotation: '배부 기준 재조정 우선 후보'
+        },
+        {
+          key: 'hq',
+          label: '본부 공통원가',
+          value: selectedDetail.allocation.headquarterCostKrw,
+          formattedValue: formatKrwCompact(selectedDetail.allocation.headquarterCostKrw),
+          cue: 'dot',
+          annotation: '공통비 배분 근거 확인 필요'
+        }
+      ])
+    : [];
+  const valuationDecisionBars = selectedDetail
+    ? buildDecisionBars(
+        selectedDetail.scenarioReturns.map((scenario) => ({
+          key: scenario.label,
+          label: `${scenario.label} 시나리오`,
+          value: scenario.npvKrw,
+          formattedValue: formatKrwCompact(scenario.npvKrw),
+          cue: scenario.label === '기준' ? 'solid' : scenario.label === '낙관' ? 'stripe' : 'dot',
+          annotation: `발생 확률 ${formatPercent(scenario.probability)}`
+        }))
+      )
+    : [];
+  const riskDecisionBars = selectedDetail
+    ? buildDecisionBars([
+        {
+          key: 'var95',
+          label: 'VaR 95%',
+          value: selectedDetail.valuation.var95Krw,
+          formattedValue: formatKrwCompact(selectedDetail.valuation.var95Krw),
+          cue: 'solid',
+          annotation: '95% 신뢰수준 손실 하한'
+        },
+        {
+          key: 'cvar95',
+          label: 'CVaR 95%',
+          value: selectedDetail.valuation.cvar95Krw,
+          formattedValue: formatKrwCompact(selectedDetail.valuation.cvar95Krw),
+          cue: 'stripe',
+          annotation: '극단 구간 평균 손실'
+        },
+        {
+          key: 'downside',
+          label: '비관 시나리오 NPV',
+          value: riskDownsideScenario?.npvKrw ?? 0,
+          formattedValue: formatKrwCompact(riskDownsideScenario?.npvKrw ?? 0),
+          cue: 'dot',
+          annotation: '시나리오 하방 기준선'
+        }
+      ])
+    : [];
   const headquarterOptions = useMemo(
     () => ['all', ...portfolio.headquarters.map((headquarter) => headquarter.name)],
     [portfolio.headquarters]
@@ -819,42 +889,30 @@ export function App() {
                       <InfoTile label="성과 갭" value={formatKrwCompact(selectedDetail.allocation.performanceGapKrw)} />
                     </section>
                     <section className="cockpit-dominant-surface" aria-label="배분 비교 surface">
-                      <article className="distribution-card">
-                        <div className="distribution-card__header">
-                          <strong>Cost Driver 구성</strong>
-                          <span>총 배분원가 {formatKrwCompact(selectedDetail.allocation.allocatedCostKrw)}</span>
-                        </div>
-                        <div className="distribution-chart">
-                          <div className="distribution-chart__item">
-                            <div className="distribution-chart__bar" style={{ height: '82%' }} />
-                            <strong>{formatKrwCompact(selectedDetail.allocation.personnelCostKrw)}</strong>
-                            <span>인력원가</span>
-                          </div>
-                          <div className="distribution-chart__item">
-                            <div className="distribution-chart__bar" style={{ height: '100%' }} />
-                            <strong>{formatKrwCompact(selectedDetail.allocation.projectCostKrw)}</strong>
-                            <span>프로젝트 직접원가</span>
-                          </div>
-                          <div className="distribution-chart__item">
-                            <div className="distribution-chart__bar" style={{ height: '56%' }} />
-                            <strong>{formatKrwCompact(selectedDetail.allocation.headquarterCostKrw)}</strong>
-                            <span>본부 공통원가</span>
-                          </div>
-                        </div>
-                      </article>
+                      <DecisionBarChart
+                        title="Cost Driver 기여도"
+                        subtitle={`총 배분원가 ${formatKrwCompact(selectedDetail.allocation.allocatedCostKrw)}`}
+                        bars={allocationDecisionBars}
+                        summary={`표준원가 대비 ${formatKrwCompact(selectedDetail.allocation.efficiencyGapKrw)} 초과 상태`}
+                      />
                     </section>
                     <section className="cockpit-support-grid" aria-label="배분 해석 및 다음 행동">
-                      <article className="workflow-note">
-                        <strong>배분 해석</strong>
-                        <p>
-                          표준 대비 {formatKrwCompact(selectedDetail.allocation.efficiencyGapKrw)} 초과입니다.
-                          인력·공통원가 배부 기준을 재정의해야 합니다.
-                        </p>
-                      </article>
-                      <article className="workflow-note">
-                        <strong>다음 행동</strong>
-                        <p>원가담당자와 재무검토자가 배부 기준 변경안을 합의 후 재배분을 실행합니다.</p>
-                      </article>
+                      <DecisionSummary
+                        title="배분 해석"
+                        items={[
+                          `표준 대비 ${formatKrwCompact(selectedDetail.allocation.efficiencyGapKrw)} 초과`,
+                          `성과 갭 ${formatKrwCompact(selectedDetail.allocation.performanceGapKrw)}로 수익성 압박`,
+                          '인력·공통원가 배부 룰 검증 우선'
+                        ]}
+                      />
+                      <DecisionSummary
+                        title="다음 행동"
+                        items={[
+                          '원가담당자/재무검토자가 기준안 합의',
+                          '배부 기준 변경 후 재배분 시뮬레이션 실행',
+                          '승인 전 기준안과 수정안 차이 기록'
+                        ]}
+                      />
                     </section>
                   </>
                 ) : null}
@@ -868,27 +926,22 @@ export function App() {
                       <InfoTile label="회수기간" value={formatYears(selectedProject?.paybackYears ?? 0)} />
                     </section>
                     <section className="cockpit-dominant-surface" aria-label="시나리오 가치 비교 surface">
-                      <article className="scenario-panel">
-                        {selectedDetail.scenarioReturns.map((scenario) => (
-                          <div key={scenario.label} className="scenario-panel__item">
-                            <span>{scenario.label}</span>
-                            <strong>{formatKrwCompact(scenario.npvKrw)}</strong>
-                            <small>확률 {formatPercent(scenario.probability)}</small>
-                          </div>
-                        ))}
-                      </article>
-                      <article className="workflow-note">
-                        <strong>의사결정 컨텍스트</strong>
-                        <p>
-                          기준 대비 비관 시나리오 격차는{' '}
-                          {formatKrwCompact(
-                            Math.abs((valuationExpectedCase?.npvKrw ?? 0) - (riskDownsideScenario?.npvKrw ?? 0))
-                          )}
-                          입니다. 기대값 기준 승인 조건을 먼저 확정하세요.
-                        </p>
-                      </article>
+                      <DecisionBarChart
+                        title="시나리오 가치 비교"
+                        subtitle="확률 가중 흐름을 한 화면에서 비교"
+                        bars={valuationDecisionBars}
+                        summary={`기준 대비 비관 격차 ${formatKrwCompact(valuationGap)}`}
+                      />
                     </section>
                     <section className="cockpit-support-grid" aria-label="가치평가 보조 정보">
+                      <DecisionSummary
+                        title="의사결정 포인트"
+                        items={[
+                          '기준 시나리오를 승인 기준선으로 사용',
+                          `비관 시나리오 하방 여유 ${formatKrwCompact(valuationGap)} 확보 필요`,
+                          '확률 가정 변경 시 재계산 후 승인'
+                        ]}
+                      />
                       <InfoTile label="신용등급" value={selectedDetail.valuation.creditGrade} />
                       <InfoTile label="Credit Score" value={`${selectedDetail.valuation.creditRiskScore}점`} />
                       <InfoTile label="Duration" value={`${selectedDetail.valuation.duration}년`} />
@@ -906,42 +959,30 @@ export function App() {
                       <InfoTile label="하방 격차" value={formatKrwCompact(riskGuardrailGap)} />
                     </section>
                     <section className="cockpit-dominant-surface" aria-label="하방 노출 surface">
-                      <article className="distribution-card">
-                        <div className="distribution-card__header">
-                          <strong>Downside Exposure</strong>
-                          <span>비관 시나리오 대비 VaR guardrail</span>
-                        </div>
-                        <div className="distribution-chart">
-                          <div className="distribution-chart__item">
-                            <div className="distribution-chart__bar" style={{ height: '96%' }} />
-                            <strong>{formatKrwCompact(selectedDetail.valuation.var95Krw)}</strong>
-                            <span>VaR 95%</span>
-                          </div>
-                          <div className="distribution-chart__item">
-                            <div className="distribution-chart__bar" style={{ height: '78%' }} />
-                            <strong>{formatKrwCompact(selectedDetail.valuation.cvar95Krw)}</strong>
-                            <span>CVaR 95%</span>
-                          </div>
-                          <div className="distribution-chart__item">
-                            <div className="distribution-chart__bar" style={{ height: '62%' }} />
-                            <strong>{formatKrwCompact(riskDownsideScenario?.npvKrw ?? 0)}</strong>
-                            <span>비관 시나리오 NPV</span>
-                          </div>
-                        </div>
-                      </article>
+                      <DecisionBarChart
+                        title="Downside Exposure"
+                        subtitle="손실 한계와 시나리오 하방을 동시 비교"
+                        bars={riskDecisionBars}
+                        summary={`VaR 대비 하방 격차 ${formatKrwCompact(riskGuardrailGap)}`}
+                      />
                     </section>
                     <section className="cockpit-support-grid" aria-label="리스크 해석">
-                      <article className="workflow-note">
-                        <strong>리스크 의미</strong>
-                        <p>
-                          현재 이슈는 단순 심각도가 아니라 현금흐름 방어력입니다.
-                          downside 손실 한계와 승인 임계치를 함께 확인해야 합니다.
-                        </p>
-                      </article>
-                      <article className="workflow-note">
-                        <strong>권장 액션</strong>
-                        <p>비관 확률 재추정과 민감도 재평가를 먼저 수행한 뒤 조건부 승인안을 작성합니다.</p>
-                      </article>
+                      <DecisionSummary
+                        title="리스크 의미"
+                        items={[
+                          '심각도 등급이 아니라 현금흐름 방어력 확인이 핵심',
+                          `하방 격차 ${formatKrwCompact(riskGuardrailGap)}는 승인 임계치 근거`,
+                          '손실 허용 범위와 승인 조건을 함께 검증'
+                        ]}
+                      />
+                      <DecisionSummary
+                        title="권장 액션"
+                        items={[
+                          '비관 확률 재추정',
+                          '민감도 재평가 후 조건부 승인안 작성',
+                          '승인 코멘트에 하방 한계 수치 명시'
+                        ]}
+                      />
                     </section>
                   </>
                 ) : null}
@@ -1101,5 +1142,82 @@ function InfoTile({ label, value }: { label: string; value: string }) {
       <span>{label}</span>
       <strong>{value}</strong>
     </div>
+  );
+}
+
+type DecisionBarCue = 'solid' | 'stripe' | 'dot';
+
+type DecisionBarInput = {
+  key: string;
+  label: string;
+  value: number;
+  formattedValue: string;
+  cue: DecisionBarCue;
+  annotation: string;
+};
+
+type DecisionBarItem = DecisionBarInput & {
+  ratio: number;
+};
+
+function buildDecisionBars(items: DecisionBarInput[]): DecisionBarItem[] {
+  const maxMagnitude = Math.max(...items.map((item) => Math.abs(item.value)), 1);
+  return items.map((item) => ({
+    ...item,
+    ratio: Math.max(Math.abs(item.value) / maxMagnitude, 0.08)
+  }));
+}
+
+function DecisionBarChart({
+  title,
+  subtitle,
+  bars,
+  summary
+}: {
+  title: string;
+  subtitle: string;
+  bars: DecisionBarItem[];
+  summary: string;
+}) {
+  return (
+    <article className="decision-chart-card">
+      <div className="decision-chart-card__header">
+        <strong>{title}</strong>
+        <span>{subtitle}</span>
+      </div>
+      <ul className="decision-chart" aria-label={title}>
+        {bars.map((bar) => (
+          <li key={bar.key} className="decision-chart__row">
+            <div className="decision-chart__meta">
+              <span className={`decision-cue decision-cue--${bar.cue}`} aria-hidden="true" />
+              <strong>{bar.label}</strong>
+              <small>{bar.annotation}</small>
+            </div>
+            <div
+              className={`decision-bar decision-bar--${bar.cue}`}
+              style={{ '--bar-ratio': `${bar.ratio * 100}%` } as CSSProperties}
+            />
+            <div className="decision-chart__value">
+              <strong>{bar.formattedValue}</strong>
+              <span>{bar.value < 0 ? '손실 구간' : '기여 구간'}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <p className="decision-chart-card__summary">{summary}</p>
+    </article>
+  );
+}
+
+function DecisionSummary({ title, items }: { title: string; items: string[] }) {
+  return (
+    <article className="decision-summary">
+      <strong>{title}</strong>
+      <ul>
+        {items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </article>
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1666,6 +1666,177 @@ textarea {
   line-height: 1.5;
 }
 
+.decision-chart-card {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(79, 103, 246, 0.18);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(244, 248, 255, 0.92)),
+    radial-gradient(circle at top right, rgba(79, 103, 246, 0.12), transparent 42%);
+}
+
+.decision-chart-card__header {
+  display: grid;
+  gap: 4px;
+}
+
+.decision-chart-card__header span {
+  color: #4b5b7f;
+  font-size: 0.85rem;
+}
+
+.decision-chart {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.decision-chart__row {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(0, 1.4fr) minmax(120px, auto);
+  gap: 10px;
+  align-items: center;
+}
+
+.decision-chart__meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 8px;
+  align-items: center;
+}
+
+.decision-chart__meta strong {
+  font-size: 0.92rem;
+}
+
+.decision-chart__meta small {
+  grid-column: 2;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.decision-cue {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  border: 1px solid rgba(49, 67, 116, 0.45);
+}
+
+.decision-cue--solid {
+  background: rgba(79, 103, 246, 0.84);
+}
+
+.decision-cue--stripe {
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      rgba(79, 103, 246, 0.82) 0 3px,
+      rgba(255, 255, 255, 0.28) 3px 6px
+    );
+}
+
+.decision-cue--dot {
+  background:
+    radial-gradient(circle, rgba(79, 103, 246, 0.78) 30%, transparent 32%) 0 0 / 6px 6px,
+    rgba(232, 238, 255, 0.96);
+}
+
+.decision-bar {
+  position: relative;
+  height: 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 103, 246, 0.16);
+  background: rgba(231, 237, 251, 0.8);
+  overflow: hidden;
+}
+
+.decision-bar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: var(--bar-ratio);
+  min-width: 28px;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.38);
+}
+
+.decision-bar--solid::before {
+  background: linear-gradient(90deg, #4f67f6, #3a53e1);
+}
+
+.decision-bar--stripe::before {
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      rgba(79, 103, 246, 0.9) 0 6px,
+      rgba(255, 255, 255, 0.3) 6px 10px
+    );
+}
+
+.decision-bar--dot::before {
+  background:
+    radial-gradient(circle, rgba(79, 103, 246, 0.9) 25%, transparent 26%) 0 0 / 10px 10px,
+    linear-gradient(90deg, rgba(79, 103, 246, 0.9), rgba(79, 103, 246, 0.72));
+}
+
+.decision-chart__value {
+  display: grid;
+  justify-items: end;
+  gap: 2px;
+}
+
+.decision-chart__value strong {
+  font-size: 0.92rem;
+}
+
+.decision-chart__value span {
+  color: var(--muted);
+  font-size: 0.74rem;
+}
+
+.decision-chart-card__summary {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(79, 103, 246, 0.08);
+  color: #2b4279;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.decision-summary {
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(123, 137, 167, 0.2);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(248, 251, 255, 0.94)),
+    repeating-linear-gradient(
+      -45deg,
+      rgba(79, 103, 246, 0.03) 0 7px,
+      rgba(79, 103, 246, 0.01) 7px 14px
+    );
+}
+
+.decision-summary strong {
+  display: block;
+  color: #2a3e71;
+  font-size: 0.93rem;
+}
+
+.decision-summary ul {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+  color: #4c5a7d;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+
 .local-nav {
   display: flex;
   gap: 10px;
@@ -1798,6 +1969,14 @@ textarea {
   .cockpit-kpi-group,
   .cockpit-support-grid {
     grid-template-columns: 1fr 1fr;
+  }
+
+  .decision-chart__row {
+    grid-template-columns: 1fr;
+  }
+
+  .decision-chart__value {
+    justify-items: start;
   }
 
   .cockpit-summary-strip__focus {


### PR DESCRIPTION
## 요약
- Allocation/Valuation/Risk 탭에 의사결정형 차트 구조를 공통 적용했습니다.
- hover 없이도 라벨/주석/요약으로 핵심 결론을 파악할 수 있도록 정리했습니다.
- 색상 외 구분 cue(솔리드/스트라이프/도트 패턴)로 접근성을 보강했습니다.

## 변경 사항
- `DecisionBarChart`, `DecisionSummary` 컴포넌트 추가
- 정적 막대 높이를 데이터 비율 기반 렌더링으로 교체
- 탭별 요약 문구와 의사결정 포인트를 차트 하단에 일관 구성
- 모바일 구간 차트 레이아웃 대응
- dev-log 추가: `docs/dev-logs/2026-04-21-detail-visualization.md`

## 범위
- 포함: 상세 탭 시각화/라벨/요약/접근성 강화
- 제외: 계산 로직 변경, 백엔드/API 변경, 외부 BI 연동

## 수용 기준 체크
- [x] Allocation/Valuation/Risk 탭 의사결정형 차트 제공
- [x] 차트+라벨+요약만으로 핵심 결론 파악 가능
- [x] 비색상 cue(패턴/마커)로 상태 구분 가능
- [x] 값/라벨/요약 텍스트 일관 제공

## 검증
- `npm run lint` 통과
- `npm run build` 통과

## 이슈
- Closes #39
