### PR TITLE
feat: DB 기반 포트폴리오 요약 전환

### DIFF
--- a/backend/src/main/java/com/costwise/persistence/JdbcProjectPersistenceRepository.java
+++ b/backend/src/main/java/com/costwise/persistence/JdbcProjectPersistenceRepository.java
@@ -120,6 +120,26 @@ public class JdbcProjectPersistenceRepository implements ProjectPersistenceRepos
     }
 
     @Override
+    public List<ProjectRecord> listProjects() {
+        String sql = """
+                select id, code, name, business_type, status, description, created_at
+                  from projects
+                 order by created_at asc, code asc
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql);
+                ResultSet resultSet = statement.executeQuery()) {
+            List<ProjectRecord> projects = new ArrayList<>();
+            while (resultSet.next()) {
+                projects.add(toProject(resultSet));
+            }
+            return projects;
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to list projects", exception);
+        }
+    }
+
+    @Override
     public boolean existsProjectCode(String code) {
         try (Connection connection = openConnection();
                 PreparedStatement statement = connection.prepareStatement("select 1 from projects where code = ?")) {

--- a/backend/src/main/java/com/costwise/persistence/ProjectPersistenceRepository.java
+++ b/backend/src/main/java/com/costwise/persistence/ProjectPersistenceRepository.java
@@ -16,6 +16,8 @@ public interface ProjectPersistenceRepository {
 
     Optional<ProjectRecord> findProject(String projectId);
 
+    List<ProjectRecord> listProjects();
+
     boolean existsProjectCode(String code);
 
     ScenarioRecord createScenario(String projectId, NewScenario scenario);

--- a/backend/src/main/java/com/costwise/service/PortfolioSummaryService.java
+++ b/backend/src/main/java/com/costwise/service/PortfolioSummaryService.java
@@ -6,15 +6,23 @@ import com.costwise.api.dto.PortfolioSummaryResponse.Assumption;
 import com.costwise.api.dto.PortfolioSummaryResponse.HeadquarterSummary;
 import com.costwise.api.dto.PortfolioSummaryResponse.Overview;
 import com.costwise.api.dto.PortfolioSummaryResponse.ProjectSummary;
+import com.costwise.persistence.ProjectPersistenceRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class PortfolioSummaryService {
+    private static final String PORTFOLIO_NAME = "보험사/금융사 전사 포트폴리오 의사결정 플랫폼";
+    private static final String PORTFOLIO_OWNER = "전략기획실";
+
+    private final ProjectPersistenceRepository projectRepository;
 
     private static final List<ProjectSeed> PROJECTS = List.of(
             new ProjectSeed(1, "암보험 신상품 출시", "언더라이팅본부", "UND", 6_500_000_000L, 11_200_000_000L, 2_100_000_000L, 0.182, 2.8, "승인", "중간"),
@@ -38,7 +46,101 @@ public class PortfolioSummaryService {
             new ProjectSeed(19, "성과관리 대시보드", "경영지원본부", "CORP", 3_200_000_000L, 5_100_000_000L, -300_000_000L, 0.097, 4.4, "검토중", "중간"),
             new ProjectSeed(20, "권한통제 재설계", "경영지원본부", "CORP", 2_100_000_000L, 3_700_000_000L, -1_200_000_000L, 0.074, 5.6, "보류", "높음"));
 
+    @Autowired
+    public PortfolioSummaryService(ProjectPersistenceRepository projectRepository) {
+        this.projectRepository = projectRepository;
+    }
+
+    public PortfolioSummaryService() {
+        this.projectRepository = null;
+    }
+
     public PortfolioSummaryResponse loadPortfolioSummary() {
+        PortfolioSummaryResponse dbSummary = loadDbBackedSummary();
+        if (dbSummary != null) {
+            return dbSummary;
+        }
+
+        return loadSeedSummary();
+    }
+
+    private PortfolioSummaryResponse loadDbBackedSummary() {
+        if (projectRepository == null) {
+            return null;
+        }
+
+        try {
+            List<ProjectPersistenceRepository.ProjectRecord> projects = projectRepository.listProjects();
+            if (projects.isEmpty()) {
+                return null;
+            }
+
+            List<ProjectProjection> projectViews = projects.stream()
+                    .map(this::projectProjection)
+                    .toList();
+            List<ProjectProjection> rankedProjects = projectViews.stream()
+                    .sorted(Comparator.comparingLong(ProjectProjection::npvKrw).reversed())
+                    .toList();
+            List<ProjectSummary> projectSummaries = java.util.stream.IntStream.range(0, rankedProjects.size())
+                    .mapToObj(index -> rankedProjects.get(index).toSummary(index + 1))
+                    .toList();
+
+            Map<String, List<ProjectProjection>> projectsByHeadquarter = projectViews.stream()
+                    .collect(Collectors.groupingBy(ProjectProjection::headquarter));
+            List<HeadquarterSummary> headquarters = projectsByHeadquarter.entrySet().stream()
+                    .map(entry -> summarizeProjectedHeadquarter(
+                            headquarterCode(entry.getKey()),
+                            entry.getKey(),
+                            headquarterRisk(entry.getValue()),
+                            entry.getValue()))
+                    .sorted(Comparator.comparing(HeadquarterSummary::code))
+                    .toList();
+
+            long totalInvestment = projectViews.stream().mapToLong(ProjectProjection::investmentKrw).sum();
+            long totalExpectedRevenue = projectViews.stream().mapToLong(ProjectProjection::expectedRevenueKrw).sum();
+            long averageNpv = averageLong(projectViews.stream().map(ProjectProjection::npvKrw).toList());
+            double averageIrr = averageDouble(projectViews.stream().map(ProjectProjection::irr).toList());
+            double averagePayback = averageDouble(projectViews.stream().map(ProjectProjection::paybackYears).toList());
+            int approvedCount = (int) projectViews.stream().filter(project -> "승인".equals(project.status())).count();
+            int conditionalCount = (int) projectViews.stream().filter(project -> "조건부 진행".equals(project.status())).count();
+
+            List<Assumption> assumptions = List.of(
+                    new Assumption("할인율", displayRate(projectViews)),
+                    new Assumption("평가기간", displayPeriod(projectViews)),
+                    new Assumption("데이터 소스", "DB 프로젝트 " + projectViews.size() + "건"),
+                    new Assumption("ABC 적용 본부", headquarters.size() + "개"));
+
+            List<AuditEvent> auditEvents = projectViews.stream()
+                    .flatMap(project -> project.auditEvents().stream())
+                    .sorted(Comparator.comparing(AuditEvent::at).reversed())
+                    .limit(12)
+                    .toList();
+
+            return new PortfolioSummaryResponse(
+                    PORTFOLIO_NAME,
+                    PORTFOLIO_OWNER,
+                    portfolioStatus(projectViews),
+                    portfolioRisk(projectViews),
+                    new Overview(
+                            headquarters.size(),
+                            projectViews.size(),
+                            totalInvestment,
+                            totalExpectedRevenue,
+                            averageNpv,
+                            averageIrr,
+                            averagePayback,
+                            approvedCount,
+                            conditionalCount),
+                    headquarters,
+                    projectSummaries,
+                    assumptions,
+                    auditEvents);
+        } catch (RuntimeException exception) {
+            return null;
+        }
+    }
+
+    private PortfolioSummaryResponse loadSeedSummary() {
         List<ProjectSeed> rankedProjects = PROJECTS.stream()
                 .sorted(Comparator.comparingLong(ProjectSeed::npvKrw).reversed())
                 .toList();
@@ -66,11 +168,11 @@ public class PortfolioSummaryService {
                 .collect(Collectors.groupingBy(ProjectSeed::headquarter));
 
         List<HeadquarterSummary> headquarters = List.of(
-                summarizeHeadquarter("UND", "언더라이팅본부", "중간", projectsByHeadquarter.get("언더라이팅본부")),
-                summarizeHeadquarter("PROD", "상품개발본부", "중간", projectsByHeadquarter.get("상품개발본부")),
-                summarizeHeadquarter("SALES", "영업본부", "중간", projectsByHeadquarter.get("영업본부")),
-                summarizeHeadquarter("IT", "IT본부", "높음", projectsByHeadquarter.get("IT본부")),
-                summarizeHeadquarter("CORP", "경영지원본부", "낮음", projectsByHeadquarter.get("경영지원본부")));
+                summarizeSeedHeadquarter("UND", "언더라이팅본부", "중간", projectsByHeadquarter.get("언더라이팅본부")),
+                summarizeSeedHeadquarter("PROD", "상품개발본부", "중간", projectsByHeadquarter.get("상품개발본부")),
+                summarizeSeedHeadquarter("SALES", "영업본부", "중간", projectsByHeadquarter.get("영업본부")),
+                summarizeSeedHeadquarter("IT", "IT본부", "높음", projectsByHeadquarter.get("IT본부")),
+                summarizeSeedHeadquarter("CORP", "경영지원본부", "낮음", projectsByHeadquarter.get("경영지원본부")));
 
         long totalInvestment = PROJECTS.stream().mapToLong(ProjectSeed::investmentKrw).sum();
         long totalExpectedRevenue = PROJECTS.stream().mapToLong(ProjectSeed::expectedRevenueKrw).sum();
@@ -82,8 +184,8 @@ public class PortfolioSummaryService {
         int conditionalCount = (int) PROJECTS.stream().filter(project -> "조건부 진행".equals(project.status())).count();
 
         return new PortfolioSummaryResponse(
-                "보험사/금융사 전사 포트폴리오 의사결정 플랫폼",
-                "전략기획실",
+                PORTFOLIO_NAME,
+                PORTFOLIO_OWNER,
                 "검토중",
                 "중간",
                 new Overview(
@@ -110,7 +212,7 @@ public class PortfolioSummaryService {
                         new AuditEvent("보안운영팀", "권한 및 감사 로그 정책을 승인했습니다.", "ACCESS", LocalDateTime.parse("2026-04-20T11:42:00"))));
     }
 
-    private HeadquarterSummary summarizeHeadquarter(
+    private HeadquarterSummary summarizeSeedHeadquarter(
             String code, String name, String risk, List<ProjectSeed> seeds) {
         long totalInvestment = seeds.stream().mapToLong(ProjectSeed::investmentKrw).sum();
         long totalExpectedRevenue = seeds.stream().mapToLong(ProjectSeed::expectedRevenueKrw).sum();
@@ -129,6 +231,275 @@ public class PortfolioSummaryService {
                 averageNpv,
                 risk,
                 topProject);
+    }
+
+    private HeadquarterSummary summarizeProjectedHeadquarter(
+            String code, String name, String risk, List<ProjectProjection> projects) {
+        long totalInvestment = projects.stream().mapToLong(ProjectProjection::investmentKrw).sum();
+        long totalExpectedRevenue = projects.stream().mapToLong(ProjectProjection::expectedRevenueKrw).sum();
+        long averageNpv = averageLong(projects.stream().map(ProjectProjection::npvKrw).toList());
+        String topProject = projects.stream()
+                .max(Comparator.comparingLong(ProjectProjection::npvKrw))
+                .map(ProjectProjection::name)
+                .orElse("프로젝트 없음");
+
+        return new HeadquarterSummary(
+                code,
+                name,
+                projects.size(),
+                totalInvestment,
+                totalExpectedRevenue,
+                averageNpv,
+                risk,
+                topProject);
+    }
+
+    private ProjectProjection projectProjection(ProjectPersistenceRepository.ProjectRecord project) {
+        List<ProjectPersistenceRepository.ScenarioRecord> scenarios = projectRepository.listScenarios(project.id());
+        ProjectPersistenceRepository.ScenarioRecord selectedScenario = selectScenario(scenarios);
+        ProjectPersistenceRepository.AnalysisRecord analysis = selectedScenario == null
+                ? new ProjectPersistenceRepository.AnalysisRecord(List.of(), List.of(), null)
+                : projectRepository.findAnalysis(project.id(), selectedScenario.id());
+
+        long investmentKrw = estimateInvestment(analysis.cashFlows());
+        long expectedRevenueKrw = estimateExpectedRevenue(analysis.cashFlows());
+        long npvKrw = decimalToLong(analysis.valuation() == null ? null : analysis.valuation().npv());
+        double irr = decimalToDouble(analysis.valuation() == null ? null : analysis.valuation().irr());
+        double paybackYears = decimalToDouble(analysis.valuation() == null ? null : analysis.valuation().paybackPeriod());
+
+        String headquarter = headquarterName(project.code(), analysis);
+        String status = displayStatus(project.status(), analysis);
+        String risk = displayRisk(analysis, npvKrw);
+
+        List<AuditEvent> auditEvents = projectRepository.listApprovalLogs(project.id()).stream()
+                .map(log -> new AuditEvent(
+                        log.actorName(),
+                        log.comment(),
+                        auditDomain(log.action()),
+                        log.createdAt()))
+                .toList();
+
+        return new ProjectProjection(
+                project.id(),
+                project.code(),
+                project.name(),
+                headquarter,
+                investmentKrw,
+                expectedRevenueKrw,
+                npvKrw,
+                irr,
+                paybackYears,
+                status,
+                risk,
+                analysis.valuation() == null ? null : analysis.valuation().discountRate(),
+                analysis.cashFlows().stream().mapToInt(ProjectPersistenceRepository.CashFlowRecord::periodNo).max().orElse(0),
+                auditEvents);
+    }
+
+    private ProjectPersistenceRepository.ScenarioRecord selectScenario(
+            List<ProjectPersistenceRepository.ScenarioRecord> scenarios) {
+        return scenarios.stream()
+                .filter(ProjectPersistenceRepository.ScenarioRecord::isActive)
+                .filter(ProjectPersistenceRepository.ScenarioRecord::isBaseline)
+                .findFirst()
+                .orElseGet(() -> scenarios.stream()
+                        .filter(ProjectPersistenceRepository.ScenarioRecord::isBaseline)
+                        .findFirst()
+                        .orElseGet(() -> scenarios.stream()
+                                .filter(ProjectPersistenceRepository.ScenarioRecord::isActive)
+                                .findFirst()
+                                .orElse(scenarios.isEmpty() ? null : scenarios.getFirst())));
+    }
+
+    private String headquarterName(String projectCode, ProjectPersistenceRepository.AnalysisRecord analysis) {
+        String ownerDepartment = null;
+        if (analysis.valuation() != null && analysis.valuation().assumptions() != null) {
+            ownerDepartment = analysis.valuation().assumptions().path("ownerDepartment").asText(null);
+        }
+        String code = ownerDepartment != null && !ownerDepartment.isBlank() ? ownerDepartment : codePrefix(projectCode);
+        return switch (code) {
+            case "UND" -> "언더라이팅본부";
+            case "PROD" -> "상품개발본부";
+            case "SALES" -> "영업본부";
+            case "IT" -> "IT본부";
+            case "CORP" -> "경영지원본부";
+            default -> "경영지원본부";
+        };
+    }
+
+    private String displayStatus(String rawStatus, ProjectPersistenceRepository.AnalysisRecord analysis) {
+        if (analysis.valuation() != null && analysis.valuation().assumptions() != null) {
+            String display = analysis.valuation().assumptions().path("displayStatus").asText(null);
+            if (display != null && !display.isBlank()) {
+                return display;
+            }
+        }
+        return switch (rawStatus) {
+            case "approved" -> "승인";
+            case "rejected", "archived" -> "보류";
+            case "in_review" -> "조건부 진행";
+            default -> "검토중";
+        };
+    }
+
+    private String displayRisk(ProjectPersistenceRepository.AnalysisRecord analysis, long npvKrw) {
+        if (analysis.valuation() != null && analysis.valuation().assumptions() != null) {
+            String risk = analysis.valuation().assumptions().path("riskLevel").asText(null);
+            if (risk != null && !risk.isBlank()) {
+                return risk;
+            }
+        }
+        return npvKrw < 0 ? "높음" : "중간";
+    }
+
+    private String auditDomain(String action) {
+        return switch (action) {
+            case "allocated" -> "ABC";
+            case "evaluated" -> "DCF";
+            case "approved", "rejected" -> "ACCESS";
+            default -> "PORTFOLIO";
+        };
+    }
+
+    private long estimateInvestment(List<ProjectPersistenceRepository.CashFlowRecord> cashFlows) {
+        return cashFlows.stream()
+                .filter(cashFlow -> cashFlow.periodNo() == 0)
+                .map(ProjectPersistenceRepository.CashFlowRecord::investmentCashFlow)
+                .findFirst()
+                .map(value -> value.abs().setScale(0, RoundingMode.HALF_UP).longValue())
+                .orElse(0L);
+    }
+
+    private long estimateExpectedRevenue(List<ProjectPersistenceRepository.CashFlowRecord> cashFlows) {
+        BigDecimal total = cashFlows.stream()
+                .filter(cashFlow -> cashFlow.periodNo() > 0)
+                .map(ProjectPersistenceRepository.CashFlowRecord::operatingCashFlow)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        return total.setScale(0, RoundingMode.HALF_UP).longValue();
+    }
+
+    private long decimalToLong(BigDecimal value) {
+        if (value == null) {
+            return 0L;
+        }
+        return value.setScale(0, RoundingMode.HALF_UP).longValue();
+    }
+
+    private double decimalToDouble(BigDecimal value) {
+        if (value == null) {
+            return 0.0;
+        }
+        return value.doubleValue();
+    }
+
+    private long averageLong(List<Long> values) {
+        return values.isEmpty() ? 0L : Math.round(values.stream().mapToLong(Long::longValue).average().orElse(0.0));
+    }
+
+    private double averageDouble(List<Double> values) {
+        return values.isEmpty() ? 0.0 : values.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+    }
+
+    private String portfolioStatus(List<ProjectProjection> projects) {
+        if (projects.stream().anyMatch(project -> "검토중".equals(project.status()))) {
+            return "검토중";
+        }
+        if (projects.stream().anyMatch(project -> "조건부 진행".equals(project.status()))) {
+            return "조건부 진행";
+        }
+        if (projects.stream().allMatch(project -> "승인".equals(project.status()))) {
+            return "승인";
+        }
+        return "검토중";
+    }
+
+    private String portfolioRisk(List<ProjectProjection> projects) {
+        long highRisk = projects.stream().filter(project -> "높음".equals(project.risk())).count();
+        if (highRisk > Math.max(1, projects.size() / 3)) {
+            return "높음";
+        }
+        if (projects.stream().anyMatch(project -> "중간".equals(project.risk()))) {
+            return "중간";
+        }
+        return "낮음";
+    }
+
+    private String headquarterCode(String headquarterName) {
+        return switch (headquarterName) {
+            case "언더라이팅본부" -> "UND";
+            case "상품개발본부" -> "PROD";
+            case "영업본부" -> "SALES";
+            case "IT본부" -> "IT";
+            case "경영지원본부" -> "CORP";
+            default -> "CORP";
+        };
+    }
+
+    private String headquarterRisk(List<ProjectProjection> projects) {
+        long highRisk = projects.stream().filter(project -> "높음".equals(project.risk())).count();
+        if (highRisk > Math.max(1, projects.size() / 2)) {
+            return "높음";
+        }
+        if (projects.stream().anyMatch(project -> "중간".equals(project.risk()))) {
+            return "중간";
+        }
+        return "낮음";
+    }
+
+    private String displayRate(List<ProjectProjection> projects) {
+        List<BigDecimal> rates = projects.stream()
+                .map(ProjectProjection::discountRate)
+                .filter(value -> value != null)
+                .toList();
+        if (rates.isEmpty()) {
+            return "11.5%";
+        }
+        BigDecimal average = rates.stream().reduce(BigDecimal.ZERO, BigDecimal::add)
+                .divide(BigDecimal.valueOf(rates.size()), 4, RoundingMode.HALF_UP);
+        return average.multiply(BigDecimal.valueOf(100)).setScale(2, RoundingMode.HALF_UP) + "%";
+    }
+
+    private String displayPeriod(List<ProjectProjection> projects) {
+        int maxPeriod = projects.stream().mapToInt(ProjectProjection::maxPeriodNo).max().orElse(0);
+        return maxPeriod + "개년";
+    }
+
+    private String codePrefix(String code) {
+        int delimiter = code.indexOf('-');
+        return delimiter > 0 ? code.substring(0, delimiter) : code;
+    }
+
+    private record ProjectProjection(
+            String projectId,
+            String code,
+            String name,
+            String headquarter,
+            long investmentKrw,
+            long expectedRevenueKrw,
+            long npvKrw,
+            double irr,
+            double paybackYears,
+            String status,
+            String risk,
+            BigDecimal discountRate,
+            int maxPeriodNo,
+            List<AuditEvent> auditEvents) {
+
+        private ProjectSummary toSummary(int rank) {
+            return new ProjectSummary(
+                    projectId,
+                    rank,
+                    code,
+                    name,
+                    headquarter,
+                    investmentKrw,
+                    expectedRevenueKrw,
+                    npvKrw,
+                    irr,
+                    paybackYears,
+                    status,
+                    risk);
+        }
     }
 
     private record ProjectSeed(

--- a/backend/src/test/java/com/costwise/service/PortfolioSummaryServiceTest.java
+++ b/backend/src/test/java/com/costwise/service/PortfolioSummaryServiceTest.java
@@ -1,8 +1,15 @@
 package com.costwise.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.costwise.api.dto.PortfolioSummaryResponse;
+import com.costwise.persistence.ProjectPersistenceRepository;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class PortfolioSummaryServiceTest {
@@ -27,5 +34,83 @@ class PortfolioSummaryServiceTest {
         PortfolioSummaryResponse second = service.loadPortfolioSummary();
 
         assertThat(second).isEqualTo(first);
+    }
+
+    @Test
+    void loadPortfolioSummaryUsesDbBackedProjectionWhenPersistedProjectsExist() {
+        ProjectPersistenceRepository repository = mock(ProjectPersistenceRepository.class);
+        PortfolioSummaryService dbBackedService = new PortfolioSummaryService(repository);
+
+        String projectId = "20000000-0000-0000-0000-000000000099";
+        String scenarioId = "30000000-0000-0000-0000-000000000099";
+        when(repository.listProjects()).thenReturn(List.of(
+                new ProjectPersistenceRepository.ProjectRecord(
+                        projectId,
+                        "UND-2026-099",
+                        "DB 기반 프로젝트",
+                        "insurance_product",
+                        "in_review",
+                        "db record",
+                        LocalDateTime.parse("2026-04-22T09:00:00"))));
+        when(repository.listScenarios(projectId)).thenReturn(List.of(
+                new ProjectPersistenceRepository.ScenarioRecord(
+                        scenarioId,
+                        "기준 시나리오",
+                        "기준",
+                        true,
+                        true,
+                        LocalDateTime.parse("2026-04-22T09:10:00"))));
+        when(repository.findAnalysis(projectId, scenarioId)).thenReturn(new ProjectPersistenceRepository.AnalysisRecord(
+                List.of(),
+                List.of(
+                        new ProjectPersistenceRepository.CashFlowRecord(
+                                0,
+                                "투자시점",
+                                "2026",
+                                BigDecimal.ZERO,
+                                new BigDecimal("-1500000000"),
+                                BigDecimal.ZERO,
+                                new BigDecimal("-1500000000"),
+                                new BigDecimal("0.115")),
+                        new ProjectPersistenceRepository.CashFlowRecord(
+                                1,
+                                "1년차",
+                                "2027",
+                                new BigDecimal("900000000"),
+                                BigDecimal.ZERO,
+                                BigDecimal.ZERO,
+                                new BigDecimal("900000000"),
+                                new BigDecimal("0.115"))),
+                new ProjectPersistenceRepository.ValuationRecord(
+                        new BigDecimal("0.115"),
+                        new BigDecimal("280000000"),
+                        new BigDecimal("0.134"),
+                        new BigDecimal("3.20"),
+                        "recommend",
+                        JsonNodeFactory.instance.objectNode()
+                                .put("ownerDepartment", "UND")
+                                .put("displayStatus", "조건부 진행")
+                                .put("riskLevel", "낮음"))));
+        when(repository.listApprovalLogs(projectId)).thenReturn(List.of(
+                new ProjectPersistenceRepository.ApprovalLogRecord(
+                        "finance_reviewer",
+                        "재무검토자",
+                        "evaluated",
+                        "DCF 재평가를 완료했습니다.",
+                        LocalDateTime.parse("2026-04-22T09:30:00"))));
+
+        PortfolioSummaryResponse summary = dbBackedService.loadPortfolioSummary();
+
+        assertThat(summary.overview().projectCount()).isEqualTo(1);
+        assertThat(summary.overview().headquarterCount()).isEqualTo(1);
+        assertThat(summary.projects()).hasSize(1);
+        assertThat(summary.projects().getFirst().projectId()).isEqualTo(projectId);
+        assertThat(summary.projects().getFirst().headquarter()).isEqualTo("언더라이팅본부");
+        assertThat(summary.projects().getFirst().status()).isEqualTo("조건부 진행");
+        assertThat(summary.projects().getFirst().risk()).isEqualTo("낮음");
+        assertThat(summary.projects().getFirst().investmentKrw()).isEqualTo(1_500_000_000L);
+        assertThat(summary.projects().getFirst().expectedRevenueKrw()).isEqualTo(900_000_000L);
+        assertThat(summary.auditEvents()).hasSize(1);
+        assertThat(summary.auditEvents().getFirst().domain()).isEqualTo("DCF");
     }
 }

--- a/docs/dev-logs/2026-04-22-db-backed-portfolio-summary.md
+++ b/docs/dev-logs/2026-04-22-db-backed-portfolio-summary.md
@@ -1,0 +1,23 @@
+# DB Backed Portfolio Summary
+
+## 기준 브랜치
+
+- 기준: `dev` (`63dd92a`, PR #63 병합 후 최신)
+- 작업 브랜치: `feat/54-db-portfolio-summary`
+- 선택 이유: #54 잔여 범위 중 포트폴리오 목록 API를 DB 기반으로 전환하는 백엔드 슬라이스를 프론트 변경과 분리해 충돌을 줄인다.
+
+## 워킹트리 비교
+
+- 변경 전: `/api/portfolio/summary`는 `PortfolioSummaryService`의 고정 seed(`PROJECTS`)만 사용했다.
+- 변경 후: `ProjectPersistenceRepository`에서 프로젝트 목록을 읽어 DB 기반 요약을 우선 생성하고, DB 조회 실패/빈 결과일 때 기존 seed 요약으로 폴백한다.
+- DB 경로에서는 시나리오/분석/승인로그를 조합해 project/headquarter/overview/audit 이벤트를 계산한다.
+- API 계약(`PortfolioSummaryResponse` 필드 구조)은 유지한다.
+
+## 검증
+
+- `backend`: `.\gradlew.bat test --tests com.costwise.service.PortfolioSummaryServiceTest --tests com.costwise.service.CostAccountingServiceTest --tests com.costwise.service.ValuationRiskServiceTest --tests com.costwise.api.workflow.WorkflowControllerSecurityTest --tests com.costwise.workflow.ApprovalWorkflowServiceTest`
+
+## 리스크/후속
+
+- 프로젝트 상태(`draft/in_review/...`)와 화면 상태(`검토중/조건부 진행/...`) 간 1:1 매핑 정보가 스키마에 완전하지 않아 일부는 가정 매핑을 사용한다.
+- 본부/리스크는 valuation assumptions 메타데이터가 없으면 코드 prefix/기본값으로 폴백한다.


### PR DESCRIPTION
## 요약

`/api/portfolio/summary`가 고정 seed만 쓰던 경로에서, DB persisted 프로젝트/시나리오/분석 데이터를 우선 집계하도록 전환했습니다. DB 조회 실패나 데이터 미존재 시에는 기존 seed 응답으로 폴백합니다.

## 변경 내용

- `ProjectPersistenceRepository`에 `listProjects()` 조회 계약을 추가했습니다.
- `JdbcProjectPersistenceRepository`에 프로젝트 목록 조회 구현을 추가했습니다.
- `PortfolioSummaryService`를 DB 우선 집계 + seed fallback 구조로 변경했습니다.
- DB 경로에서 프로젝트/본부/overview/audit 이벤트를 계산하고 기존 `PortfolioSummaryResponse` 계약을 유지했습니다.
- `PortfolioSummaryServiceTest`에 DB 기반 요약 경로 단위 테스트를 추가했습니다.
- `docs/dev-logs/2026-04-22-db-backed-portfolio-summary.md`에 브랜치 선택과 검증 로그를 기록했습니다.

## 이유

#54 잔여 범위 중 핵심은 포트폴리오 목록 API의 실데이터 전환입니다. 상세/감사로그 화면은 이미 API 우선으로 전환됐지만 목록 API는 seed 고정이어서, 프론트/백엔드 수치 일관성에 한계가 있었습니다.

## 검증

- [x] 관련 테스트를 실행했습니다.
- [ ] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
- [x] 인접한 흐름에서 회귀가 없는지 확인했습니다.

실행한 명령:

```text
cd backend
.\gradlew.bat test --tests com.costwise.service.PortfolioSummaryServiceTest --tests com.costwise.service.CostAccountingServiceTest --tests com.costwise.service.ValuationRiskServiceTest --tests com.costwise.api.workflow.WorkflowControllerSecurityTest --tests com.costwise.workflow.ApprovalWorkflowServiceTest

# pre-commit hook 자동 실행
.\gradlew.bat check
```

## 스크린샷 또는 로그

- Gradle `test` 성공
- pre-commit backend `gradle check` 성공

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [ ] 후속 작업이 필요하면 별도 이슈로 분리했습니다.

후속은 #54의 남은 범위(공통 에러/재시도 UX 정리 등)로 유지합니다.

## 브랜치

- [x] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
- [x] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.