### PR TITLE
fix: 핵심 비즈니스 API 인증/인가 정책 강화

### DIFF
--- a/backend/src/main/java/com/costwise/config/SecurityConfig.java
+++ b/backend/src/main/java/com/costwise/config/SecurityConfig.java
@@ -89,20 +89,21 @@ public class SecurityConfig {
                         .jwtAuthenticationConverter(jwtAuthenticationConverter)));
         http.authorizeHttpRequests(
                 auth -> auth
-                        .requestMatchers("/api/health",
-                                "/api/dashboard",
+                        .requestMatchers("/api/health")
+                        .permitAll()
+                        .requestMatchers("/api/dashboard",
                                 "/api/portfolio/summary",
                                 "/api/cost-accounting/summary",
                                 "/api/valuation-risk/projects/**",
                                 "/api/compute")
-                        .permitAll()
+                        .hasAnyRole("PLANNER", "FINANCE_REVIEWER", "EXECUTIVE")
                         .requestMatchers("/actuator/health", "/actuator/info")
                         .permitAll()
                         .requestMatchers("/actuator/**")
                         .access((authentication, context) ->
                                 new AuthorizationDecision(securityPolicyProperties.actuatorAllPublic()))
                         .requestMatchers("/api/projects/*/workflow", "/api/projects/*/review").authenticated()
-                        .requestMatchers("/api/audit-logs").authenticated()
+                        .requestMatchers("/api/audit-logs").hasRole("EXECUTIVE")
                         .requestMatchers(HttpMethod.OPTIONS, "/**")
                         .permitAll()
                         .requestMatchers("/v3/api-docs",

--- a/backend/src/test/java/com/costwise/api/audit/AuditLogControllerTest.java
+++ b/backend/src/test/java/com/costwise/api/audit/AuditLogControllerTest.java
@@ -84,10 +84,10 @@ class AuditLogControllerTest {
     @Test
     void appendAndQuerySupportsFilteringCursorAndSecretMasking() throws Exception {
         Instant now = Instant.now();
-        String plannerAuth = bearerToken(token("planner", ISSUER, AUDIENCE, now, now.plusSeconds(3600)));
+        String executiveAuth = bearerToken(token("executive", ISSUER, AUDIENCE, now, now.plusSeconds(3600)));
 
         mockMvc.perform(post("/api/audit-logs")
-                        .header("Authorization", plannerAuth)
+                        .header("Authorization", executiveAuth)
                         .header("X-Request-Id", "req-1")
                         .contentType(APPLICATION_JSON)
                         .content("""
@@ -105,15 +105,15 @@ class AuditLogControllerTest {
                                   },
                                   "occurredAt": "2026-04-20T10:00:00Z"
                                 }
-                                """))
+                """))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.actorRole").value("PLANNER"))
-                .andExpect(jsonPath("$.actorId").value("planner@example.com"))
+                .andExpect(jsonPath("$.actorRole").value("EXECUTIVE"))
+                .andExpect(jsonPath("$.actorId").value("executive@example.com"))
                 .andExpect(jsonPath("$.metadata.token").value("***"))
                 .andExpect(jsonPath("$.requestContext.authorization").value("***"));
 
         mockMvc.perform(post("/api/audit-logs")
-                        .header("Authorization", plannerAuth)
+                        .header("Authorization", executiveAuth)
                         .header("X-Request-Id", "req-2")
                         .contentType(APPLICATION_JSON)
                         .content("""
@@ -136,7 +136,7 @@ class AuditLogControllerTest {
                 .andExpect(jsonPath("$.metadata.authorization").value("***"));
 
         mockMvc.perform(post("/api/audit-logs")
-                        .header("Authorization", plannerAuth)
+                        .header("Authorization", executiveAuth)
                         .contentType(APPLICATION_JSON)
                         .content("""
                                 {
@@ -156,7 +156,7 @@ class AuditLogControllerTest {
                 .andExpect(status().isCreated());
 
         MvcResult firstPage = mockMvc.perform(get("/api/audit-logs")
-                        .header("Authorization", plannerAuth)
+                        .header("Authorization", executiveAuth)
                         .queryParam("projectId", "PJT-001")
                         .queryParam("limit", "1"))
                 .andExpect(status().isOk())
@@ -168,7 +168,7 @@ class AuditLogControllerTest {
         String cursor = JsonFieldReader.read(firstPage.getResponse().getContentAsString(), "nextCursor");
 
         mockMvc.perform(get("/api/audit-logs")
-                        .header("Authorization", plannerAuth)
+                        .header("Authorization", executiveAuth)
                         .queryParam("projectId", "PJT-001")
                         .queryParam("cursor", cursor))
                 .andExpect(status().isOk())
@@ -177,7 +177,7 @@ class AuditLogControllerTest {
                 .andExpect(jsonPath("$.nextCursor").value(nullValue()));
 
         mockMvc.perform(get("/api/audit-logs")
-                        .header("Authorization", plannerAuth)
+                        .header("Authorization", executiveAuth)
                         .queryParam("projectId", "PJT-001")
                         .queryParam("eventType", "review"))
                 .andExpect(status().isOk())
@@ -185,7 +185,7 @@ class AuditLogControllerTest {
                 .andExpect(jsonPath("$.items[0].eventType").value("REVIEW"));
 
         mockMvc.perform(get("/api/audit-logs")
-                        .header("Authorization", plannerAuth)
+                        .header("Authorization", executiveAuth)
                         .queryParam("projectId", "PJT-001")
                         .queryParam("from", "2026-04-20T10:30:00Z")
                         .queryParam("to", "2026-04-20T11:30:00Z"))

--- a/backend/src/test/java/com/costwise/api/workflow/WorkflowControllerSecurityTest.java
+++ b/backend/src/test/java/com/costwise/api/workflow/WorkflowControllerSecurityTest.java
@@ -124,17 +124,63 @@ class WorkflowControllerSecurityTest {
     void auditLogsRequireProjectId() throws Exception {
         Instant now = Instant.now();
         mockMvc.perform(get("/api/audit-logs")
-                        .header("Authorization", bearerToken(token("planner", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
+                        .header("Authorization", bearerToken(token("executive", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
-    void auditLogsAllowPlannerRole() throws Exception {
+    void auditLogsRejectPlannerRole() throws Exception {
         Instant now = Instant.now();
         mockMvc.perform(get("/api/audit-logs?projectId=P-100")
                         .header("Authorization", bearerToken(token("planner", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void auditLogsAllowExecutiveRole() throws Exception {
+        Instant now = Instant.now();
+        mockMvc.perform(get("/api/audit-logs?projectId=P-100")
+                        .header("Authorization", bearerToken(token("executive", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.items").isArray());
+    }
+
+    @Test
+    void coreBusinessApisRejectAnonymousRequests() throws Exception {
+        mockMvc.perform(get("/api/dashboard"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/portfolio/summary"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/cost-accounting/summary"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/valuation-risk/projects/14"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(post("/api/compute")
+                        .contentType(APPLICATION_JSON)
+                        .content(validComputeRequest()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void coreBusinessApisAllowAuthenticatedBusinessRoles() throws Exception {
+        Instant now = Instant.now();
+        for (String role : List.of("planner", "finance_reviewer", "executive")) {
+            String authHeader = bearerToken(token(role, ISSUER, AUDIENCE, now, now.plusSeconds(3600)));
+
+            mockMvc.perform(get("/api/dashboard").header("Authorization", authHeader))
+                    .andExpect(status().isOk());
+            mockMvc.perform(get("/api/portfolio/summary").header("Authorization", authHeader))
+                    .andExpect(status().isOk());
+            mockMvc.perform(get("/api/cost-accounting/summary").header("Authorization", authHeader))
+                    .andExpect(status().isOk());
+            mockMvc.perform(get("/api/valuation-risk/projects/14").header("Authorization", authHeader))
+                    .andExpect(status().isOk());
+            mockMvc.perform(post("/api/compute")
+                            .header("Authorization", authHeader)
+                            .contentType(APPLICATION_JSON)
+                            .content(validComputeRequest()))
+                    .andExpect(status().isOk());
+        }
     }
 
     @Test
@@ -167,5 +213,30 @@ class WorkflowControllerSecurityTest {
                 .build();
         return encoder.encode(JwtEncoderParameters.from(JwsHeader.with(MacAlgorithm.HS256).build(), claims))
                 .getTokenValue();
+    }
+
+    private String validComputeRequest() {
+        return """
+                {
+                  "projectName": "테스트 프로젝트",
+                  "discountRate": 0.08,
+                  "departments": [
+                    {"id": "HQ-1", "name": "기획본부"}
+                  ],
+                  "costPools": [
+                    {
+                      "name": "공통 인건비",
+                      "amount": 1000000,
+                      "allocationTargets": [
+                        {"departmentId": "HQ-1", "departmentName": "기획본부", "weight": 1}
+                      ]
+                    }
+                  ],
+                  "cashFlows": [
+                    {"periodNo": 0, "periodLabel": "초기", "yearLabel": "Y0", "netCashFlow": -1000000},
+                    {"periodNo": 1, "periodLabel": "1년차", "yearLabel": "Y1", "netCashFlow": 1200000}
+                  ]
+                }
+                """;
     }
 }

--- a/docs/dev-logs/2026-04-22-core-api-auth-policy.md
+++ b/docs/dev-logs/2026-04-22-core-api-auth-policy.md
@@ -1,0 +1,28 @@
+# Core API Auth Policy
+
+## Branch
+
+- Worktree: `.worktrees/feat-53-core-api-auth`
+- Branch: `feat/53-core-api-auth`
+- Base: `dev`
+- Related issue: `#53`
+
+## Comparison
+
+- Option A: keep dashboard, portfolio, accounting, valuation, and compute endpoints public.
+- Option B: keep only health public and require authenticated business roles for core business APIs.
+
+Option B was selected because project, cost, valuation, and compute APIs expose business data or business capability and should align with the server-side auth boundary described in the product security direction.
+
+## Changes
+
+- Kept `/api/health` public.
+- Required `PLANNER`, `FINANCE_REVIEWER`, or `EXECUTIVE` for dashboard, portfolio summary, cost accounting summary, valuation-risk detail, and compute APIs.
+- Restricted audit log API access to `EXECUTIVE`.
+- Added security tests for anonymous denial, business-role access, and audit-log role behavior.
+
+## Validation
+
+- `.\gradlew.bat test --tests com.costwise.api.workflow.WorkflowControllerSecurityTest`
+- `.\gradlew.bat check`
+- Pre-commit backend Gradle check during commit


### PR DESCRIPTION
## 요약

핵심 업무 API가 비인증 사용자에게 열려 있던 정책을 정리했습니다. `/api/health`만 공개로 유지하고, 프로젝트/원가/평가/계산 관련 API는 인증된 업무 역할만 접근하도록 제한했습니다.

## 변경 내용

- `/api/health`는 공개 엔드포인트로 유지
- `/api/dashboard`, `/api/portfolio/summary`, `/api/cost-accounting/summary`, `/api/valuation-risk/projects/**`, `/api/compute`는 `PLANNER`, `FINANCE_REVIEWER`, `EXECUTIVE` 역할만 접근 가능하도록 변경
- `/api/audit-logs`는 `EXECUTIVE` 전용으로 제한
- 익명 접근 차단, 업무 역할 접근 허용, 감사로그 역할 제한 테스트 보강
- `docs/dev-logs/2026-04-22-core-api-auth-policy.md`에 워킹트리 비교와 선택 이유 기록

## 이유

이슈 #53의 요구사항은 포트폴리오, 원가, 가치평가, 계산 API를 공개 API가 아니라 서버 인증/인가 경계 안에 두는 것입니다. 설계 문서의 보안 방향과 맞추고, 제출/운영 관점에서 핵심 업무 데이터가 비인증 사용자에게 노출되지 않도록 정책을 강화했습니다.

## 이슈 체크리스트

- [x] 공개 유지가 필요한 엔드포인트와 보호가 필요한 엔드포인트 구분
- [x] `/api/portfolio/summary`, `/api/cost-accounting/summary`, `/api/valuation-risk/projects/**`, `/api/dashboard`, `/api/compute` 정책 재검토 및 보호 적용
- [x] 역할별 접근 범위 정의: 핵심 업무 API는 `PLANNER`, `FINANCE_REVIEWER`, `EXECUTIVE`, 감사로그는 `EXECUTIVE`
- [x] 보안 테스트 보강
- [x] 핵심 업무 데이터는 인증 후에만 조회 가능
- [x] 보안 설정과 설계 방향 일치

## 검증

- [x] 관련 테스트를 실행했습니다.
  - `.\gradlew.bat test --tests com.costwise.api.workflow.WorkflowControllerSecurityTest`
  - `.\gradlew.bat check`
  - 커밋 시 pre-commit backend Gradle check 통과
- [x] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
  - MockMvc로 익명 요청 401, 업무 역할 요청 200, 감사로그 planner 403/executive 200 확인
- [x] 인접한 흐름에서 회귀가 없는지 확인했습니다.
  - 전체 backend `check` 통과

## 스크린샷 또는 로그

화면 변경은 없습니다. 검증 로그는 PR 커밋 전 로컬 Gradle 실행 결과와 pre-commit 결과로 확인했습니다.

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [x] 후속 작업이 필요하면 별도 이슈로 분리했습니다.

## 브랜치

- [x] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
- [x] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.