### PR TITLE
fix: 감사 로그 Authorization 헤더 저장 제거

### DIFF
--- a/backend/src/main/java/com/costwise/api/audit/AuditLogController.java
+++ b/backend/src/main/java/com/costwise/api/audit/AuditLogController.java
@@ -90,7 +90,6 @@ public class AuditLogController {
         context.put("requestId", request.getHeader("X-Request-Id"));
         context.put("remoteAddr", request.getRemoteAddr());
         context.put("userAgent", request.getHeader("User-Agent"));
-        context.put("authorization", request.getHeader("Authorization"));
         context.put("principal", authentication == null ? null : authentication.getName());
         context.put("capturedAt", Instant.now().toString());
         return context;

--- a/backend/src/main/java/com/costwise/audit/AuditLogService.java
+++ b/backend/src/main/java/com/costwise/audit/AuditLogService.java
@@ -48,7 +48,7 @@ public class AuditLogService {
                 command.target().trim(),
                 command.result().trim(),
                 sanitize(command.metadata()),
-                sanitize(command.requestContext()),
+                sanitizeRequestContext(command.requestContext()),
                 command.occurredAt(),
                 createdAt));
         return toResponse(entry);
@@ -142,6 +142,21 @@ public class AuditLogService {
     private JsonNode sanitize(JsonNode input) {
         JsonNode node = input == null ? JsonNodeFactory.instance.objectNode() : input.deepCopy();
         return sanitizeNode(node, null);
+    }
+
+    private JsonNode sanitizeRequestContext(JsonNode input) {
+        JsonNode node = sanitize(input);
+        if (node.isObject()) {
+            ObjectNode object = (ObjectNode) node;
+            List<String> fieldNames = new ArrayList<>();
+            object.fieldNames().forEachRemaining(fieldNames::add);
+            for (String name : fieldNames) {
+                if (isSensitiveKey(name)) {
+                    object.remove(name);
+                }
+            }
+        }
+        return node;
     }
 
     private JsonNode sanitizeNode(JsonNode node, String fieldName) {

--- a/backend/src/test/java/com/costwise/api/audit/AuditLogControllerTest.java
+++ b/backend/src/test/java/com/costwise/api/audit/AuditLogControllerTest.java
@@ -8,7 +8,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+import com.costwise.api.dto.audit.CreateAuditLogRequest;
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
 import java.time.Instant;
 import java.sql.Connection;
@@ -18,12 +21,19 @@ import java.util.Base64;
 import java.util.List;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+import com.costwise.audit.AuditLogService;
 import com.costwise.api.support.JsonFieldReader;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
@@ -50,6 +60,42 @@ class AuditLogControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Test
+    void appendDoesNotCollectAuthorizationHeaderInRequestContext() {
+        AuditLogService auditLogService = mock(AuditLogService.class);
+        AuditLogController controller = new AuditLogController(auditLogService);
+        MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+        httpRequest.addHeader("Authorization", "Bearer raw-header-value");
+        httpRequest.addHeader("X-Request-Id", "req-unit");
+        httpRequest.addHeader("User-Agent", "unit-test");
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(
+                "controller-user",
+                "credentials",
+                List.of(new SimpleGrantedAuthority("ROLE_PLANNER")));
+
+        controller.append(
+                new CreateAuditLogRequest(
+                        "PJT-UNIT",
+                        "REVIEW",
+                        "system",
+                        "fallback-user",
+                        "submit",
+                        "project",
+                        "success",
+                        JsonNodeFactory.instance.objectNode(),
+                        Instant.parse("2026-04-20T10:00:00Z")),
+                authentication,
+                httpRequest);
+
+        ArgumentCaptor<AuditLogService.AppendCommand> commandCaptor =
+                ArgumentCaptor.forClass(AuditLogService.AppendCommand.class);
+        verify(auditLogService).append(commandCaptor.capture());
+
+        Assertions.assertFalse(commandCaptor.getValue().requestContext().has("authorization"));
+        Assertions.assertEquals("req-unit", commandCaptor.getValue().requestContext().path("requestId").asText());
+        Assertions.assertEquals("unit-test", commandCaptor.getValue().requestContext().path("userAgent").asText());
+    }
 
     @BeforeEach
     void createSchema() throws Exception {
@@ -110,7 +156,7 @@ class AuditLogControllerTest {
                 .andExpect(jsonPath("$.actorRole").value("PLANNER"))
                 .andExpect(jsonPath("$.actorId").value("planner@example.com"))
                 .andExpect(jsonPath("$.metadata.token").value("***"))
-                .andExpect(jsonPath("$.requestContext.authorization").value("***"));
+                .andExpect(jsonPath("$.requestContext.authorization").doesNotExist());
 
         mockMvc.perform(post("/api/audit-logs")
                         .header("Authorization", plannerAuth)

--- a/backend/src/test/java/com/costwise/audit/JdbcAuditLogRepositoryTest.java
+++ b/backend/src/test/java/com/costwise/audit/JdbcAuditLogRepositoryTest.java
@@ -44,7 +44,7 @@ class JdbcAuditLogRepositoryTest {
 
         assertThat(response.items()).hasSize(1);
         assertThat(response.items().getFirst().metadata().path("token").asText()).isEqualTo("***");
-        assertThat(response.items().getFirst().requestContext().path("authorization").asText()).isEqualTo("***");
+        assertThat(response.items().getFirst().requestContext().has("authorization")).isFalse();
     }
 
     private void createSchema(String jdbcUrl) throws Exception {

--- a/docs/dev-logs/2026-04-22-audit-authorization-header-removal.md
+++ b/docs/dev-logs/2026-04-22-audit-authorization-header-removal.md
@@ -1,0 +1,28 @@
+# Audit Authorization Header Removal
+
+## Branch
+
+- Worktree: `.worktrees/feat-52-remove-auth-header`
+- Branch: `feat/52-remove-auth-header`
+- Base: `dev`
+- Related issue: `#52`
+
+## Comparison
+
+- Option A: keep collecting `Authorization` in audit request context and rely on generic masking.
+- Option B: stop collecting the header in the controller and remove sensitive request-context keys before persistence.
+
+Option B was selected because the issue requires non-storage, not only redaction. It also protects any future direct `AppendCommand` caller that accidentally passes sensitive request context.
+
+## Changes
+
+- Removed `Authorization` header collection from audit request context assembly.
+- Added stricter request-context sanitization that removes sensitive keys before storage.
+- Updated controller and repository tests to assert that `authorization` is absent.
+- Added a controller-level test that proves the header is not passed to `AuditLogService`.
+
+## Validation
+
+- `.\gradlew.bat test --tests com.costwise.api.audit.AuditLogControllerTest --tests com.costwise.audit.JdbcAuditLogRepositoryTest`
+- `.\gradlew.bat check`
+- Pre-commit backend Gradle check during commit


### PR DESCRIPTION
## 요약

감사로그 request context에 `Authorization` 헤더가 남지 않도록 수집과 저장 경로를 정리했습니다. 민감한 request context 키는 저장 직전에 제거되며, 자유 형식 metadata의 민감값 마스킹은 유지됩니다.

## 변경 내용

- `AuditLogController`에서 `Authorization` 헤더를 request context에 추가하지 않도록 변경
- `AuditLogService`에서 request context의 민감 키를 저장 전 제거하도록 보강
- 컨트롤러가 `AppendCommand.requestContext()`에 Authorization 값을 전달하지 않는 단위 테스트 추가
- 저장/재조회 결과에 `authorization` 필드가 없는지 회귀 테스트 보강
- `docs/dev-logs/2026-04-22-audit-authorization-header-removal.md`에 워킹트리 비교와 선택 이유 기록

## 이유

이슈 #52의 요구사항은 토큰 값을 마스킹하는 수준이 아니라 감사로그 저장 대상에서 `Authorization` 헤더를 제거하는 것입니다. 감사로그 조회 권한이 있는 사용자에게 인증 정보가 노출될 가능성을 줄이고, 보안 검토 시 민감정보 미저장 근거를 명확히 하기 위해 변경했습니다.

## 이슈 체크리스트

- [x] `Authorization` 헤더를 감사로그 저장 대상에서 제거
- [x] 필요한 경우 metadata의 민감값은 마스킹된 형태로만 저장
- [x] request context 허용 필드 재정의: `requestId`, `remoteAddr`, `userAgent`, `principal`, `capturedAt`만 수집
- [x] 관련 테스트 보강
- [x] 감사로그에 토큰/세션/비밀값이 저장되지 않는 근거 확보
- [x] 보안 검토 시 `민감정보 미저장` 근거 설명 가능

## 검증

- [x] 관련 테스트를 실행했습니다.
  - `.\gradlew.bat test --tests com.costwise.api.audit.AuditLogControllerTest --tests com.costwise.audit.JdbcAuditLogRepositoryTest`
  - `.\gradlew.bat check`
  - 커밋 시 pre-commit backend Gradle check 통과
- [x] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
  - MockMvc 응답과 저장소 재조회에서 `requestContext.authorization` 부재 확인
- [x] 인접한 흐름에서 회귀가 없는지 확인했습니다.
  - 전체 backend `check` 통과

## 스크린샷 또는 로그

화면 변경은 없습니다. 검증 로그는 PR 커밋 전 로컬 Gradle 실행 결과와 pre-commit 결과로 확인했습니다.

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [x] 후속 작업이 필요하면 별도 이슈로 분리했습니다.

## 브랜치

- [x] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
- [x] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.