### PR TITLE
feat: #49 원가 배부 기준·계산 근거·변경 이력 가시화 (1차)

### DIFF
--- a/backend/src/main/java/com/costwise/api/dto/CostAccountingSummaryResponse.java
+++ b/backend/src/main/java/com/costwise/api/dto/CostAccountingSummaryResponse.java
@@ -31,13 +31,16 @@ public record CostAccountingSummaryResponse(
             String projectId,
             String projectName,
             String headquarter,
+            String allocationBasis,
+            long driverVolume,
             long personnelCostKrw,
             long projectDirectCostKrw,
             long standardAllocatedCostKrw,
             long standardCostKrw,
             long actualCostKrw,
             long costVarianceKrw,
-            long internalTransferNetKrw) {}
+            long internalTransferNetKrw,
+            String calculationTrace) {}
 
     public record FactorAnalysis(String factor, long varianceImpactKrw, String note) {}
 }

--- a/backend/src/main/java/com/costwise/service/CostAccountingService.java
+++ b/backend/src/main/java/com/costwise/service/CostAccountingService.java
@@ -47,6 +47,8 @@ public class CostAccountingService {
             long actualCost = personnelCost + projectDirectCost + enterpriseAllocatedCost + round(project.investmentKrw() * plan.transferShare());
             long transferNet = round(project.investmentKrw() * plan.transferShare());
             long variance = actualCost - standardCost;
+            String allocationBasis = "활동기준(인력55%+직접비45%)";
+            String calculationTrace = "표준원가=인력원가+프로젝트직접비+표준배부액, 실제원가=표준원가+전사배부액+내부대체가액";
 
             projectCostViews.add(
                     new ProjectCostView(
@@ -54,6 +56,8 @@ public class CostAccountingService {
                             project.code(),
                             project.name(),
                             project.headquarter(),
+                            allocationBasis,
+                            driverVolume,
                             personnelCost,
                             projectDirectCost,
                             standardAllocatedCost,
@@ -61,7 +65,8 @@ public class CostAccountingService {
                             standardCost,
                             actualCost,
                             variance,
-                            transferNet));
+                            transferNet,
+                            calculationTrace));
         }
 
         Map<String, List<ProjectCostView>> byHeadquarter = new LinkedHashMap<>();
@@ -144,13 +149,16 @@ public class CostAccountingService {
                 project.projectId(),
                 project.projectName(),
                 project.headquarter(),
+                project.allocationBasis(),
+                project.driverVolume(),
                 project.personnelCostKrw(),
                 project.projectDirectCostKrw(),
                 project.standardAllocatedCostKrw(),
                 project.standardCostKrw(),
                 project.actualCostKrw(),
                 project.costVarianceKrw(),
-                project.internalTransferNetKrw());
+                project.internalTransferNetKrw(),
+                project.calculationTrace());
     }
 
     private HeadquarterPlan planFor(String headquarter) {
@@ -190,6 +198,8 @@ public class CostAccountingService {
             String projectId,
             String projectName,
             String headquarter,
+            String allocationBasis,
+            long driverVolume,
             long personnelCostKrw,
             long projectDirectCostKrw,
             long standardAllocatedCostKrw,
@@ -197,5 +207,6 @@ public class CostAccountingService {
             long standardCostKrw,
             long actualCostKrw,
             long costVarianceKrw,
-            long internalTransferNetKrw) {}
+            long internalTransferNetKrw,
+            String calculationTrace) {}
 }

--- a/backend/src/test/java/com/costwise/service/CostAccountingServiceTest.java
+++ b/backend/src/test/java/com/costwise/service/CostAccountingServiceTest.java
@@ -48,6 +48,9 @@ class CostAccountingServiceTest {
         assertThat(project.actualCostKrw()).isPositive();
         assertThat(project.costVarianceKrw()).isNotZero();
         assertThat(project.internalTransferNetKrw()).isPositive();
+        assertThat(project.allocationBasis()).isNotBlank();
+        assertThat(project.driverVolume()).isPositive();
+        assertThat(project.calculationTrace()).isNotBlank();
         assertThat(summary.factorAnalysis())
                 .extracting(CostAccountingSummaryResponse.FactorAnalysis::factor)
                 .contains("인력 원가", "프로젝트 직접비", "내부대체가액", "표준원가 배분", "원가/성과 요인");

--- a/docs/dev-logs/2026-04-23-cost-accounting-traceability-phase1.md
+++ b/docs/dev-logs/2026-04-23-cost-accounting-traceability-phase1.md
@@ -1,0 +1,28 @@
+# Cost Accounting Traceability Phase 1
+
+## 기준 브랜치
+
+- 기준: `dev` (`28dcf79`)
+- 작업 브랜치: `feat/issue-49-cost-accounting-traceability`
+- 선택 이유: #49를 한 번에 크게 바꾸기보다, 사용자 가시성이 높은 "배부 기준/계산 근거/변경 이력"을 먼저 안정적으로 반영
+
+## 워킹트리 비교
+
+- 변경 전:
+  - 원가관리회계 화면에서 합계/지표는 보이지만 배부 기준과 계산식 설명, 변경 이력 노출이 제한적
+  - 원가요약 API의 프로젝트 단위 응답에 배부 기준/드라이버/계산 근거 문구가 없음
+- 변경 후:
+  - `CostAccountingSummaryResponse.ProjectCostSummary`에 `allocationBasis`, `driverVolume`, `calculationTrace` 추가
+  - `CostAccountingService`가 프로젝트별 배부 기준 문자열, 드라이버 볼륨, 계산식 추적 문구를 함께 제공
+  - 프론트 관리회계 탭에서 배부 규칙 상세 테이블, 계산 근거, 최근 변경 이력(approval logs 기반) 표시
+
+## 검증
+
+- `backend`: `.\\gradlew.bat test` 통과
+- `frontend`: `npm run lint` 통과
+- `frontend`: `npm run build` 통과
+
+## 리스크/후속
+
+- #49의 "입력 화면/API 보강" 중 입력 작성 UX 자체는 후속 단계에서 별도 구현 필요
+- 현재 변경 이력은 승인 로그 기반이며, 배부 규칙 단위의 세분화된 diff 이벤트 모델은 후속 도입 가능

--- a/frontend/src/app/portfolioData.ts
+++ b/frontend/src/app/portfolioData.ts
@@ -50,6 +50,23 @@ export type ProjectDetail = {
     allocatedCostKrw: number;
     efficiencyGapKrw: number;
     performanceGapKrw: number;
+    allocationBasis: string;
+    calculationTrace: string;
+    rules: Array<{
+      departmentCode: string;
+      basis: string;
+      allocationRate: number;
+      costPoolName: string;
+      costPoolCategory: string;
+      costPoolAmount: number;
+      allocatedAmount: number;
+    }>;
+    changeHistory: Array<{
+      actor: string;
+      action: string;
+      comment: string;
+      at: string;
+    }>;
   };
   valuation: {
     fairValueKrw: number;
@@ -876,6 +893,21 @@ function adaptProjectDetail(
   const approvalStage = approvalStageFromStatus(
     persistedDetail.approval?.status ?? persistedDetail.status
   );
+  const allocationRules = scenario.allocationRules.map((rule) => ({
+    departmentCode: rule.departmentCode ?? '-',
+    basis: rule.basis ?? '-',
+    allocationRate: toNumber(rule.allocationRate, 0),
+    costPoolName: rule.costPoolName ?? '-',
+    costPoolCategory: rule.costPoolCategory ?? '-',
+    costPoolAmount: toNumber(rule.costPoolAmount, 0),
+    allocatedAmount: toNumber(rule.allocatedAmount, 0)
+  }));
+  const changeHistory = (persistedDetail.approval?.logs ?? []).map((log) => ({
+    actor: log.actorName ?? '담당자',
+    action: log.action ?? 'updated',
+    comment: log.comment ?? '',
+    at: log.createdAt ?? new Date().toISOString()
+  }));
 
   return {
     code: persistedDetail.code || project.code,
@@ -908,7 +940,16 @@ function adaptProjectDetail(
         standardCostKrw,
       performanceGapKrw:
         operatingCashFlow -
-        (allocationTotal || defaults.allocation.allocatedCostKrw)
+        (allocationTotal || defaults.allocation.allocatedCostKrw),
+      allocationBasis:
+        allocationRules.length > 0
+          ? '시나리오 배부 규칙 기반(부서/비용풀/배부율)'
+          : defaults.allocation.allocationBasis,
+      calculationTrace:
+        '표준원가=인력+직접비+표준배부, 실제원가=배부원가+내부대체가액, 성과갭=영업현금흐름-배부원가',
+      rules: allocationRules.length > 0 ? allocationRules : defaults.allocation.rules,
+      changeHistory:
+        changeHistory.length > 0 ? changeHistory : defaults.allocation.changeHistory
     },
     valuation: {
       fairValueKrw: toNumber(
@@ -1055,7 +1096,12 @@ function buildDetailDefaultsFromProject(
       standardCostKrw,
       allocatedCostKrw,
       efficiencyGapKrw: allocatedCostKrw - standardCostKrw,
-      performanceGapKrw: project.expectedRevenueKrw - allocatedCostKrw
+      performanceGapKrw: project.expectedRevenueKrw - allocatedCostKrw,
+      allocationBasis: '프로젝트 투자구조 기반 기본 배부식',
+      calculationTrace:
+        '표준원가=인력+직접비+표준배부, 실제원가=배부원가+내부대체가액, 성과갭=예상수익-배부원가',
+      rules: [],
+      changeHistory: []
     },
     valuation: {
       fairValueKrw: Math.round(project.expectedRevenueKrw * 0.82),
@@ -1159,7 +1205,12 @@ export function buildProjectDetail(projectCode: string): ProjectDetail {
       standardCostKrw,
       allocatedCostKrw,
       efficiencyGapKrw,
-      performanceGapKrw
+      performanceGapKrw,
+      allocationBasis: 'seed 기준 배부식',
+      calculationTrace:
+        '표준원가=인력+직접비+표준배부, 실제원가=배부원가+내부대체가액, 성과갭=예상수익-배부원가',
+      rules: [],
+      changeHistory: []
     },
     valuation: {
       fairValueKrw: Math.round(seed.expectedRevenueKrw * 0.82),

--- a/frontend/src/views/workspace/WorkspaceView.tsx
+++ b/frontend/src/views/workspace/WorkspaceView.tsx
@@ -271,6 +271,73 @@ export function WorkspaceView({
                 ]}
               />
             </section>
+            <section className="cockpit-support-grid" aria-label="배부 기준과 변경 이력">
+              <article className="workflow-note">
+                <strong>계산 근거</strong>
+                <p>{selectedDetail.allocation.allocationBasis}</p>
+                <p>{selectedDetail.allocation.calculationTrace}</p>
+              </article>
+              <article className="workflow-note">
+                <strong>최근 변경 이력</strong>
+                {selectedDetail.allocation.changeHistory.length === 0 ? (
+                  <p>기록된 변경 이력이 없습니다.</p>
+                ) : (
+                  <ol className="audit-list">
+                    {selectedDetail.allocation.changeHistory
+                      .slice(0, 5)
+                      .map((history) => (
+                        <li
+                          key={`${history.at}-${history.actor}-${history.action}`}
+                        >
+                          <strong>{history.actor}</strong>
+                          <span>
+                            {history.action} · {history.comment || '-'}
+                          </span>
+                          <small>{new Date(history.at).toLocaleString()}</small>
+                        </li>
+                      ))}
+                  </ol>
+                )}
+              </article>
+            </section>
+            <section
+              className="cockpit-dominant-surface"
+              aria-label="배부 규칙 상세"
+            >
+              <h3>배부 규칙 상세</h3>
+              {selectedDetail.allocation.rules.length === 0 ? (
+                <p>배부 규칙 상세 데이터가 없습니다.</p>
+              ) : (
+                <div className="table-shell">
+                  <table className="data-table">
+                    <thead>
+                      <tr>
+                        <th>부서</th>
+                        <th>비용풀</th>
+                        <th>카테고리</th>
+                        <th>배부 기준</th>
+                        <th>배부율</th>
+                        <th>배부원가</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {selectedDetail.allocation.rules.map((rule) => (
+                        <tr
+                          key={`${rule.departmentCode}-${rule.costPoolName}-${rule.basis}`}
+                        >
+                          <td>{rule.departmentCode}</td>
+                          <td>{rule.costPoolName}</td>
+                          <td>{rule.costPoolCategory}</td>
+                          <td>{rule.basis}</td>
+                          <td>{formatPercent(rule.allocationRate)}</td>
+                          <td>{formatKrwCompact(rule.allocatedAmount)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </section>
           </>
         ) : null}
 


### PR DESCRIPTION
## 요약

#49 1차로 원가·관리회계 화면에서 배부 기준, 계산 근거, 변경 이력을 직접 확인할 수 있도록 API/프론트를 보강했습니다.

## 변경 내용

- 백엔드 `CostAccountingSummaryResponse.ProjectCostSummary` 확장
  - `allocationBasis`, `driverVolume`, `calculationTrace` 추가
- 백엔드 `CostAccountingService` 보강
  - 프로젝트별 배부 기준 문자열, 드라이버 볼륨, 계산 추적 문구 생성
- 프론트 `ProjectDetail` 모델 확장
  - `allocation.rules`, `allocation.changeHistory`, `allocation.allocationBasis`, `allocation.calculationTrace` 추가
- 프론트 관리회계 탭 보강
  - 배부 규칙 상세 테이블
  - 계산 근거 문구
  - 최근 변경 이력(approval logs 기반)
- 문서
  - `docs/dev-logs/2026-04-23-cost-accounting-traceability-phase1.md` 추가

## 이유

- #49 완료조건의 핵심인 “배부 기준과 원가 근거 직접 확인” 및 “결과값뿐 아니라 계산 근거 설명 가능”을 우선 충족하기 위한 단계입니다.

## 검증

- [x] 관련 테스트를 실행했습니다.
- [ ] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
- [x] 인접한 흐름에서 회귀가 없는지 확인했습니다.

실행 결과:
- `backend`: `.\\gradlew.bat test` 통과
- `frontend`: `npm run lint` 통과
- `frontend`: `npm run build` 통과

## 스크린샷 또는 로그

- 스크린샷 미첨부
- 테스트/빌드 로그는 로컬 실행으로 확인

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [x] 후속 작업이 필요하면 별도 이슈로 분리했습니다. (`#49` 후속: 입력 작성 UX/API 확장)

## 브랜치

- [x] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
- [x] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.

관련 이슈: Refs #49
