### PR TITLE
feat: 분석 결과 DB 영속화 및 재구성

### DIFF
--- a/backend/src/main/java/com/costwise/persistence/JdbcProjectPersistenceRepository.java
+++ b/backend/src/main/java/com/costwise/persistence/JdbcProjectPersistenceRepository.java
@@ -1,6 +1,9 @@
 package com.costwise.persistence;
 
 import com.costwise.config.AuditPersistenceProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -12,15 +15,24 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class JdbcProjectPersistenceRepository implements ProjectPersistenceRepository {
 
     private final AuditPersistenceProperties persistenceProperties;
+    private final ObjectMapper objectMapper;
 
     public JdbcProjectPersistenceRepository(AuditPersistenceProperties persistenceProperties) {
+        this(persistenceProperties, new ObjectMapper());
+    }
+
+    @Autowired
+    public JdbcProjectPersistenceRepository(
+            AuditPersistenceProperties persistenceProperties, ObjectMapper objectMapper) {
         this.persistenceProperties = persistenceProperties;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -174,13 +186,22 @@ public class JdbcProjectPersistenceRepository implements ProjectPersistenceRepos
     @Override
     public void deleteScenario(String projectId, String scenarioId) {
         String sql = "delete from scenarios where project_id = ? and id = ?";
-        try (Connection connection = openConnection();
-                PreparedStatement statement = connection.prepareStatement(sql)) {
-            statement.setObject(1, uuid(projectId));
-            statement.setObject(2, uuid(scenarioId));
-            int deleted = statement.executeUpdate();
-            if (deleted == 0) {
-                throw new IllegalArgumentException("Unknown scenario id: " + scenarioId);
+        try (Connection connection = openConnection()) {
+            connection.setAutoCommit(false);
+            try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                deleteScenarioAnalysis(connection, projectId, scenarioId);
+                statement.setObject(1, uuid(projectId));
+                statement.setObject(2, uuid(scenarioId));
+                int deleted = statement.executeUpdate();
+                if (deleted == 0) {
+                    throw new IllegalArgumentException("Unknown scenario id: " + scenarioId);
+                }
+                connection.commit();
+            } catch (SQLException | RuntimeException exception) {
+                connection.rollback();
+                throw exception;
+            } finally {
+                connection.setAutoCommit(true);
             }
         } catch (SQLException exception) {
             throw new IllegalStateException("Failed to delete scenario", exception);
@@ -259,6 +280,73 @@ public class JdbcProjectPersistenceRepository implements ProjectPersistenceRepos
         }
     }
 
+    @Override
+    public void upsertAnalysis(
+            String projectId, String scenarioId, AnalysisRecord analysis, ApprovalLogRecord approvalLog) {
+        try (Connection connection = openConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                deleteScenarioAnalysis(connection, projectId, scenarioId);
+                for (AllocationRuleRecord allocation : analysis.allocationRules()) {
+                    String departmentId = upsertDepartment(connection, allocation.departmentCode());
+                    String costPoolId = insertCostPool(connection, projectId, scenarioId, allocation);
+                    insertAllocationRule(connection, projectId, scenarioId, departmentId, costPoolId, allocation);
+                }
+                for (CashFlowRecord cashFlow : analysis.cashFlows()) {
+                    insertCashFlow(connection, projectId, scenarioId, cashFlow);
+                }
+                if (analysis.valuation() != null) {
+                    insertValuation(connection, projectId, scenarioId, analysis.valuation());
+                }
+                insertApprovalLog(connection, projectId, scenarioId, approvalLog);
+                connection.commit();
+            } catch (SQLException | RuntimeException exception) {
+                connection.rollback();
+                throw exception;
+            } finally {
+                connection.setAutoCommit(true);
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to upsert analysis", exception);
+        }
+    }
+
+    @Override
+    public AnalysisRecord findAnalysis(String projectId, String scenarioId) {
+        return new AnalysisRecord(
+                listAllocationRules(projectId, scenarioId),
+                listCashFlows(projectId, scenarioId),
+                findValuation(projectId, scenarioId).orElse(null));
+    }
+
+    @Override
+    public List<ApprovalLogRecord> listApprovalLogs(String projectId) {
+        String sql = """
+                select actor_role, actor_name, action, comment, created_at
+                  from approval_logs
+                 where project_id = ?
+                 order by created_at asc, id asc
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, uuid(projectId));
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<ApprovalLogRecord> logs = new ArrayList<>();
+                while (resultSet.next()) {
+                    logs.add(new ApprovalLogRecord(
+                            resultSet.getString("actor_role"),
+                            resultSet.getString("actor_name"),
+                            resultSet.getString("action"),
+                            resultSet.getString("comment"),
+                            resultSet.getTimestamp("created_at").toLocalDateTime()));
+                }
+                return logs;
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to list approval logs", exception);
+        }
+    }
+
     private Connection openConnection() throws SQLException {
         AuditPersistenceProperties.ResolvedConnection connection = persistenceProperties.resolveConnection();
         return DriverManager.getConnection(connection.jdbcUrl(), connection.username(), connection.password());
@@ -283,6 +371,274 @@ public class JdbcProjectPersistenceRepository implements ProjectPersistenceRepos
                 resultSet.getBoolean("is_baseline"),
                 resultSet.getBoolean("is_active"),
                 resultSet.getTimestamp("created_at").toLocalDateTime());
+    }
+
+    private void deleteScenarioAnalysis(Connection connection, String projectId, String scenarioId) throws SQLException {
+        deleteByScenario(connection, "allocation_rules", projectId, scenarioId);
+        deleteByScenario(connection, "cost_pools", projectId, scenarioId);
+        deleteByScenario(connection, "cash_flows", projectId, scenarioId);
+        deleteByScenario(connection, "valuation_results", projectId, scenarioId);
+    }
+
+    private void deleteByScenario(Connection connection, String table, String projectId, String scenarioId)
+            throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "delete from " + table + " where project_id = ? and scenario_id = ?")) {
+            statement.setObject(1, uuid(projectId));
+            statement.setObject(2, uuid(scenarioId));
+            statement.executeUpdate();
+        }
+    }
+
+    private String upsertDepartment(Connection connection, String departmentCode) throws SQLException {
+        String insert = """
+                insert into departments (code, name)
+                select ?, ?
+                 where not exists (select 1 from departments where code = ?)
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(insert)) {
+            statement.setString(1, departmentCode);
+            statement.setString(2, departmentCode);
+            statement.setString(3, departmentCode);
+            statement.executeUpdate();
+        }
+        try (PreparedStatement statement = connection.prepareStatement("select id from departments where code = ?")) {
+            statement.setString(1, departmentCode);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    throw new IllegalStateException("Failed to resolve department: " + departmentCode);
+                }
+                return resultSet.getString("id");
+            }
+        }
+    }
+
+    private String insertCostPool(
+            Connection connection, String projectId, String scenarioId, AllocationRuleRecord allocation)
+            throws SQLException {
+        String sql = """
+                insert into cost_pools (project_id, scenario_id, name, category, amount)
+                values (?, ?, ?, ?, ?)
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            statement.setObject(1, uuid(projectId));
+            statement.setObject(2, uuid(scenarioId));
+            statement.setString(3, allocation.costPoolName());
+            statement.setString(4, allocation.costPoolCategory());
+            statement.setBigDecimal(5, allocation.costPoolAmount());
+            statement.executeUpdate();
+            return readGeneratedUuid(statement);
+        }
+    }
+
+    private void insertAllocationRule(
+            Connection connection,
+            String projectId,
+            String scenarioId,
+            String departmentId,
+            String costPoolId,
+            AllocationRuleRecord allocation)
+            throws SQLException {
+        String sql = """
+                insert into allocation_rules (
+                    project_id, scenario_id, cost_pool_id, department_id, basis, allocation_rate, allocated_amount
+                ) values (?, ?, ?, ?, ?, ?, ?)
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, uuid(projectId));
+            statement.setObject(2, uuid(scenarioId));
+            statement.setObject(3, uuid(costPoolId));
+            statement.setObject(4, uuid(departmentId));
+            statement.setString(5, allocation.basis());
+            statement.setBigDecimal(6, allocation.allocationRate());
+            statement.setBigDecimal(7, allocation.allocatedAmount());
+            statement.executeUpdate();
+        }
+    }
+
+    private void insertCashFlow(Connection connection, String projectId, String scenarioId, CashFlowRecord cashFlow)
+            throws SQLException {
+        String sql = """
+                insert into cash_flows (
+                    project_id, scenario_id, period_no, period_label, year_label,
+                    operating_cash_flow, investment_cash_flow, financing_cash_flow, net_cash_flow, discount_rate
+                ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, uuid(projectId));
+            statement.setObject(2, uuid(scenarioId));
+            statement.setInt(3, cashFlow.periodNo());
+            statement.setString(4, cashFlow.periodLabel());
+            statement.setString(5, cashFlow.yearLabel());
+            statement.setBigDecimal(6, cashFlow.operatingCashFlow());
+            statement.setBigDecimal(7, cashFlow.investmentCashFlow());
+            statement.setBigDecimal(8, cashFlow.financingCashFlow());
+            statement.setBigDecimal(9, cashFlow.netCashFlow());
+            statement.setBigDecimal(10, cashFlow.discountRate());
+            statement.executeUpdate();
+        }
+    }
+
+    private void insertValuation(
+            Connection connection, String projectId, String scenarioId, ValuationRecord valuation)
+            throws SQLException {
+        String sql = """
+                insert into valuation_results (
+                    project_id, scenario_id, discount_rate, npv, irr, payback_period, decision, assumptions
+                ) values (?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, uuid(projectId));
+            statement.setObject(2, uuid(scenarioId));
+            statement.setBigDecimal(3, valuation.discountRate());
+            statement.setBigDecimal(4, valuation.npv());
+            statement.setBigDecimal(5, valuation.irr());
+            statement.setBigDecimal(6, valuation.paybackPeriod());
+            statement.setString(7, valuation.decision());
+            statement.setString(8, toJson(valuation.assumptions()));
+            statement.executeUpdate();
+        }
+    }
+
+    private void insertApprovalLog(
+            Connection connection, String projectId, String scenarioId, ApprovalLogRecord approvalLog)
+            throws SQLException {
+        String sql = """
+                insert into approval_logs (project_id, scenario_id, actor_role, actor_name, action, comment, created_at)
+                values (?, ?, ?, ?, ?, ?, ?)
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, uuid(projectId));
+            statement.setObject(2, uuid(scenarioId));
+            statement.setString(3, approvalLog.actorRole());
+            statement.setString(4, approvalLog.actorName());
+            statement.setString(5, approvalLog.action());
+            statement.setString(6, approvalLog.comment());
+            statement.setTimestamp(7, Timestamp.valueOf(approvalLog.createdAt()));
+            statement.executeUpdate();
+        }
+    }
+
+    private List<AllocationRuleRecord> listAllocationRules(String projectId, String scenarioId) {
+        String sql = """
+                select d.code as department_code,
+                       ar.basis,
+                       ar.allocation_rate,
+                       ar.allocated_amount,
+                       cp.name as cost_pool_name,
+                       cp.category as cost_pool_category,
+                       cp.amount as cost_pool_amount
+                  from allocation_rules ar
+                  join departments d on d.id = ar.department_id
+                  join cost_pools cp on cp.id = ar.cost_pool_id
+                 where ar.project_id = ?
+                   and ar.scenario_id = ?
+                 order by ar.created_at asc, d.code asc, cp.name asc
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, uuid(projectId));
+            statement.setObject(2, uuid(scenarioId));
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<AllocationRuleRecord> allocations = new ArrayList<>();
+                while (resultSet.next()) {
+                    allocations.add(new AllocationRuleRecord(
+                            resultSet.getString("department_code"),
+                            resultSet.getString("basis"),
+                            resultSet.getBigDecimal("allocation_rate"),
+                            resultSet.getBigDecimal("allocated_amount"),
+                            resultSet.getString("cost_pool_name"),
+                            resultSet.getString("cost_pool_category"),
+                            resultSet.getBigDecimal("cost_pool_amount")));
+                }
+                return allocations;
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to list allocation rules", exception);
+        }
+    }
+
+    private List<CashFlowRecord> listCashFlows(String projectId, String scenarioId) {
+        String sql = """
+                select period_no,
+                       period_label,
+                       year_label,
+                       operating_cash_flow,
+                       investment_cash_flow,
+                       financing_cash_flow,
+                       net_cash_flow,
+                       discount_rate
+                  from cash_flows
+                 where project_id = ?
+                   and scenario_id = ?
+                 order by period_no asc
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, uuid(projectId));
+            statement.setObject(2, uuid(scenarioId));
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<CashFlowRecord> cashFlows = new ArrayList<>();
+                while (resultSet.next()) {
+                    cashFlows.add(new CashFlowRecord(
+                            resultSet.getInt("period_no"),
+                            resultSet.getString("period_label"),
+                            resultSet.getString("year_label"),
+                            resultSet.getBigDecimal("operating_cash_flow"),
+                            resultSet.getBigDecimal("investment_cash_flow"),
+                            resultSet.getBigDecimal("financing_cash_flow"),
+                            resultSet.getBigDecimal("net_cash_flow"),
+                            resultSet.getBigDecimal("discount_rate")));
+                }
+                return cashFlows;
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to list cash flows", exception);
+        }
+    }
+
+    private Optional<ValuationRecord> findValuation(String projectId, String scenarioId) {
+        String sql = """
+                select discount_rate, npv, irr, payback_period, decision, assumptions
+                  from valuation_results
+                 where project_id = ?
+                   and scenario_id = ?
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, uuid(projectId));
+            statement.setObject(2, uuid(scenarioId));
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return Optional.empty();
+                }
+                return Optional.of(new ValuationRecord(
+                        resultSet.getBigDecimal("discount_rate"),
+                        resultSet.getBigDecimal("npv"),
+                        resultSet.getBigDecimal("irr"),
+                        resultSet.getBigDecimal("payback_period"),
+                        resultSet.getString("decision"),
+                        fromJson(resultSet.getString("assumptions"))));
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to find valuation", exception);
+        }
+    }
+
+    private String toJson(JsonNode value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Failed to serialize JSON payload", exception);
+        }
+    }
+
+    private JsonNode fromJson(String value) {
+        try {
+            return objectMapper.readTree(value);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Failed to deserialize JSON payload", exception);
+        }
     }
 
     private String readGeneratedUuid(PreparedStatement statement) throws SQLException {

--- a/backend/src/main/java/com/costwise/persistence/PersistenceService.java
+++ b/backend/src/main/java/com/costwise/persistence/PersistenceService.java
@@ -13,12 +13,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -38,9 +35,6 @@ public class PersistenceService {
             Set.of("recommend", "review", "reject");
 
     private final ProjectPersistenceRepository projectRepository;
-    private final Map<String, ScenarioAnalysisState> scenarioAnalyses = new ConcurrentHashMap<>();
-    private final Map<String, ApprovalSummaryState> approvalSummaries = new ConcurrentHashMap<>();
-    private final Map<String, List<ApprovalLog>> approvalLogs = new ConcurrentHashMap<>();
 
     public PersistenceService(ProjectPersistenceRepository projectRepository) {
         this.projectRepository = projectRepository;
@@ -58,12 +52,11 @@ public class PersistenceService {
                         request.businessType().trim(),
                         "draft",
                         request.description()));
-        approvalSummaries.put(project.id(), createdApprovalSummary(project.status(), project.createdAt()));
         return toProjectSummary(project);
     }
 
     public ProjectSummaryResponse updateProject(String projectId, UpdateProjectRequest request) {
-        ProjectPersistenceRepository.ProjectRecord currentProject = getProjectState(projectId);
+        getProjectState(projectId);
         String status = normalizeEnum(request.status(), PROJECT_STATUSES, "project status");
         ProjectPersistenceRepository.ProjectRecord project = projectRepository.updateProject(
                 new ProjectPersistenceRepository.ProjectUpdate(
@@ -72,19 +65,11 @@ public class PersistenceService {
                         request.businessType().trim(),
                         status,
                         request.description()));
-        ApprovalSummaryState approvalSummary = approvalSummaries.computeIfAbsent(
-                projectId,
-                ignored -> createdApprovalSummary(currentProject.status(), currentProject.createdAt()));
-        approvalSummary.status = status;
-        approvalSummary.updatedAt = LocalDateTime.now();
         return toProjectSummary(project);
     }
 
     public void deleteProject(String projectId) {
         projectRepository.deleteProject(projectId);
-        approvalSummaries.remove(projectId);
-        approvalLogs.remove(projectId);
-        scenarioAnalyses.keySet().removeIf(key -> key.startsWith(projectId + ":"));
     }
 
     public ScenarioResponse createScenario(String projectId, CreateScenarioRequest request) {
@@ -119,7 +104,6 @@ public class PersistenceService {
     public void deleteScenario(String projectId, String scenarioId) {
         getProjectState(projectId);
         projectRepository.deleteScenario(projectId, scenarioId);
-        scenarioAnalyses.remove(analysisKey(projectId, scenarioId));
     }
 
     public AnalysisUpdateResponse upsertAnalysis(
@@ -127,7 +111,7 @@ public class PersistenceService {
         ProjectPersistenceRepository.ProjectRecord project = getProjectState(projectId);
         getScenarioState(projectId, scenarioId);
 
-        ScenarioAnalysisState analysis = new ScenarioAnalysisState(
+        ProjectPersistenceRepository.AnalysisRecord analysis = new ProjectPersistenceRepository.AnalysisRecord(
                 request.allocationRules().stream()
                         .map(this::toAllocationRule)
                         .toList(),
@@ -135,9 +119,8 @@ public class PersistenceService {
                         .map(this::toCashFlow)
                         .toList(),
                 toValuation(request.valuation()));
-        scenarioAnalyses.put(analysisKey(projectId, scenarioId), analysis);
 
-        ApprovalLog approvalLog = toApprovalLog(request.approval());
+        ProjectPersistenceRepository.ApprovalLogRecord approvalLog = toApprovalLog(request.approval());
         String projectStatus = normalizeEnum(
                 request.approval().projectStatus(), PROJECT_STATUSES, "project status");
         projectRepository.updateProject(new ProjectPersistenceRepository.ProjectUpdate(
@@ -146,17 +129,10 @@ public class PersistenceService {
                 project.businessType(),
                 projectStatus,
                 project.description()));
-        ApprovalSummaryState approvalSummary = approvalSummaries.computeIfAbsent(
-                projectId,
-                ignored -> createdApprovalSummary(project.status(), project.createdAt()));
-        approvalSummary.status = projectStatus;
-        approvalSummary.lastAction = approvalLog.action;
-        approvalSummary.lastActor = approvalLog.actorName;
-        approvalSummary.lastComment = approvalLog.comment;
-        approvalSummary.updatedAt = approvalLog.createdAt;
-        approvalLogs.computeIfAbsent(projectId, ignored -> new ArrayList<>()).add(approvalLog);
+        projectRepository.upsertAnalysis(projectId, scenarioId, analysis, approvalLog);
 
-        return new AnalysisUpdateResponse(projectId, scenarioId, analysis.allocationRules.size(), analysis.cashFlows.size());
+        return new AnalysisUpdateResponse(
+                projectId, scenarioId, analysis.allocationRules().size(), analysis.cashFlows().size());
     }
 
     public ProjectDetailResponse getProjectDetail(String projectId) {
@@ -164,21 +140,19 @@ public class PersistenceService {
         List<ProjectDetailResponse.ScenarioDetailResponse> scenarios = projectRepository.listScenarios(projectId).stream()
                 .map(scenario -> toScenarioDetailResponse(projectId, scenario))
                 .toList();
-        List<ProjectDetailResponse.ApprovalEvent> logs = approvalLogs
-                .getOrDefault(projectId, List.of())
-                .stream()
+        List<ProjectPersistenceRepository.ApprovalLogRecord> storedLogs = projectRepository.listApprovalLogs(projectId);
+        List<ProjectDetailResponse.ApprovalEvent> logs = storedLogs.stream()
                 .map(log -> new ProjectDetailResponse.ApprovalEvent(
-                        log.actorRole, log.actorName, log.action, log.comment, log.createdAt))
+                        log.actorRole(), log.actorName(), log.action(), log.comment(), log.createdAt()))
                 .toList();
-        ApprovalSummaryState approvalSummaryState = approvalSummaries.computeIfAbsent(
-                projectId,
-                ignored -> createdApprovalSummary(project.status(), project.createdAt()));
+        ProjectPersistenceRepository.ApprovalLogRecord latestApproval =
+                storedLogs.isEmpty() ? null : storedLogs.getLast();
         ProjectDetailResponse.ApprovalSummary approvalSummary = new ProjectDetailResponse.ApprovalSummary(
-                approvalSummaryState.status,
-                approvalSummaryState.lastAction,
-                approvalSummaryState.lastActor,
-                approvalSummaryState.lastComment,
-                approvalSummaryState.updatedAt,
+                project.status(),
+                latestApproval == null ? "created" : latestApproval.action(),
+                latestApproval == null ? "system" : latestApproval.actorName(),
+                latestApproval == null ? "project created" : latestApproval.comment(),
+                latestApproval == null ? project.createdAt() : latestApproval.createdAt(),
                 logs);
         return new ProjectDetailResponse(
                 project.id(),
@@ -215,39 +189,37 @@ public class PersistenceService {
 
     private ProjectDetailResponse.ScenarioDetailResponse toScenarioDetailResponse(
             String projectId, ProjectPersistenceRepository.ScenarioRecord scenario) {
-        ScenarioAnalysisState analysis = scenarioAnalyses.getOrDefault(
-                analysisKey(projectId, scenario.id()),
-                ScenarioAnalysisState.empty());
-        List<ProjectDetailResponse.AllocationRule> allocations = analysis.allocationRules.stream()
+        ProjectPersistenceRepository.AnalysisRecord analysis = projectRepository.findAnalysis(projectId, scenario.id());
+        List<ProjectDetailResponse.AllocationRule> allocations = analysis.allocationRules().stream()
                 .map(value -> new ProjectDetailResponse.AllocationRule(
-                        value.departmentCode,
-                        value.basis,
-                        value.allocationRate,
-                        value.allocatedAmount,
-                        value.costPoolName,
-                        value.costPoolCategory,
-                        value.costPoolAmount))
+                        value.departmentCode(),
+                        value.basis(),
+                        value.allocationRate(),
+                        value.allocatedAmount(),
+                        value.costPoolName(),
+                        value.costPoolCategory(),
+                        value.costPoolAmount()))
                 .toList();
-        List<ProjectDetailResponse.CashFlow> cashFlows = analysis.cashFlows.stream()
+        List<ProjectDetailResponse.CashFlow> cashFlows = analysis.cashFlows().stream()
                 .map(value -> new ProjectDetailResponse.CashFlow(
-                        value.periodNo,
-                        value.periodLabel,
-                        value.yearLabel,
-                        value.operatingCashFlow,
-                        value.investmentCashFlow,
-                        value.financingCashFlow,
-                        value.netCashFlow,
-                        value.discountRate))
+                        value.periodNo(),
+                        value.periodLabel(),
+                        value.yearLabel(),
+                        value.operatingCashFlow(),
+                        value.investmentCashFlow(),
+                        value.financingCashFlow(),
+                        value.netCashFlow(),
+                        value.discountRate()))
                 .toList();
-        ProjectDetailResponse.Valuation valuation = analysis.valuation == null
+        ProjectDetailResponse.Valuation valuation = analysis.valuation() == null
                 ? null
                 : new ProjectDetailResponse.Valuation(
-                        analysis.valuation.discountRate,
-                        analysis.valuation.npv,
-                        analysis.valuation.irr,
-                        analysis.valuation.paybackPeriod,
-                        analysis.valuation.decision,
-                        analysis.valuation.assumptions);
+                        analysis.valuation().discountRate(),
+                        analysis.valuation().npv(),
+                        analysis.valuation().irr(),
+                        analysis.valuation().paybackPeriod(),
+                        analysis.valuation().decision(),
+                        analysis.valuation().assumptions());
         return new ProjectDetailResponse.ScenarioDetailResponse(
                 scenario.id(),
                 scenario.name(),
@@ -260,7 +232,8 @@ public class PersistenceService {
                 valuation);
     }
 
-    private AllocationRuleState toAllocationRule(AnalysisUpsertRequest.AllocationRuleInput input) {
+    private ProjectPersistenceRepository.AllocationRuleRecord toAllocationRule(
+            AnalysisUpsertRequest.AllocationRuleInput input) {
         String basis = normalizeEnum(input.basis(), ALLOCATION_BASIS, "allocation basis");
         String costPoolCategory = normalizeEnum(input.costPoolCategory(), COST_POOL_CATEGORIES, "cost pool category");
         if (input.allocationRate().compareTo(BigDecimal.ZERO) < 0 || input.allocationRate().compareTo(BigDecimal.ONE) > 0) {
@@ -269,7 +242,7 @@ public class PersistenceService {
         if (input.allocatedAmount().compareTo(BigDecimal.ZERO) < 0 || input.costPoolAmount().compareTo(BigDecimal.ZERO) < 0) {
             throw new IllegalArgumentException("allocatedAmount and costPoolAmount must be >= 0");
         }
-        return new AllocationRuleState(
+        return new ProjectPersistenceRepository.AllocationRuleRecord(
                 input.departmentCode().trim(),
                 basis,
                 input.allocationRate(),
@@ -279,7 +252,7 @@ public class PersistenceService {
                 input.costPoolAmount());
     }
 
-    private CashFlowState toCashFlow(AnalysisUpsertRequest.CashFlowInput input) {
+    private ProjectPersistenceRepository.CashFlowRecord toCashFlow(AnalysisUpsertRequest.CashFlowInput input) {
         if (input.periodNo() < 0) {
             throw new IllegalArgumentException("periodNo must be >= 0");
         }
@@ -289,7 +262,7 @@ public class PersistenceService {
         // Schema contract keeps net_cash_flow as stored value; this slice derives it deterministically
         // from operating + investment + financing to avoid drift between API payload and persisted shape.
         BigDecimal netCashFlow = input.operatingCashFlow().add(input.investmentCashFlow()).add(input.financingCashFlow());
-        return new CashFlowState(
+        return new ProjectPersistenceRepository.CashFlowRecord(
                 input.periodNo(),
                 input.periodLabel().trim(),
                 input.yearLabel().trim(),
@@ -300,13 +273,13 @@ public class PersistenceService {
                 input.discountRate());
     }
 
-    private ValuationState toValuation(AnalysisUpsertRequest.ValuationInput input) {
+    private ProjectPersistenceRepository.ValuationRecord toValuation(AnalysisUpsertRequest.ValuationInput input) {
         String decision = normalizeEnum(input.decision(), VALUATION_DECISIONS, "valuation decision");
         if (input.discountRate().compareTo(BigDecimal.ZERO) < 0) {
             throw new IllegalArgumentException("discountRate must be >= 0");
         }
         JsonNode assumptions = input.assumptions() == null ? JsonNodeFactory.instance.objectNode() : input.assumptions();
-        return new ValuationState(
+        return new ProjectPersistenceRepository.ValuationRecord(
                 input.discountRate(),
                 input.npv(),
                 input.irr(),
@@ -315,10 +288,11 @@ public class PersistenceService {
                 assumptions);
     }
 
-    private ApprovalLog toApprovalLog(AnalysisUpsertRequest.ApprovalInput input) {
+    private ProjectPersistenceRepository.ApprovalLogRecord toApprovalLog(AnalysisUpsertRequest.ApprovalInput input) {
         String actorRole = normalizeEnum(input.actorRole(), ACTOR_ROLES, "actor role");
         String action = normalizeEnum(input.action(), APPROVAL_ACTIONS, "approval action");
-        return new ApprovalLog(actorRole, input.actorName().trim(), action, input.comment(), LocalDateTime.now());
+        return new ProjectPersistenceRepository.ApprovalLogRecord(
+                actorRole, input.actorName().trim(), action, input.comment(), LocalDateTime.now());
     }
 
     private ProjectPersistenceRepository.ProjectRecord getProjectState(String projectId) {
@@ -346,69 +320,4 @@ public class PersistenceService {
         return normalized;
     }
 
-    private ApprovalSummaryState createdApprovalSummary(String status, LocalDateTime createdAt) {
-        ApprovalSummaryState approvalSummary = new ApprovalSummaryState();
-        approvalSummary.status = status;
-        approvalSummary.lastAction = "created";
-        approvalSummary.lastActor = "system";
-        approvalSummary.lastComment = "project created";
-        approvalSummary.updatedAt = createdAt;
-        return approvalSummary;
-    }
-
-    private String analysisKey(String projectId, String scenarioId) {
-        return projectId + ":" + scenarioId;
-    }
-
-    private record ScenarioAnalysisState(
-            List<AllocationRuleState> allocationRules,
-            List<CashFlowState> cashFlows,
-            ValuationState valuation) {
-
-        private static ScenarioAnalysisState empty() {
-            return new ScenarioAnalysisState(List.of(), List.of(), null);
-        }
-    }
-
-    private record AllocationRuleState(
-            String departmentCode,
-            String basis,
-            BigDecimal allocationRate,
-            BigDecimal allocatedAmount,
-            String costPoolName,
-            String costPoolCategory,
-            BigDecimal costPoolAmount) {}
-
-    private record CashFlowState(
-            int periodNo,
-            String periodLabel,
-            String yearLabel,
-            BigDecimal operatingCashFlow,
-            BigDecimal investmentCashFlow,
-            BigDecimal financingCashFlow,
-            BigDecimal netCashFlow,
-            BigDecimal discountRate) {}
-
-    private record ValuationState(
-            BigDecimal discountRate,
-            BigDecimal npv,
-            BigDecimal irr,
-            BigDecimal paybackPeriod,
-            String decision,
-            JsonNode assumptions) {}
-
-    private static final class ApprovalSummaryState {
-        private String status;
-        private String lastAction;
-        private String lastActor;
-        private String lastComment;
-        private LocalDateTime updatedAt;
-    }
-
-    private record ApprovalLog(
-            String actorRole,
-            String actorName,
-            String action,
-            String comment,
-            LocalDateTime createdAt) {}
 }

--- a/backend/src/main/java/com/costwise/persistence/ProjectPersistenceRepository.java
+++ b/backend/src/main/java/com/costwise/persistence/ProjectPersistenceRepository.java
@@ -1,5 +1,7 @@
 package com.costwise.persistence;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +29,12 @@ public interface ProjectPersistenceRepository {
     List<ScenarioRecord> listScenarios(String projectId);
 
     boolean existsScenarioName(String projectId, String normalizedName, String skipScenarioId);
+
+    void upsertAnalysis(String projectId, String scenarioId, AnalysisRecord analysis, ApprovalLogRecord approvalLog);
+
+    AnalysisRecord findAnalysis(String projectId, String scenarioId);
+
+    List<ApprovalLogRecord> listApprovalLogs(String projectId);
 
     record NewProject(String code, String name, String businessType, String status, String description) {}
 
@@ -61,5 +69,49 @@ public interface ProjectPersistenceRepository {
             String description,
             boolean isBaseline,
             boolean isActive,
+            LocalDateTime createdAt) {}
+
+    record AnalysisRecord(
+            List<AllocationRuleRecord> allocationRules,
+            List<CashFlowRecord> cashFlows,
+            ValuationRecord valuation) {
+
+        static AnalysisRecord empty() {
+            return new AnalysisRecord(List.of(), List.of(), null);
+        }
+    }
+
+    record AllocationRuleRecord(
+            String departmentCode,
+            String basis,
+            BigDecimal allocationRate,
+            BigDecimal allocatedAmount,
+            String costPoolName,
+            String costPoolCategory,
+            BigDecimal costPoolAmount) {}
+
+    record CashFlowRecord(
+            int periodNo,
+            String periodLabel,
+            String yearLabel,
+            BigDecimal operatingCashFlow,
+            BigDecimal investmentCashFlow,
+            BigDecimal financingCashFlow,
+            BigDecimal netCashFlow,
+            BigDecimal discountRate) {}
+
+    record ValuationRecord(
+            BigDecimal discountRate,
+            BigDecimal npv,
+            BigDecimal irr,
+            BigDecimal paybackPeriod,
+            String decision,
+            JsonNode assumptions) {}
+
+    record ApprovalLogRecord(
+            String actorRole,
+            String actorName,
+            String action,
+            String comment,
             LocalDateTime createdAt) {}
 }

--- a/backend/src/test/java/com/costwise/api/persistence/PersistenceControllerTest.java
+++ b/backend/src/test/java/com/costwise/api/persistence/PersistenceControllerTest.java
@@ -57,7 +57,13 @@ class PersistenceControllerTest {
                         "sa",
                         "");
                 Statement statement = connection.createStatement()) {
+            statement.execute("drop table if exists approval_logs");
+            statement.execute("drop table if exists valuation_results");
+            statement.execute("drop table if exists cash_flows");
+            statement.execute("drop table if exists allocation_rules");
+            statement.execute("drop table if exists cost_pools");
             statement.execute("drop table if exists scenarios");
+            statement.execute("drop table if exists departments");
             statement.execute("drop table if exists projects");
             statement.execute("""
                     create table projects (
@@ -71,6 +77,14 @@ class PersistenceControllerTest {
                     )
                     """);
             statement.execute("""
+                    create table departments (
+                      id uuid default random_uuid() primary key,
+                      code text not null unique,
+                      name text not null,
+                      sort_order integer not null default 0
+                    )
+                    """);
+            statement.execute("""
                     create table scenarios (
                       id uuid default random_uuid() primary key,
                       project_id uuid not null references projects (id) on delete cascade,
@@ -80,6 +94,77 @@ class PersistenceControllerTest {
                       is_active boolean not null default true,
                       created_at timestamp not null default current_timestamp,
                       unique (project_id, name)
+                    )
+                    """);
+            statement.execute("""
+                    create table cost_pools (
+                      id uuid default random_uuid() primary key,
+                      project_id uuid not null references projects (id) on delete cascade,
+                      scenario_id uuid references scenarios (id) on delete set null,
+                      name text not null,
+                      category text not null,
+                      amount numeric(14, 2) not null,
+                      currency char(3) not null default 'KRW',
+                      description text,
+                      created_at timestamp not null default current_timestamp
+                    )
+                    """);
+            statement.execute("""
+                    create table allocation_rules (
+                      id uuid default random_uuid() primary key,
+                      project_id uuid not null references projects (id) on delete cascade,
+                      scenario_id uuid references scenarios (id) on delete set null,
+                      cost_pool_id uuid not null references cost_pools (id) on delete cascade,
+                      department_id uuid not null references departments (id),
+                      basis text not null,
+                      allocation_rate numeric(7, 6) not null,
+                      allocated_amount numeric(14, 2) not null,
+                      created_at timestamp not null default current_timestamp,
+                      unique (scenario_id, cost_pool_id, department_id)
+                    )
+                    """);
+            statement.execute("""
+                    create table cash_flows (
+                      id uuid default random_uuid() primary key,
+                      project_id uuid not null references projects (id) on delete cascade,
+                      scenario_id uuid references scenarios (id) on delete set null,
+                      period_no integer not null,
+                      period_label text not null,
+                      year_label text not null,
+                      operating_cash_flow numeric(14, 2) not null default 0,
+                      investment_cash_flow numeric(14, 2) not null default 0,
+                      financing_cash_flow numeric(14, 2) not null default 0,
+                      net_cash_flow numeric(14, 2) not null,
+                      discount_rate numeric(8, 6) not null,
+                      created_at timestamp not null default current_timestamp,
+                      unique (project_id, scenario_id, period_no)
+                    )
+                    """);
+            statement.execute("""
+                    create table valuation_results (
+                      id uuid default random_uuid() primary key,
+                      project_id uuid not null references projects (id) on delete cascade,
+                      scenario_id uuid references scenarios (id) on delete set null,
+                      discount_rate numeric(8, 6) not null,
+                      npv numeric(14, 2) not null,
+                      irr numeric(8, 6) not null,
+                      payback_period numeric(8, 2) not null,
+                      decision text not null,
+                      assumptions clob not null,
+                      created_at timestamp not null default current_timestamp,
+                      unique (project_id, scenario_id)
+                    )
+                    """);
+            statement.execute("""
+                    create table approval_logs (
+                      id uuid default random_uuid() primary key,
+                      project_id uuid not null references projects (id) on delete cascade,
+                      scenario_id uuid references scenarios (id) on delete set null,
+                      actor_role text not null,
+                      actor_name text not null,
+                      action text not null,
+                      comment text,
+                      created_at timestamp not null default current_timestamp
                     )
                     """);
         }

--- a/backend/src/test/java/com/costwise/persistence/JdbcProjectPersistenceRepositoryTest.java
+++ b/backend/src/test/java/com/costwise/persistence/JdbcProjectPersistenceRepositoryTest.java
@@ -3,14 +3,18 @@ package com.costwise.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.costwise.api.dto.persistence.AnalysisUpsertRequest;
 import com.costwise.api.dto.persistence.CreateProjectRequest;
 import com.costwise.api.dto.persistence.CreateScenarioRequest;
 import com.costwise.api.dto.persistence.UpdateProjectRequest;
 import com.costwise.api.dto.persistence.UpdateScenarioRequest;
 import com.costwise.config.AuditPersistenceProperties;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class JdbcProjectPersistenceRepositoryTest {
@@ -43,6 +47,76 @@ class JdbcProjectPersistenceRepositoryTest {
         assertThat(detail.scenarios()).hasSize(1);
         assertThat(detail.scenarios().getFirst().id()).isEqualTo(scenario.id());
         assertThat(detail.scenarios().getFirst().name()).isEqualTo("Base");
+    }
+
+    @Test
+    void analysisResultsAndApprovalHistoryAreReadableAcrossServiceRecreation() throws Exception {
+        String jdbcUrl = "jdbc:h2:mem:persistence-analysis;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE";
+        createSchema(jdbcUrl);
+        AuditPersistenceProperties properties = new AuditPersistenceProperties(null, jdbcUrl, "sa", "", "disable");
+
+        PersistenceService writer = new PersistenceService(new JdbcProjectPersistenceRepository(properties));
+        var project = writer.createProject(new CreateProjectRequest(
+                "PJT-DB-ANALYSIS",
+                "분석 저장 프로젝트",
+                "new_business",
+                "analysis restart test"));
+        var scenario = writer.createScenario(project.id(), new CreateScenarioRequest(
+                "Base",
+                "기준 시나리오",
+                true,
+                true));
+
+        writer.upsertAnalysis(
+                project.id(),
+                scenario.id(),
+                new AnalysisUpsertRequest(
+                        List.of(new AnalysisUpsertRequest.AllocationRuleInput(
+                                "D-001",
+                                "manual",
+                                new BigDecimal("1.000000"),
+                                new BigDecimal("1000000.00"),
+                                "공통비",
+                                "shared",
+                                new BigDecimal("1000000.00"))),
+                        List.of(new AnalysisUpsertRequest.CashFlowInput(
+                                0,
+                                "현재",
+                                "2026",
+                                new BigDecimal("500000.00"),
+                                new BigDecimal("-200000.00"),
+                                BigDecimal.ZERO,
+                                new BigDecimal("0.080000"))),
+                        new AnalysisUpsertRequest.ValuationInput(
+                                new BigDecimal("0.080000"),
+                                new BigDecimal("300000.00"),
+                                new BigDecimal("0.120000"),
+                                new BigDecimal("2.50"),
+                                "recommend",
+                                JsonNodeFactory.instance.objectNode().put("growthRate", 0.03)),
+                        new AnalysisUpsertRequest.ApprovalInput(
+                                "planner",
+                                "plan-user",
+                                "allocated",
+                                "분석 반영",
+                                "in_review")));
+
+        PersistenceService reader = new PersistenceService(new JdbcProjectPersistenceRepository(properties));
+        var detail = reader.getProjectDetail(project.id());
+        var scenarioDetail = detail.scenarios().getFirst();
+
+        assertThat(detail.status()).isEqualTo("in_review");
+        assertThat(detail.approval().status()).isEqualTo("in_review");
+        assertThat(detail.approval().lastAction()).isEqualTo("allocated");
+        assertThat(detail.approval().lastActor()).isEqualTo("plan-user");
+        assertThat(detail.approval().logs()).hasSize(1);
+        assertThat(scenarioDetail.allocationRules()).hasSize(1);
+        assertThat(scenarioDetail.allocationRules().getFirst().departmentCode()).isEqualTo("D-001");
+        assertThat(scenarioDetail.cashFlows()).hasSize(1);
+        assertThat(scenarioDetail.cashFlows().getFirst().netCashFlow()).isEqualByComparingTo("300000.00");
+        assertThat(scenarioDetail.valuation()).isNotNull();
+        assertThat(scenarioDetail.valuation().decision()).isEqualTo("recommend");
+        assertThat(scenarioDetail.valuation().assumptions().path("growthRate").asDouble()).isEqualTo(0.03);
     }
 
     @Test
@@ -132,6 +206,14 @@ class JdbcProjectPersistenceRepositoryTest {
                     )
                     """);
             statement.execute("""
+                    create table departments (
+                      id uuid default random_uuid() primary key,
+                      code text not null unique,
+                      name text not null,
+                      sort_order integer not null default 0
+                    )
+                    """);
+            statement.execute("""
                     create table scenarios (
                       id uuid default random_uuid() primary key,
                       project_id uuid not null references projects (id) on delete cascade,
@@ -141,6 +223,77 @@ class JdbcProjectPersistenceRepositoryTest {
                       is_active boolean not null default true,
                       created_at timestamp not null default current_timestamp,
                       unique (project_id, name)
+                    )
+                    """);
+            statement.execute("""
+                    create table cost_pools (
+                      id uuid default random_uuid() primary key,
+                      project_id uuid not null references projects (id) on delete cascade,
+                      scenario_id uuid references scenarios (id) on delete set null,
+                      name text not null,
+                      category text not null,
+                      amount numeric(14, 2) not null,
+                      currency char(3) not null default 'KRW',
+                      description text,
+                      created_at timestamp not null default current_timestamp
+                    )
+                    """);
+            statement.execute("""
+                    create table allocation_rules (
+                      id uuid default random_uuid() primary key,
+                      project_id uuid not null references projects (id) on delete cascade,
+                      scenario_id uuid references scenarios (id) on delete set null,
+                      cost_pool_id uuid not null references cost_pools (id) on delete cascade,
+                      department_id uuid not null references departments (id),
+                      basis text not null,
+                      allocation_rate numeric(7, 6) not null,
+                      allocated_amount numeric(14, 2) not null,
+                      created_at timestamp not null default current_timestamp,
+                      unique (scenario_id, cost_pool_id, department_id)
+                    )
+                    """);
+            statement.execute("""
+                    create table cash_flows (
+                      id uuid default random_uuid() primary key,
+                      project_id uuid not null references projects (id) on delete cascade,
+                      scenario_id uuid references scenarios (id) on delete set null,
+                      period_no integer not null,
+                      period_label text not null,
+                      year_label text not null,
+                      operating_cash_flow numeric(14, 2) not null default 0,
+                      investment_cash_flow numeric(14, 2) not null default 0,
+                      financing_cash_flow numeric(14, 2) not null default 0,
+                      net_cash_flow numeric(14, 2) not null,
+                      discount_rate numeric(8, 6) not null,
+                      created_at timestamp not null default current_timestamp,
+                      unique (project_id, scenario_id, period_no)
+                    )
+                    """);
+            statement.execute("""
+                    create table valuation_results (
+                      id uuid default random_uuid() primary key,
+                      project_id uuid not null references projects (id) on delete cascade,
+                      scenario_id uuid references scenarios (id) on delete set null,
+                      discount_rate numeric(8, 6) not null,
+                      npv numeric(14, 2) not null,
+                      irr numeric(8, 6) not null,
+                      payback_period numeric(8, 2) not null,
+                      decision text not null,
+                      assumptions clob not null,
+                      created_at timestamp not null default current_timestamp,
+                      unique (project_id, scenario_id)
+                    )
+                    """);
+            statement.execute("""
+                    create table approval_logs (
+                      id uuid default random_uuid() primary key,
+                      project_id uuid not null references projects (id) on delete cascade,
+                      scenario_id uuid references scenarios (id) on delete set null,
+                      actor_role text not null,
+                      actor_name text not null,
+                      action text not null,
+                      comment text,
+                      created_at timestamp not null default current_timestamp
                     )
                     """);
         }

--- a/docs/dev-logs/2026-04-22-analysis-persistence.md
+++ b/docs/dev-logs/2026-04-22-analysis-persistence.md
@@ -1,0 +1,30 @@
+# Analysis Persistence
+
+## Branch
+
+- Worktree: `.worktrees/feat-50-analysis-persistence`
+- Branch: `feat/50-analysis-persistence`
+- Base: `dev`
+- Related issue: `#50`
+
+## Comparison
+
+- Option A: keep analysis payloads in `PersistenceService` maps after project/scenario persistence.
+- Option B: persist allocation rules, cash flows, valuation results, and approval logs through the JDBC repository and reconstruct project detail from database reads.
+
+Option B was selected because issue `#50` requires analysis results to survive service recreation and requires minimizing the in-memory persistence dependency.
+
+## Changes
+
+- Extended `ProjectPersistenceRepository` with analysis write/read contracts.
+- Persisted allocation rules through `departments`, `cost_pools`, and `allocation_rules`.
+- Persisted cash flows, valuation results, and approval logs into their existing migration tables.
+- Rebuilt `ProjectDetailResponse` analysis sections and approval summary from database reads.
+- Removed in-memory analysis, approval summary, and approval log maps from `PersistenceService`.
+- Added restart-style tests proving analysis and approval history remain after service recreation.
+
+## Validation
+
+- `.\gradlew.bat test --tests com.costwise.persistence.JdbcProjectPersistenceRepositoryTest`
+- `.\gradlew.bat test --tests com.costwise.api.persistence.PersistenceControllerTest --tests com.costwise.persistence.JdbcProjectPersistenceRepositoryTest`
+- `.\gradlew.bat check`


### PR DESCRIPTION
## 요약

#50의 남은 분석 영속화 항목을 처리했습니다. 배부규칙, 현금흐름, 평가결과, 승인 이력을 기존 Supabase/Postgres 스키마 테이블에 저장하고, 프로젝트 상세 응답을 DB에서 재구성하도록 변경했습니다.

## 변경 내용

- `ProjectPersistenceRepository`에 분석 write/read 계약 추가
- `JdbcProjectPersistenceRepository`에서 `departments`, `cost_pools`, `allocation_rules`, `cash_flows`, `valuation_results`, `approval_logs` 저장/조회 구현
- `PersistenceService`의 인메모리 분석 상태, approval summary map, approval log map 제거
- `ProjectDetailResponse`의 allocation/cashflow/valuation/approval 정보를 DB 조회 결과로 재구성
- 시나리오 삭제 시 연결된 분석 행을 먼저 삭제해 orphan 분석 데이터를 남기지 않도록 정리
- 서비스 재생성 후에도 분석 결과와 승인 이력이 유지되는 repository 테스트 추가
- controller H2 테스트 스키마를 분석 테이블까지 확장
- `docs/dev-logs/2026-04-22-analysis-persistence.md`에 워킹트리 비교와 선택 이유 기록

## 이유

PR #60은 프로젝트/시나리오 CRUD 영속화 기반까지만 다뤘고, 분석 payload는 임시 인메모리 상태로 남아 있었습니다. 이 변경은 #50의 남은 완료 조건인 분석 결과 재시작 유지와 인메모리 분석 상태 제거를 충족하기 위한 후속 슬라이스입니다.

## 이슈 체크리스트

- [x] `PersistenceService`를 DB 기반 저장 구조로 전환
- [x] 프로젝트 생성/수정/조회/삭제가 DB에 반영됨
- [x] 시나리오 생성/수정/조회/삭제가 DB에 반영됨
- [x] 배부규칙, 현금흐름, 평가결과, 승인 이력 DB 저장 연결
- [x] 분석 결과가 재시작 후에도 유지됨
- [x] 인메모리 분석 상태 제거
- [x] 기존 migration과 서비스/DTO 정합성 점검
- [x] CRUD 및 분석 저장 테스트 추가

## 검증

- [x] 관련 테스트를 실행했습니다.
  - `.\gradlew.bat test --tests com.costwise.persistence.JdbcProjectPersistenceRepositoryTest`
  - `.\gradlew.bat test --tests com.costwise.api.persistence.PersistenceControllerTest --tests com.costwise.persistence.JdbcProjectPersistenceRepositoryTest`
  - `.\gradlew.bat check`
  - 커밋 시 pre-commit backend Gradle check 통과
- [x] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
  - MockMvc persistence API flow로 분석 저장 후 상세 조회를 확인했습니다.
- [x] 인접한 흐름에서 회귀가 없는지 확인했습니다.
  - 전체 backend `check` 통과

## 스크린샷 또는 로그

화면 변경은 없습니다. 검증 로그는 로컬 Gradle 실행 결과와 pre-commit 결과로 확인했습니다.

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [x] 후속 작업이 필요하면 별도 이슈로 분리했습니다.

## 브랜치

- [x] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
- [x] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.