### PR TITLE
feat: 감사로그 API 우선 로딩 및 상태 표시

### DIFF
--- a/docs/dev-logs/2026-04-22-audit-log-api-states.md
+++ b/docs/dev-logs/2026-04-22-audit-log-api-states.md
@@ -1,0 +1,25 @@
+# Audit Log API States
+
+## 기준 브랜치
+
+- 기준: `dev` (`2bd380b`, PR #62 병합 후 최신)
+- 작업 브랜치: `feat/54-audit-log-states`
+- 선택 이유: #54 잔여 범위 중 감사로그 API 전환과 상태 UI는 프론트 단독 변경으로 분리 가능하다.
+
+## 워킹트리 비교
+
+- 변경 전: Reviews 화면은 `portfolio.auditEvents` seed/fallback 이벤트를 항상 렌더링했다.
+- 변경 후: 선택 프로젝트의 `projectId`로 `/api/audit-logs`를 우선 호출하고, 실패 시 기존 로컬 이벤트를 fallback으로 표시한다.
+- 감사로그 영역에 API/fallback 소스, loading, empty 상태를 명시했다.
+- 백엔드 응답 계약은 기존 `AuditLogListResponse.items`를 그대로 사용한다.
+
+## 검증
+
+- `frontend`: `npm run build`
+- `frontend`: `npm run lint`
+- `frontend`: `npx prettier --check src/App.tsx src/app/portfolioData.ts src/views/reviews/ReviewsView.tsx`
+
+## 후속 확인
+
+- `npm run format:check`는 기존 프론트 전체 포맷 불일치가 남아 있어 별도 정리가 필요하다.
+- 실제 API 수동 확인은 EXECUTIVE 권한 JWT와 실행 중인 백엔드가 필요하다.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,9 +3,11 @@ import {
   buildDecisionSignals,
   detailTabs,
   defaultPortfolioSummary,
+  loadAuditEvents,
   loadProjectDetail,
   loadPortfolioSummary,
   roleInsights,
+  type AuditEvent,
   type DataSource,
   type ProjectDetail,
   type PortfolioSummary,
@@ -51,6 +53,13 @@ export function App() {
   );
   const [selectedDetailSource, setSelectedDetailSource] =
     useState<DataSource>('local');
+  const [auditEvents, setAuditEvents] = useState<AuditEvent[]>(
+    defaultPortfolioSummary.auditEvents
+  );
+  const [auditSource, setAuditSource] = useState<DataSource>('local');
+  const [auditStatus, setAuditStatus] = useState<'idle' | 'loading' | 'ready'>(
+    'idle'
+  );
   const [searchTerm, setSearchTerm] = useState(initialExplorerState.search);
   const [explorerSort, setExplorerSort] = useState<ExplorerSortKey>(
     initialExplorerState.sort
@@ -92,6 +101,9 @@ export function App() {
     if (!selectedProject) {
       setSelectedDetail(null);
       setSelectedDetailSource('local');
+      setAuditEvents(portfolio.auditEvents);
+      setAuditSource(portfolioSource);
+      setAuditStatus('ready');
       return;
     }
 
@@ -102,6 +114,27 @@ export function App() {
       if (!cancelled) {
         setSelectedDetail(detail);
         setSelectedDetailSource(source);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedProject]);
+
+  useEffect(() => {
+    if (!selectedProject) {
+      return;
+    }
+
+    let cancelled = false;
+    setAuditStatus('loading');
+
+    void loadAuditEvents(selectedProject).then(({ events, source }) => {
+      if (!cancelled) {
+        setAuditEvents(events);
+        setAuditSource(source);
+        setAuditStatus('ready');
       }
     });
 
@@ -500,7 +533,13 @@ export function App() {
           ) : null}
 
           {activeView === 'reviews' ? (
-            <ReviewsView portfolio={portfolio} />
+            <ReviewsView
+              portfolio={portfolio}
+              auditEvents={auditEvents}
+              auditSource={auditSource}
+              auditStatus={auditStatus}
+              selectedProjectName={selectedProject?.name ?? null}
+            />
           ) : null}
 
           {activeView === 'settings' ? (

--- a/frontend/src/app/portfolioData.ts
+++ b/frontend/src/app/portfolioData.ts
@@ -86,7 +86,7 @@ export type AuditEvent = {
   at: string;
   actor: string;
   action: string;
-  domain: 'PORTFOLIO' | 'ABC' | 'DCF' | 'ACCESS';
+  domain: string;
 };
 
 export type PortfolioSummary = {
@@ -559,6 +559,34 @@ export async function loadProjectDetail(project: ProjectSummary): Promise<{
   }
 }
 
+export async function loadAuditEvents(project: ProjectSummary): Promise<{
+  events: AuditEvent[];
+  source: DataSource;
+}> {
+  const projectId = project.projectId ?? project.code;
+
+  try {
+    const response = await apiFetch(
+      `/api/audit-logs?projectId=${encodeURIComponent(projectId)}&limit=20`
+    );
+    if (!response.ok) {
+      throw new Error(`Audit log request failed: ${response.status}`);
+    }
+
+    const payload = (await response.json()) as AuditLogListApiResponse;
+
+    return {
+      events: payload.items.map(adaptAuditEvent),
+      source: 'api'
+    };
+  } catch {
+    return {
+      events: defaultPortfolioSummary.auditEvents,
+      source: 'local'
+    };
+  }
+}
+
 export function buildDecisionSignals(summary: PortfolioSummary) {
   return [
     { label: '검토 단계', value: summary.status },
@@ -772,6 +800,36 @@ type ValuationRiskApiResponse = {
     ratingBand?: string;
   };
 };
+
+type AuditLogListApiResponse = {
+  items: AuditLogEntryApiResponse[];
+  nextCursor?: string | null;
+};
+
+type AuditLogEntryApiResponse = {
+  eventType?: string;
+  actorRole?: string;
+  actorId?: string;
+  action?: string;
+  target?: string;
+  result?: string;
+  occurredAt?: string;
+  createdAt?: string;
+};
+
+function adaptAuditEvent(entry: AuditLogEntryApiResponse): AuditEvent {
+  const actor = [entry.actorRole, entry.actorId].filter(Boolean).join(' · ');
+  const action = [entry.action, entry.target, entry.result]
+    .filter(Boolean)
+    .join(' / ');
+
+  return {
+    at: entry.occurredAt ?? entry.createdAt ?? new Date().toISOString(),
+    actor: actor || '감사 로그',
+    action: action || '이력이 기록되었습니다.',
+    domain: entry.eventType ?? 'AUDIT'
+  };
+}
 
 function adaptProjectDetail(
   project: ProjectSummary,

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1341,6 +1341,33 @@ textarea {
   grid-template-columns: 1fr;
 }
 
+.audit-status,
+.audit-state {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(123, 137, 167, 0.14);
+  background: #f9fafc;
+}
+
+.audit-status {
+  align-items: center;
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+.audit-status p,
+.audit-state p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.audit-state strong {
+  color: var(--text);
+}
+
 .status-pill {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/views/reviews/ReviewsView.tsx
+++ b/frontend/src/views/reviews/ReviewsView.tsx
@@ -1,15 +1,35 @@
 import { formatDateTime } from '../../app/format';
-import type { PortfolioSummary } from '../../app/portfolioData';
+import type {
+  AuditEvent,
+  DataSource,
+  PortfolioSummary
+} from '../../app/portfolioData';
 import { Panel } from '../../shared/components/Panel';
 
 type ReviewsViewProps = {
   portfolio: PortfolioSummary;
+  auditEvents: AuditEvent[];
+  auditSource: DataSource;
+  auditStatus: 'idle' | 'loading' | 'ready';
+  selectedProjectName: string | null;
 };
 
-export function ReviewsView({ portfolio }: ReviewsViewProps) {
+export function ReviewsView({
+  portfolio,
+  auditEvents,
+  auditSource,
+  auditStatus,
+  selectedProjectName
+}: ReviewsViewProps) {
+  const isAuditLoading = auditStatus === 'loading';
+  const hasAuditEvents = auditEvents.length > 0;
+
   return (
     <section className="reviews-grid">
-      <Panel title="Assumptions" subtitle="검토 레이어에서 가정값과 전제 조건을 따로 읽습니다.">
+      <Panel
+        title="Assumptions"
+        subtitle="검토 레이어에서 가정값과 전제 조건을 따로 읽습니다."
+      >
         <div className="assumption-list">
           {portfolio.assumptions.map((item) => (
             <div key={item.label} className="assumption-list__item">
@@ -20,18 +40,50 @@ export function ReviewsView({ portfolio }: ReviewsViewProps) {
         </div>
       </Panel>
 
-      <Panel title="Audit trail" subtitle="운영 이력은 포트폴리오/워크스페이스 화면과 분리된 리뷰 레이어에 둡니다.">
-        <ol className="audit-list audit-list--wide">
-          {portfolio.auditEvents.map((item) => (
-            <li key={`${item.actor}-${item.at}`}>
-              <strong>{item.actor}</strong>
-              <span>{item.action}</span>
-              <small>
-                {item.domain} · {formatDateTime(item.at)}
-              </small>
-            </li>
-          ))}
-        </ol>
+      <Panel
+        title="Audit trail"
+        subtitle="운영 이력은 포트폴리오/워크스페이스 화면과 분리된 리뷰 레이어에 둡니다."
+      >
+        <div className="audit-status" aria-live="polite">
+          <span
+            className={`status-pill status-pill--${auditSource === 'api' ? 'low' : 'mid'}`}
+          >
+            {auditSource === 'api' ? '감사 API' : '로컬 fallback'}
+          </span>
+          <p>
+            {selectedProjectName
+              ? `${selectedProjectName} 기준 감사 이력을 표시합니다.`
+              : '선택된 프로젝트가 없어 포트폴리오 기준 감사 이력을 표시합니다.'}
+          </p>
+        </div>
+
+        {isAuditLoading ? (
+          <div className="audit-state" role="status">
+            <strong>감사 이력을 불러오는 중입니다.</strong>
+            <p>권한과 프로젝트 기준을 확인하고 있습니다.</p>
+          </div>
+        ) : null}
+
+        {!isAuditLoading && !hasAuditEvents ? (
+          <div className="empty-state">
+            <strong>표시할 감사 이력이 없습니다.</strong>
+            <p>승인, 평가, 원가 검토 이벤트가 기록되면 이곳에 표시됩니다.</p>
+          </div>
+        ) : null}
+
+        {!isAuditLoading && hasAuditEvents ? (
+          <ol className="audit-list audit-list--wide">
+            {auditEvents.map((item) => (
+              <li key={`${item.actor}-${item.action}-${item.at}`}>
+                <strong>{item.actor}</strong>
+                <span>{item.action}</span>
+                <small>
+                  {item.domain} · {formatDateTime(item.at)}
+                </small>
+              </li>
+            ))}
+          </ol>
+        ) : null}
       </Panel>
     </section>
   );


### PR DESCRIPTION
## 요약

Reviews 화면의 Audit trail을 선택 프로젝트 기준 감사로그 API(`/api/audit-logs`) 우선 로딩으로 전환했습니다. API 호출 중/빈 결과/fallback 상태를 화면에 명시해 로컬 시드 의존을 숨기지 않도록 했습니다.

## 변경 내용

- 선택 프로젝트의 `projectId` 또는 `code`로 `/api/audit-logs?projectId=...&limit=20`을 호출하는 프론트 로더를 추가했습니다.
- 백엔드 `AuditLogListResponse.items`를 기존 `AuditEvent` 화면 모델로 어댑트했습니다.
- Reviews 화면에 감사로그 소스(API/fallback), 로딩 상태, 빈 상태를 추가했습니다.
- API 실패 또는 권한 토큰 누락 시 기존 포트폴리오 감사 이벤트를 fallback으로 표시합니다.
- `docs/dev-logs/2026-04-22-audit-log-api-states.md`에 dev 비교와 브랜치 선택 이유를 기록했습니다.

## 이유

#54의 잔여 범위 중 감사로그는 아직 포트폴리오 summary의 seed/fallback 이벤트를 그대로 표시하고 있었습니다. 이 변경으로 상세/워크스페이스에 이어 리뷰 레이어도 백엔드 응답 중심으로 이동하고, fallback 여부를 사용자가 확인할 수 있게 했습니다.

## 검증

- [x] 관련 테스트를 실행했습니다.
- [ ] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
- [x] 인접한 흐름에서 회귀가 없는지 확인했습니다.

실행한 명령:

```text
cd frontend
npm run build
npm run lint
npx prettier --check src/App.tsx src/app/portfolioData.ts src/views/reviews/ReviewsView.tsx
git diff --check
```

참고: `npm run format:check`는 기존 프론트 전체 포맷 불일치가 남아 있어 별도 정리가 필요합니다. 이번 수정 TypeScript/TSX 파일 포맷 체크는 통과했습니다. 실제 감사로그 API 수동 확인은 EXECUTIVE 권한 JWT와 실행 중인 백엔드가 필요합니다.

## 스크린샷 또는 로그

- Vite production build 성공
- ESLint 오류 없음
- 수정 TS/TSX 파일 Prettier check 통과

## #54 체크리스트 충족 여부

- [x] 포트폴리오 상세/원가관리회계/금융평가 화면이 선택 프로젝트의 API 응답을 우선 사용합니다. (PR #62)
- [x] 감사로그 화면이 선택 프로젝트의 감사로그 API 응답을 우선 사용합니다.
- [x] 로컬 시드는 API 실패 또는 인증 토큰 누락 시 fallback으로만 사용합니다.
- [x] 감사로그 영역에 로딩/빈 상태를 추가했습니다.
- [ ] 포트폴리오 목록 자체의 DB 기반 전환은 아직 남아 있습니다.
- [ ] 전체 화면 공통 에러/재시도 UX 정리는 후속 작업이 필요합니다.

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [ ] 후속 작업이 필요하면 별도 이슈로 분리했습니다.

후속은 현재 #54의 잔여 범위로 유지합니다.

## 브랜치

- [x] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
- [x] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.