### PR TITLE
feat: 프로젝트/시나리오 DB 영속화 기반 전환

### DIFF
--- a/backend/src/main/java/com/costwise/persistence/JdbcProjectPersistenceRepository.java
+++ b/backend/src/main/java/com/costwise/persistence/JdbcProjectPersistenceRepository.java
@@ -1,0 +1,300 @@
+package com.costwise.persistence;
+
+import com.costwise.config.AuditPersistenceProperties;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcProjectPersistenceRepository implements ProjectPersistenceRepository {
+
+    private final AuditPersistenceProperties persistenceProperties;
+
+    public JdbcProjectPersistenceRepository(AuditPersistenceProperties persistenceProperties) {
+        this.persistenceProperties = persistenceProperties;
+    }
+
+    @Override
+    public ProjectRecord createProject(NewProject project) {
+        String sql = """
+                insert into projects (code, name, business_type, status, description)
+                values (?, ?, ?, ?, ?)
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            statement.setString(1, project.code());
+            statement.setString(2, project.name());
+            statement.setString(3, project.businessType());
+            statement.setString(4, project.status());
+            statement.setString(5, project.description());
+            statement.executeUpdate();
+            return findProject(readGeneratedUuid(statement)).orElseThrow(
+                    () -> new IllegalStateException("Failed to read created project"));
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to create project", exception);
+        }
+    }
+
+    @Override
+    public ProjectRecord updateProject(ProjectUpdate project) {
+        String sql = """
+                update projects
+                   set name = ?,
+                       business_type = ?,
+                       status = ?,
+                       description = ?
+                 where id = ?
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, project.name());
+            statement.setString(2, project.businessType());
+            statement.setString(3, project.status());
+            statement.setString(4, project.description());
+            statement.setObject(5, uuid(project.id()));
+            int updated = statement.executeUpdate();
+            if (updated == 0) {
+                throw new IllegalArgumentException("Unknown project id: " + project.id());
+            }
+            return findProject(project.id()).orElseThrow(
+                    () -> new IllegalStateException("Failed to read updated project"));
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to update project", exception);
+        }
+    }
+
+    @Override
+    public void deleteProject(String projectId) {
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement("delete from projects where id = ?")) {
+            statement.setObject(1, uuid(projectId));
+            int deleted = statement.executeUpdate();
+            if (deleted == 0) {
+                throw new IllegalArgumentException("Unknown project id: " + projectId);
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to delete project", exception);
+        }
+    }
+
+    @Override
+    public Optional<ProjectRecord> findProject(String projectId) {
+        String sql = """
+                select id, code, name, business_type, status, description, created_at
+                  from projects
+                 where id = ?
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, uuid(projectId));
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return Optional.empty();
+                }
+                return Optional.of(toProject(resultSet));
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to find project", exception);
+        }
+    }
+
+    @Override
+    public boolean existsProjectCode(String code) {
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement("select 1 from projects where code = ?")) {
+            statement.setString(1, code);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to check project code", exception);
+        }
+    }
+
+    @Override
+    public ScenarioRecord createScenario(String projectId, NewScenario scenario) {
+        String sql = """
+                insert into scenarios (project_id, name, description, is_baseline, is_active)
+                values (?, ?, ?, ?, ?)
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            statement.setObject(1, uuid(projectId));
+            statement.setString(2, scenario.name());
+            statement.setString(3, scenario.description());
+            statement.setBoolean(4, scenario.isBaseline());
+            statement.setBoolean(5, scenario.isActive());
+            statement.executeUpdate();
+            return findScenario(projectId, readGeneratedUuid(statement)).orElseThrow(
+                    () -> new IllegalStateException("Failed to read created scenario"));
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to create scenario", exception);
+        }
+    }
+
+    @Override
+    public ScenarioRecord updateScenario(String projectId, ScenarioUpdate scenario) {
+        String sql = """
+                update scenarios
+                   set name = ?,
+                       description = ?,
+                       is_baseline = ?,
+                       is_active = ?
+                 where project_id = ?
+                   and id = ?
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, scenario.name());
+            statement.setString(2, scenario.description());
+            statement.setBoolean(3, scenario.isBaseline());
+            statement.setBoolean(4, scenario.isActive());
+            statement.setObject(5, uuid(projectId));
+            statement.setObject(6, uuid(scenario.id()));
+            int updated = statement.executeUpdate();
+            if (updated == 0) {
+                throw new IllegalArgumentException("Unknown scenario id: " + scenario.id());
+            }
+            return findScenario(projectId, scenario.id()).orElseThrow(
+                    () -> new IllegalStateException("Failed to read updated scenario"));
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to update scenario", exception);
+        }
+    }
+
+    @Override
+    public void deleteScenario(String projectId, String scenarioId) {
+        String sql = "delete from scenarios where project_id = ? and id = ?";
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, uuid(projectId));
+            statement.setObject(2, uuid(scenarioId));
+            int deleted = statement.executeUpdate();
+            if (deleted == 0) {
+                throw new IllegalArgumentException("Unknown scenario id: " + scenarioId);
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to delete scenario", exception);
+        }
+    }
+
+    @Override
+    public Optional<ScenarioRecord> findScenario(String projectId, String scenarioId) {
+        String sql = """
+                select id, name, description, is_baseline, is_active, created_at
+                  from scenarios
+                 where project_id = ?
+                   and id = ?
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, uuid(projectId));
+            statement.setObject(2, uuid(scenarioId));
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return Optional.empty();
+                }
+                return Optional.of(toScenario(resultSet));
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to find scenario", exception);
+        }
+    }
+
+    @Override
+    public List<ScenarioRecord> listScenarios(String projectId) {
+        String sql = """
+                select id, name, description, is_baseline, is_active, created_at
+                  from scenarios
+                 where project_id = ?
+                 order by created_at asc, name asc
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, uuid(projectId));
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<ScenarioRecord> scenarios = new ArrayList<>();
+                while (resultSet.next()) {
+                    scenarios.add(toScenario(resultSet));
+                }
+                return scenarios;
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to list scenarios", exception);
+        }
+    }
+
+    @Override
+    public boolean existsScenarioName(String projectId, String normalizedName, String skipScenarioId) {
+        StringBuilder sql = new StringBuilder("""
+                select 1
+                  from scenarios
+                 where project_id = ?
+                   and lower(name) = ?
+                """);
+        if (skipScenarioId != null) {
+            sql.append(" and id <> ?");
+        }
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql.toString())) {
+            statement.setObject(1, uuid(projectId));
+            statement.setString(2, normalizedName);
+            if (skipScenarioId != null) {
+                statement.setObject(3, uuid(skipScenarioId));
+            }
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to check scenario name", exception);
+        }
+    }
+
+    private Connection openConnection() throws SQLException {
+        AuditPersistenceProperties.ResolvedConnection connection = persistenceProperties.resolveConnection();
+        return DriverManager.getConnection(connection.jdbcUrl(), connection.username(), connection.password());
+    }
+
+    private ProjectRecord toProject(ResultSet resultSet) throws SQLException {
+        return new ProjectRecord(
+                resultSet.getString("id"),
+                resultSet.getString("code"),
+                resultSet.getString("name"),
+                resultSet.getString("business_type"),
+                resultSet.getString("status"),
+                resultSet.getString("description"),
+                resultSet.getTimestamp("created_at").toLocalDateTime());
+    }
+
+    private ScenarioRecord toScenario(ResultSet resultSet) throws SQLException {
+        return new ScenarioRecord(
+                resultSet.getString("id"),
+                resultSet.getString("name"),
+                resultSet.getString("description"),
+                resultSet.getBoolean("is_baseline"),
+                resultSet.getBoolean("is_active"),
+                resultSet.getTimestamp("created_at").toLocalDateTime());
+    }
+
+    private String readGeneratedUuid(PreparedStatement statement) throws SQLException {
+        try (ResultSet keys = statement.getGeneratedKeys()) {
+            if (!keys.next()) {
+                throw new IllegalStateException("Failed to read generated id");
+            }
+            return keys.getObject(1).toString();
+        }
+    }
+
+    private UUID uuid(String value) {
+        return UUID.fromString(value);
+    }
+}

--- a/backend/src/main/java/com/costwise/persistence/PersistenceService.java
+++ b/backend/src/main/java/com/costwise/persistence/PersistenceService.java
@@ -14,12 +14,10 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Service;
 
@@ -39,143 +37,188 @@ public class PersistenceService {
     private static final Set<String> VALUATION_DECISIONS =
             Set.of("recommend", "review", "reject");
 
-    private final Map<String, ProjectState> projects = new ConcurrentHashMap<>();
-    private final Map<String, String> codeToProjectId = new ConcurrentHashMap<>();
+    private final ProjectPersistenceRepository projectRepository;
+    private final Map<String, ScenarioAnalysisState> scenarioAnalyses = new ConcurrentHashMap<>();
+    private final Map<String, ApprovalSummaryState> approvalSummaries = new ConcurrentHashMap<>();
+    private final Map<String, List<ApprovalLog>> approvalLogs = new ConcurrentHashMap<>();
+
+    public PersistenceService(ProjectPersistenceRepository projectRepository) {
+        this.projectRepository = projectRepository;
+    }
 
     public ProjectSummaryResponse createProject(CreateProjectRequest request) {
         String code = request.code().trim();
-        if (codeToProjectId.containsKey(code)) {
+        if (projectRepository.existsProjectCode(code)) {
             throw new IllegalArgumentException("Project code already exists: " + code);
         }
-        String id = UUID.randomUUID().toString();
-        LocalDateTime now = LocalDateTime.now();
-        ProjectState project = new ProjectState(
-                id, code, request.name().trim(), request.businessType().trim(), "draft", request.description(), now);
-        projects.put(id, project);
-        codeToProjectId.put(code, id);
+        ProjectPersistenceRepository.ProjectRecord project = projectRepository.createProject(
+                new ProjectPersistenceRepository.NewProject(
+                        code,
+                        request.name().trim(),
+                        request.businessType().trim(),
+                        "draft",
+                        request.description()));
+        approvalSummaries.put(project.id(), createdApprovalSummary(project.status(), project.createdAt()));
         return toProjectSummary(project);
     }
 
     public ProjectSummaryResponse updateProject(String projectId, UpdateProjectRequest request) {
-        ProjectState project = getProjectState(projectId);
+        ProjectPersistenceRepository.ProjectRecord currentProject = getProjectState(projectId);
         String status = normalizeEnum(request.status(), PROJECT_STATUSES, "project status");
-        project.name = request.name().trim();
-        project.businessType = request.businessType().trim();
-        project.description = request.description();
-        project.status = status;
-        project.approvalSummary.status = status;
-        project.approvalSummary.updatedAt = LocalDateTime.now();
+        ProjectPersistenceRepository.ProjectRecord project = projectRepository.updateProject(
+                new ProjectPersistenceRepository.ProjectUpdate(
+                        projectId,
+                        request.name().trim(),
+                        request.businessType().trim(),
+                        status,
+                        request.description()));
+        ApprovalSummaryState approvalSummary = approvalSummaries.computeIfAbsent(
+                projectId,
+                ignored -> createdApprovalSummary(currentProject.status(), currentProject.createdAt()));
+        approvalSummary.status = status;
+        approvalSummary.updatedAt = LocalDateTime.now();
         return toProjectSummary(project);
     }
 
     public void deleteProject(String projectId) {
-        ProjectState removed = projects.remove(projectId);
-        if (removed == null) {
-            throw new IllegalArgumentException("Unknown project id: " + projectId);
-        }
-        codeToProjectId.remove(removed.code);
+        projectRepository.deleteProject(projectId);
+        approvalSummaries.remove(projectId);
+        approvalLogs.remove(projectId);
+        scenarioAnalyses.keySet().removeIf(key -> key.startsWith(projectId + ":"));
     }
 
     public ScenarioResponse createScenario(String projectId, CreateScenarioRequest request) {
-        ProjectState project = getProjectState(projectId);
-        ensureScenarioNameUnique(project, request.name(), null);
-        ScenarioState scenario = new ScenarioState(
-                UUID.randomUUID().toString(),
-                request.name().trim(),
-                request.description(),
-                request.isBaseline(),
-                request.isActive(),
-                LocalDateTime.now());
-        project.scenarios.put(scenario.id, scenario);
+        getProjectState(projectId);
+        ensureScenarioNameUnique(projectId, request.name(), null);
+        ProjectPersistenceRepository.ScenarioRecord scenario = projectRepository.createScenario(
+                projectId,
+                new ProjectPersistenceRepository.NewScenario(
+                        request.name().trim(),
+                        request.description(),
+                        request.isBaseline(),
+                        request.isActive()));
         return toScenarioResponse(scenario);
     }
 
     public ScenarioResponse updateScenario(
             String projectId, String scenarioId, UpdateScenarioRequest request) {
-        ProjectState project = getProjectState(projectId);
-        ScenarioState scenario = getScenarioState(project, scenarioId);
-        ensureScenarioNameUnique(project, request.name(), scenarioId);
-        scenario.name = request.name().trim();
-        scenario.description = request.description();
-        scenario.isBaseline = request.isBaseline();
-        scenario.isActive = request.isActive();
+        getProjectState(projectId);
+        getScenarioState(projectId, scenarioId);
+        ensureScenarioNameUnique(projectId, request.name(), scenarioId);
+        ProjectPersistenceRepository.ScenarioRecord scenario = projectRepository.updateScenario(
+                projectId,
+                new ProjectPersistenceRepository.ScenarioUpdate(
+                        scenarioId,
+                        request.name().trim(),
+                        request.description(),
+                        request.isBaseline(),
+                        request.isActive()));
         return toScenarioResponse(scenario);
     }
 
     public void deleteScenario(String projectId, String scenarioId) {
-        ProjectState project = getProjectState(projectId);
-        ScenarioState removed = project.scenarios.remove(scenarioId);
-        if (removed == null) {
-            throw new IllegalArgumentException("Unknown scenario id: " + scenarioId);
-        }
+        getProjectState(projectId);
+        projectRepository.deleteScenario(projectId, scenarioId);
+        scenarioAnalyses.remove(analysisKey(projectId, scenarioId));
     }
 
     public AnalysisUpdateResponse upsertAnalysis(
             String projectId, String scenarioId, AnalysisUpsertRequest request) {
-        ProjectState project = getProjectState(projectId);
-        ScenarioState scenario = getScenarioState(project, scenarioId);
+        ProjectPersistenceRepository.ProjectRecord project = getProjectState(projectId);
+        getScenarioState(projectId, scenarioId);
 
-        scenario.allocationRules = request.allocationRules().stream()
-                .map(this::toAllocationRule)
-                .toList();
-        scenario.cashFlows = request.cashFlows().stream()
-                .map(this::toCashFlow)
-                .toList();
-        scenario.valuation = toValuation(request.valuation());
+        ScenarioAnalysisState analysis = new ScenarioAnalysisState(
+                request.allocationRules().stream()
+                        .map(this::toAllocationRule)
+                        .toList(),
+                request.cashFlows().stream()
+                        .map(this::toCashFlow)
+                        .toList(),
+                toValuation(request.valuation()));
+        scenarioAnalyses.put(analysisKey(projectId, scenarioId), analysis);
 
         ApprovalLog approvalLog = toApprovalLog(request.approval());
-        project.approvalSummary.status = normalizeEnum(
+        String projectStatus = normalizeEnum(
                 request.approval().projectStatus(), PROJECT_STATUSES, "project status");
-        project.approvalSummary.lastAction = approvalLog.action;
-        project.approvalSummary.lastActor = approvalLog.actorName;
-        project.approvalSummary.lastComment = approvalLog.comment;
-        project.approvalSummary.updatedAt = approvalLog.createdAt;
-        project.approvalLogs.add(approvalLog);
-        project.status = project.approvalSummary.status;
+        projectRepository.updateProject(new ProjectPersistenceRepository.ProjectUpdate(
+                projectId,
+                project.name(),
+                project.businessType(),
+                projectStatus,
+                project.description()));
+        ApprovalSummaryState approvalSummary = approvalSummaries.computeIfAbsent(
+                projectId,
+                ignored -> createdApprovalSummary(project.status(), project.createdAt()));
+        approvalSummary.status = projectStatus;
+        approvalSummary.lastAction = approvalLog.action;
+        approvalSummary.lastActor = approvalLog.actorName;
+        approvalSummary.lastComment = approvalLog.comment;
+        approvalSummary.updatedAt = approvalLog.createdAt;
+        approvalLogs.computeIfAbsent(projectId, ignored -> new ArrayList<>()).add(approvalLog);
 
-        return new AnalysisUpdateResponse(projectId, scenarioId, scenario.allocationRules.size(), scenario.cashFlows.size());
+        return new AnalysisUpdateResponse(projectId, scenarioId, analysis.allocationRules.size(), analysis.cashFlows.size());
     }
 
     public ProjectDetailResponse getProjectDetail(String projectId) {
-        ProjectState project = getProjectState(projectId);
-        List<ProjectDetailResponse.ScenarioDetailResponse> scenarios = project.scenarios.values().stream()
-                .map(this::toScenarioDetailResponse)
+        ProjectPersistenceRepository.ProjectRecord project = getProjectState(projectId);
+        List<ProjectDetailResponse.ScenarioDetailResponse> scenarios = projectRepository.listScenarios(projectId).stream()
+                .map(scenario -> toScenarioDetailResponse(projectId, scenario))
                 .toList();
-        List<ProjectDetailResponse.ApprovalEvent> logs = project.approvalLogs.stream()
+        List<ProjectDetailResponse.ApprovalEvent> logs = approvalLogs
+                .getOrDefault(projectId, List.of())
+                .stream()
                 .map(log -> new ProjectDetailResponse.ApprovalEvent(
                         log.actorRole, log.actorName, log.action, log.comment, log.createdAt))
                 .toList();
+        ApprovalSummaryState approvalSummaryState = approvalSummaries.computeIfAbsent(
+                projectId,
+                ignored -> createdApprovalSummary(project.status(), project.createdAt()));
         ProjectDetailResponse.ApprovalSummary approvalSummary = new ProjectDetailResponse.ApprovalSummary(
-                project.approvalSummary.status,
-                project.approvalSummary.lastAction,
-                project.approvalSummary.lastActor,
-                project.approvalSummary.lastComment,
-                project.approvalSummary.updatedAt,
+                approvalSummaryState.status,
+                approvalSummaryState.lastAction,
+                approvalSummaryState.lastActor,
+                approvalSummaryState.lastComment,
+                approvalSummaryState.updatedAt,
                 logs);
         return new ProjectDetailResponse(
-                project.id,
-                project.code,
-                project.name,
-                project.businessType,
-                project.status,
-                project.description,
-                project.createdAt,
+                project.id(),
+                project.code(),
+                project.name(),
+                project.businessType(),
+                project.status(),
+                project.description(),
+                project.createdAt(),
                 scenarios,
                 approvalSummary);
     }
 
-    private ProjectSummaryResponse toProjectSummary(ProjectState project) {
+    private ProjectSummaryResponse toProjectSummary(ProjectPersistenceRepository.ProjectRecord project) {
         return new ProjectSummaryResponse(
-                project.id, project.code, project.name, project.businessType, project.status, project.description, project.createdAt);
+                project.id(),
+                project.code(),
+                project.name(),
+                project.businessType(),
+                project.status(),
+                project.description(),
+                project.createdAt());
     }
 
-    private ScenarioResponse toScenarioResponse(ScenarioState scenario) {
+    private ScenarioResponse toScenarioResponse(ProjectPersistenceRepository.ScenarioRecord scenario) {
         return new ScenarioResponse(
-                scenario.id, scenario.name, scenario.description, scenario.isBaseline, scenario.isActive, scenario.createdAt);
+                scenario.id(),
+                scenario.name(),
+                scenario.description(),
+                scenario.isBaseline(),
+                scenario.isActive(),
+                scenario.createdAt());
     }
 
-    private ProjectDetailResponse.ScenarioDetailResponse toScenarioDetailResponse(ScenarioState scenario) {
-        List<ProjectDetailResponse.AllocationRule> allocations = scenario.allocationRules.stream()
+    private ProjectDetailResponse.ScenarioDetailResponse toScenarioDetailResponse(
+            String projectId, ProjectPersistenceRepository.ScenarioRecord scenario) {
+        ScenarioAnalysisState analysis = scenarioAnalyses.getOrDefault(
+                analysisKey(projectId, scenario.id()),
+                ScenarioAnalysisState.empty());
+        List<ProjectDetailResponse.AllocationRule> allocations = analysis.allocationRules.stream()
                 .map(value -> new ProjectDetailResponse.AllocationRule(
                         value.departmentCode,
                         value.basis,
@@ -185,7 +228,7 @@ public class PersistenceService {
                         value.costPoolCategory,
                         value.costPoolAmount))
                 .toList();
-        List<ProjectDetailResponse.CashFlow> cashFlows = scenario.cashFlows.stream()
+        List<ProjectDetailResponse.CashFlow> cashFlows = analysis.cashFlows.stream()
                 .map(value -> new ProjectDetailResponse.CashFlow(
                         value.periodNo,
                         value.periodLabel,
@@ -196,22 +239,22 @@ public class PersistenceService {
                         value.netCashFlow,
                         value.discountRate))
                 .toList();
-        ProjectDetailResponse.Valuation valuation = scenario.valuation == null
+        ProjectDetailResponse.Valuation valuation = analysis.valuation == null
                 ? null
                 : new ProjectDetailResponse.Valuation(
-                        scenario.valuation.discountRate,
-                        scenario.valuation.npv,
-                        scenario.valuation.irr,
-                        scenario.valuation.paybackPeriod,
-                        scenario.valuation.decision,
-                        scenario.valuation.assumptions);
+                        analysis.valuation.discountRate,
+                        analysis.valuation.npv,
+                        analysis.valuation.irr,
+                        analysis.valuation.paybackPeriod,
+                        analysis.valuation.decision,
+                        analysis.valuation.assumptions);
         return new ProjectDetailResponse.ScenarioDetailResponse(
-                scenario.id,
-                scenario.name,
-                scenario.description,
-                scenario.isBaseline,
-                scenario.isActive,
-                scenario.createdAt,
+                scenario.id(),
+                scenario.name(),
+                scenario.description(),
+                scenario.isBaseline(),
+                scenario.isActive(),
+                scenario.createdAt(),
                 allocations,
                 cashFlows,
                 valuation);
@@ -278,27 +321,19 @@ public class PersistenceService {
         return new ApprovalLog(actorRole, input.actorName().trim(), action, input.comment(), LocalDateTime.now());
     }
 
-    private ProjectState getProjectState(String projectId) {
-        ProjectState project = projects.get(projectId);
-        if (project == null) {
-            throw new IllegalArgumentException("Unknown project id: " + projectId);
-        }
-        return project;
+    private ProjectPersistenceRepository.ProjectRecord getProjectState(String projectId) {
+        return projectRepository.findProject(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown project id: " + projectId));
     }
 
-    private ScenarioState getScenarioState(ProjectState project, String scenarioId) {
-        ScenarioState scenario = project.scenarios.get(scenarioId);
-        if (scenario == null) {
-            throw new IllegalArgumentException("Unknown scenario id: " + scenarioId);
-        }
-        return scenario;
+    private ProjectPersistenceRepository.ScenarioRecord getScenarioState(String projectId, String scenarioId) {
+        return projectRepository.findScenario(projectId, scenarioId)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown scenario id: " + scenarioId));
     }
 
-    private void ensureScenarioNameUnique(ProjectState project, String candidateName, String skipScenarioId) {
+    private void ensureScenarioNameUnique(String projectId, String candidateName, String skipScenarioId) {
         String normalized = candidateName.trim().toLowerCase(Locale.ROOT);
-        boolean duplicated = project.scenarios.values().stream()
-                .anyMatch(s -> !s.id.equals(skipScenarioId) && s.name.trim().toLowerCase(Locale.ROOT).equals(normalized));
-        if (duplicated) {
+        if (projectRepository.existsScenarioName(projectId, normalized, skipScenarioId)) {
             throw new IllegalArgumentException("Scenario name already exists in project: " + candidateName);
         }
     }
@@ -311,65 +346,27 @@ public class PersistenceService {
         return normalized;
     }
 
-    private static final class ProjectState {
-        private final String id;
-        private final String code;
-        private String name;
-        private String businessType;
-        private String status;
-        private String description;
-        private final LocalDateTime createdAt;
-        private final Map<String, ScenarioState> scenarios = new LinkedHashMap<>();
-        private final ApprovalSummaryState approvalSummary = new ApprovalSummaryState();
-        private final List<ApprovalLog> approvalLogs = new ArrayList<>();
-
-        private ProjectState(
-                String id,
-                String code,
-                String name,
-                String businessType,
-                String status,
-                String description,
-                LocalDateTime createdAt) {
-            this.id = id;
-            this.code = code;
-            this.name = name;
-            this.businessType = businessType;
-            this.status = status;
-            this.description = description;
-            this.createdAt = createdAt;
-            this.approvalSummary.status = status;
-            this.approvalSummary.lastAction = "created";
-            this.approvalSummary.lastActor = "system";
-            this.approvalSummary.lastComment = "project created";
-            this.approvalSummary.updatedAt = createdAt;
-        }
+    private ApprovalSummaryState createdApprovalSummary(String status, LocalDateTime createdAt) {
+        ApprovalSummaryState approvalSummary = new ApprovalSummaryState();
+        approvalSummary.status = status;
+        approvalSummary.lastAction = "created";
+        approvalSummary.lastActor = "system";
+        approvalSummary.lastComment = "project created";
+        approvalSummary.updatedAt = createdAt;
+        return approvalSummary;
     }
 
-    private static final class ScenarioState {
-        private final String id;
-        private String name;
-        private String description;
-        private boolean isBaseline;
-        private boolean isActive;
-        private final LocalDateTime createdAt;
-        private List<AllocationRuleState> allocationRules = List.of();
-        private List<CashFlowState> cashFlows = List.of();
-        private ValuationState valuation;
+    private String analysisKey(String projectId, String scenarioId) {
+        return projectId + ":" + scenarioId;
+    }
 
-        private ScenarioState(
-                String id,
-                String name,
-                String description,
-                boolean isBaseline,
-                boolean isActive,
-                LocalDateTime createdAt) {
-            this.id = id;
-            this.name = name;
-            this.description = description;
-            this.isBaseline = isBaseline;
-            this.isActive = isActive;
-            this.createdAt = createdAt;
+    private record ScenarioAnalysisState(
+            List<AllocationRuleState> allocationRules,
+            List<CashFlowState> cashFlows,
+            ValuationState valuation) {
+
+        private static ScenarioAnalysisState empty() {
+            return new ScenarioAnalysisState(List.of(), List.of(), null);
         }
     }
 

--- a/backend/src/main/java/com/costwise/persistence/ProjectPersistenceRepository.java
+++ b/backend/src/main/java/com/costwise/persistence/ProjectPersistenceRepository.java
@@ -1,0 +1,65 @@
+package com.costwise.persistence;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface ProjectPersistenceRepository {
+
+    ProjectRecord createProject(NewProject project);
+
+    ProjectRecord updateProject(ProjectUpdate project);
+
+    void deleteProject(String projectId);
+
+    Optional<ProjectRecord> findProject(String projectId);
+
+    boolean existsProjectCode(String code);
+
+    ScenarioRecord createScenario(String projectId, NewScenario scenario);
+
+    ScenarioRecord updateScenario(String projectId, ScenarioUpdate scenario);
+
+    void deleteScenario(String projectId, String scenarioId);
+
+    Optional<ScenarioRecord> findScenario(String projectId, String scenarioId);
+
+    List<ScenarioRecord> listScenarios(String projectId);
+
+    boolean existsScenarioName(String projectId, String normalizedName, String skipScenarioId);
+
+    record NewProject(String code, String name, String businessType, String status, String description) {}
+
+    record ProjectUpdate(
+            String id,
+            String name,
+            String businessType,
+            String status,
+            String description) {}
+
+    record ProjectRecord(
+            String id,
+            String code,
+            String name,
+            String businessType,
+            String status,
+            String description,
+            LocalDateTime createdAt) {}
+
+    record NewScenario(String name, String description, boolean isBaseline, boolean isActive) {}
+
+    record ScenarioUpdate(
+            String id,
+            String name,
+            String description,
+            boolean isBaseline,
+            boolean isActive) {}
+
+    record ScenarioRecord(
+            String id,
+            String name,
+            String description,
+            boolean isBaseline,
+            boolean isActive,
+            LocalDateTime createdAt) {}
+}

--- a/backend/src/test/java/com/costwise/api/persistence/PersistenceControllerTest.java
+++ b/backend/src/test/java/com/costwise/api/persistence/PersistenceControllerTest.java
@@ -9,12 +9,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import com.costwise.api.support.JsonFieldReader;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -31,7 +35,10 @@ import org.springframework.test.web.servlet.MvcResult;
 @SpringBootTest(properties = {
     "app.security.jwt.issuer-uri=https://example.supabase.co/auth/v1",
     "app.security.jwt.audience=authenticated",
-    "app.security.jwt.secret-base64=c3VwYWJhc2UtYmVhcmVyLXRlc3Qtc2VjcmV0LXN1cHBvcnQ="
+    "app.security.jwt.secret-base64=c3VwYWJhc2UtYmVhcmVyLXRlc3Qtc2VjcmV0LXN1cHBvcnQ=",
+    "app.persistence.jdbc-url=jdbc:h2:mem:persistence-controller;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE",
+    "app.persistence.username=sa",
+    "app.persistence.password="
 })
 @AutoConfigureMockMvc
 class PersistenceControllerTest {
@@ -42,6 +49,41 @@ class PersistenceControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @BeforeEach
+    void createSchema() throws Exception {
+        try (Connection connection = DriverManager.getConnection(
+                        "jdbc:h2:mem:persistence-controller;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE",
+                        "sa",
+                        "");
+                Statement statement = connection.createStatement()) {
+            statement.execute("drop table if exists scenarios");
+            statement.execute("drop table if exists projects");
+            statement.execute("""
+                    create table projects (
+                      id uuid default random_uuid() primary key,
+                      code text not null unique,
+                      name text not null,
+                      business_type text not null default 'new_business',
+                      status text not null default 'draft',
+                      description text,
+                      created_at timestamp not null default current_timestamp
+                    )
+                    """);
+            statement.execute("""
+                    create table scenarios (
+                      id uuid default random_uuid() primary key,
+                      project_id uuid not null references projects (id) on delete cascade,
+                      name text not null,
+                      description text,
+                      is_baseline boolean not null default false,
+                      is_active boolean not null default true,
+                      created_at timestamp not null default current_timestamp,
+                      unique (project_id, name)
+                    )
+                    """);
+        }
+    }
 
     @Test
     void projectScenarioCrudAndAnalysisPersistenceFlow() throws Exception {

--- a/backend/src/test/java/com/costwise/persistence/JdbcProjectPersistenceRepositoryTest.java
+++ b/backend/src/test/java/com/costwise/persistence/JdbcProjectPersistenceRepositoryTest.java
@@ -1,0 +1,148 @@
+package com.costwise.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.costwise.api.dto.persistence.CreateProjectRequest;
+import com.costwise.api.dto.persistence.CreateScenarioRequest;
+import com.costwise.api.dto.persistence.UpdateProjectRequest;
+import com.costwise.api.dto.persistence.UpdateScenarioRequest;
+import com.costwise.config.AuditPersistenceProperties;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import org.junit.jupiter.api.Test;
+
+class JdbcProjectPersistenceRepositoryTest {
+
+    @Test
+    void projectsAndScenariosAreReadableAcrossServiceRecreation() throws Exception {
+        String jdbcUrl = "jdbc:h2:mem:persistence-restart;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE";
+        createSchema(jdbcUrl);
+        AuditPersistenceProperties properties = new AuditPersistenceProperties(null, jdbcUrl, "sa", "", "disable");
+
+        PersistenceService writer = new PersistenceService(new JdbcProjectPersistenceRepository(properties));
+        var project = writer.createProject(new CreateProjectRequest(
+                "PJT-DB-001",
+                "DB 저장 프로젝트",
+                "new_business",
+                "restart test"));
+        var scenario = writer.createScenario(project.id(), new CreateScenarioRequest(
+                "Base",
+                "기준 시나리오",
+                true,
+                true));
+
+        PersistenceService reader = new PersistenceService(new JdbcProjectPersistenceRepository(properties));
+        var detail = reader.getProjectDetail(project.id());
+
+        assertThat(detail.code()).isEqualTo("PJT-DB-001");
+        assertThat(detail.name()).isEqualTo("DB 저장 프로젝트");
+        assertThat(detail.approval().status()).isEqualTo("draft");
+        assertThat(detail.approval().lastAction()).isEqualTo("created");
+        assertThat(detail.scenarios()).hasSize(1);
+        assertThat(detail.scenarios().getFirst().id()).isEqualTo(scenario.id());
+        assertThat(detail.scenarios().getFirst().name()).isEqualTo("Base");
+    }
+
+    @Test
+    void projectAndScenarioCrudUseDatabaseState() throws Exception {
+        String jdbcUrl = "jdbc:h2:mem:persistence-crud;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE";
+        createSchema(jdbcUrl);
+        AuditPersistenceProperties properties = new AuditPersistenceProperties(null, jdbcUrl, "sa", "", "disable");
+        PersistenceService service = new PersistenceService(new JdbcProjectPersistenceRepository(properties));
+
+        var project = service.createProject(new CreateProjectRequest(
+                "PJT-DB-002",
+                "초기 프로젝트",
+                "new_business",
+                "before update"));
+        var updatedProject = service.updateProject(project.id(), new UpdateProjectRequest(
+                "수정 프로젝트",
+                "renewal",
+                "after update",
+                "in_review"));
+
+        assertThat(updatedProject.name()).isEqualTo("수정 프로젝트");
+        assertThat(service.getProjectDetail(project.id()).approval().status()).isEqualTo("in_review");
+
+        var scenario = service.createScenario(project.id(), new CreateScenarioRequest(
+                "Base",
+                "before update",
+                true,
+                true));
+        var updatedScenario = service.updateScenario(project.id(), scenario.id(), new UpdateScenarioRequest(
+                "Stress",
+                "after update",
+                false,
+                false));
+
+        assertThat(updatedScenario.name()).isEqualTo("Stress");
+        assertThat(service.getProjectDetail(project.id()).scenarios().getFirst().isActive()).isFalse();
+
+        service.deleteScenario(project.id(), scenario.id());
+        assertThat(service.getProjectDetail(project.id()).scenarios()).isEmpty();
+
+        service.deleteProject(project.id());
+        assertThatThrownBy(() -> service.getProjectDetail(project.id()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown project id");
+    }
+
+    @Test
+    void duplicateProjectCodeAndScenarioNameAreRejectedByDatabaseBackedService() throws Exception {
+        String jdbcUrl = "jdbc:h2:mem:persistence-duplicates;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE";
+        createSchema(jdbcUrl);
+        AuditPersistenceProperties properties = new AuditPersistenceProperties(null, jdbcUrl, "sa", "", "disable");
+        PersistenceService service = new PersistenceService(new JdbcProjectPersistenceRepository(properties));
+
+        var project = service.createProject(new CreateProjectRequest(
+                "PJT-DB-003",
+                "중복 테스트",
+                "new_business",
+                null));
+        service.createScenario(project.id(), new CreateScenarioRequest("Base", null, true, true));
+
+        assertThatThrownBy(() -> service.createProject(new CreateProjectRequest(
+                        "PJT-DB-003",
+                        "중복 프로젝트",
+                        "new_business",
+                        null)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Project code already exists");
+        assertThatThrownBy(() -> service.createScenario(
+                        project.id(),
+                        new CreateScenarioRequest("base", null, false, true)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Scenario name already exists");
+    }
+
+    private void createSchema(String jdbcUrl) throws Exception {
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, "sa", "");
+                Statement statement = connection.createStatement()) {
+            statement.execute("""
+                    create table projects (
+                      id uuid default random_uuid() primary key,
+                      code text not null unique,
+                      name text not null,
+                      business_type text not null default 'new_business',
+                      status text not null default 'draft',
+                      description text,
+                      created_at timestamp not null default current_timestamp
+                    )
+                    """);
+            statement.execute("""
+                    create table scenarios (
+                      id uuid default random_uuid() primary key,
+                      project_id uuid not null references projects (id) on delete cascade,
+                      name text not null,
+                      description text,
+                      is_baseline boolean not null default false,
+                      is_active boolean not null default true,
+                      created_at timestamp not null default current_timestamp,
+                      unique (project_id, name)
+                    )
+                    """);
+        }
+    }
+}

--- a/docs/dev-logs/2026-04-22-project-scenario-persistence.md
+++ b/docs/dev-logs/2026-04-22-project-scenario-persistence.md
@@ -1,0 +1,35 @@
+# Project And Scenario Persistence
+
+## Branch
+
+- Worktree: `.worktrees/feat-50-project-scenario-persistence`
+- Branch: `feat/50-project-scenario-persistence`
+- Base: `dev`
+- Related issue: `#50`
+
+## Comparison
+
+- Option A: convert projects, scenarios, analysis rows, valuation results, and approval history in one large PR.
+- Option B: create a DB-backed repository boundary and move project/scenario CRUD first, leaving analysis persistence for a follow-up slice.
+
+Option B was selected because it creates a durable foundation while keeping the first PR reviewable. Analysis persistence needs additional read-model reconstruction across `allocation_rules`, `cash_flows`, `valuation_results`, and `approval_logs`, so it should be handled as the next focused slice.
+
+## Changes
+
+- Added `ProjectPersistenceRepository` as the service-facing persistence boundary.
+- Added `JdbcProjectPersistenceRepository` using the existing `app.persistence` JDBC/Supabase connection settings.
+- Moved project and scenario create/update/delete/detail reads from `ConcurrentHashMap` state into database-backed storage.
+- Kept in-process analysis payload state as a temporary compatibility bridge for this slice.
+- Added restart-style repository tests proving project/scenario data survives service recreation.
+- Updated persistence controller tests to run against an H2 schema.
+
+## Validation
+
+- `.\gradlew.bat test --tests com.costwise.persistence.JdbcProjectPersistenceRepositoryTest`
+- `.\gradlew.bat test --tests com.costwise.api.persistence.PersistenceControllerTest --tests com.costwise.persistence.JdbcProjectPersistenceRepositoryTest`
+- `.\gradlew.bat check`
+
+## Follow-Up
+
+- Persist allocation rules, cash flows, valuation results, and approval logs into the existing Supabase tables.
+- Rebuild project detail responses from those persisted analysis tables after restart.


### PR DESCRIPTION
## 요약

#50의 첫 번째 슬라이스로 프로젝트/시나리오 CRUD를 DB-backed 저장소로 전환했습니다. 분석 결과 전체 영속화는 다음 슬라이스로 분리하고, 이번 PR은 저장소 경계와 재시작 후 프로젝트/시나리오 조회 가능성을 검증하는 데 집중했습니다.

## 변경 내용

- `ProjectPersistenceRepository` 인터페이스 추가
- `JdbcProjectPersistenceRepository` 추가: 기존 `app.persistence` JDBC/Supabase 설정을 사용
- `PersistenceService`의 프로젝트/시나리오 생성, 수정, 삭제, 상세 조회를 DB 저장소 기반으로 전환
- 기존 분석 payload는 이번 슬라이스에서 임시 in-process compatibility state로 유지
- 서비스 재생성 후에도 프로젝트/시나리오를 DB에서 다시 읽는 repository 테스트 추가
- persistence controller 테스트를 H2 schema 기반으로 업데이트
- `docs/dev-logs/2026-04-22-project-scenario-persistence.md`에 워킹트리 비교와 선택 이유 기록

## 이유

현재 persistence 흐름은 `ConcurrentHashMap` 기반이라 서버 재시작 시 프로젝트/시나리오 데이터가 사라집니다. #50 전체 범위는 분석 테이블까지 포함해 크므로, 먼저 프로젝트/시나리오 저장 경계를 DB로 옮겨 실제 Supabase/Postgres 전환의 기반을 만들었습니다.

## 이슈 체크리스트

- [x] `PersistenceService`를 DB 기반 저장 구조로 전환 시작
- [x] 프로젝트 생성/수정/조회/삭제가 DB에 반영됨
- [x] 시나리오 생성/수정/조회/삭제가 DB에 반영됨
- [x] 프로젝트/시나리오가 서비스 재생성 후에도 유지됨
- [x] 기존 migration의 `projects`, `scenarios` 테이블과 서비스/DTO 정합성 점검
- [x] CRUD 및 재시작형 저장 테스트 추가
- [ ] 배부규칙, 현금흐름, 평가결과, 승인 이력 DB 저장 연결
- [ ] 분석 결과가 재시작 후에도 유지됨
- [ ] 인메모리 분석 상태 제거

## 검증

- [x] 관련 테스트를 실행했습니다.
  - `.\gradlew.bat test --tests com.costwise.persistence.JdbcProjectPersistenceRepositoryTest`
  - `.\gradlew.bat test --tests com.costwise.api.persistence.PersistenceControllerTest --tests com.costwise.persistence.JdbcProjectPersistenceRepositoryTest`
  - `.\gradlew.bat check`
  - 커밋 시 pre-commit backend Gradle check 통과
- [x] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
  - MockMvc persistence API flow로 프로젝트/시나리오 CRUD와 분석 compatibility path 확인
- [x] 인접한 흐름에서 회귀가 없는지 확인했습니다.
  - 전체 backend `check` 통과

## 스크린샷 또는 로그

화면 변경은 없습니다. 검증 로그는 로컬 Gradle 실행 결과와 pre-commit 결과로 확인했습니다.

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [x] 후속 작업이 필요하면 별도 이슈로 분리했습니다.

## 브랜치

- [x] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
- [x] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.