### PR TITLE
feat: #51 평가 근거 데이터·시나리오 구조 보강 (1차)

### DIFF
--- a/backend/src/main/java/com/costwise/api/dto/ValuationRiskResponse.java
+++ b/backend/src/main/java/com/costwise/api/dto/ValuationRiskResponse.java
@@ -7,6 +7,7 @@ public record ValuationRiskResponse(
         String projectId,
         String projectName,
         ProjectValuation projectValuation,
+        ValuationBasis valuationBasis,
         StockValuation stockValuation,
         BondValuation bondValuation,
         DerivativeValuation derivativeValuation,
@@ -18,6 +19,19 @@ public record ValuationRiskResponse(
             Double irr,
             Double paybackPeriodYears,
             String outlook) {}
+
+    public record ValuationBasis(
+            BigDecimal discountRate,
+            BigDecimal riskPremium,
+            String ownerDepartment,
+            String interpretation,
+            List<ScenarioAssumption> scenarioAssumptions) {}
+
+    public record ScenarioAssumption(
+            String label,
+            BigDecimal npv,
+            BigDecimal probability,
+            String note) {}
 
     public record StockValuation(
             String symbol,

--- a/backend/src/main/java/com/costwise/service/ValuationRiskService.java
+++ b/backend/src/main/java/com/costwise/service/ValuationRiskService.java
@@ -161,7 +161,8 @@ public class ValuationRiskService {
         ProjectProfile profile = projectProfile(projectId);
 
         List<ComputeRequest.CashFlowInput> cashFlows = profile.cashFlows();
-        BigDecimal discountRate = BigDecimal.valueOf(0.115);
+        BigDecimal riskPremium = profile.riskPremium();
+        BigDecimal discountRate = BigDecimal.valueOf(0.085).add(riskPremium);
         DcfValuationService.DcfResult dcfResult = dcfValuationService.evaluate(cashFlows, discountRate);
 
         BigDecimal npv =
@@ -186,6 +187,32 @@ public class ValuationRiskService {
                 npv.multiply(BigDecimal.valueOf(0.75)),
                 npv.multiply(BigDecimal.valueOf(0.40)),
                 npv.multiply(BigDecimal.valueOf(-0.30)));
+        List<ValuationRiskResponse.ScenarioAssumption> scenarioAssumptions = List.of(
+                new ValuationRiskResponse.ScenarioAssumption(
+                        "낙관",
+                        scale(scenarioValues.get(0)),
+                        BigDecimal.valueOf(0.20),
+                        "시장 성장률과 전환율이 목표 대비 상회"),
+                new ValuationRiskResponse.ScenarioAssumption(
+                        "기준",
+                        scale(scenarioValues.get(1)),
+                        BigDecimal.valueOf(0.45),
+                        "현재 사업계획 기준 현금흐름 유지"),
+                new ValuationRiskResponse.ScenarioAssumption(
+                        "보수",
+                        scale(scenarioValues.get(2)),
+                        BigDecimal.valueOf(0.20),
+                        "비용 상승과 매출 지연을 반영"),
+                new ValuationRiskResponse.ScenarioAssumption(
+                        "스트레스",
+                        scale(scenarioValues.get(3)),
+                        BigDecimal.valueOf(0.10),
+                        "규제/시장 충격 시나리오"),
+                new ValuationRiskResponse.ScenarioAssumption(
+                        "최악",
+                        scale(scenarioValues.get(4)),
+                        BigDecimal.valueOf(0.05),
+                        "대체 투자안 전환 필요 구간"));
         RiskMetricsResult riskMetrics = calculateRiskMetrics(scenarioValues);
         CreditRiskResult creditRisk = assessCreditRisk(profile.creditRiskInput());
 
@@ -193,6 +220,12 @@ public class ValuationRiskService {
                 profile.projectId(),
                 profile.projectName(),
                 projectValuation,
+                new ValuationRiskResponse.ValuationBasis(
+                        scale(discountRate),
+                        scale(riskPremium),
+                        profile.headquarterCode(),
+                        profile.interpretation(),
+                        scenarioAssumptions),
                 new ValuationRiskResponse.StockValuation(
                         stockValuation.symbol(),
                         stockValuation.currentPrice(),
@@ -318,7 +351,7 @@ public class ValuationRiskService {
         private CreditRiskInput creditRiskInput() {
             double leverage = 2.8 + (baseInvestmentKrw / 1_000_000_000.0);
             double coverage = 4.0 + (baseInvestmentKrw / 2_000_000_000.0);
-            double volatility = 0.18 + (baseInvestmentKrw / 10_000_000_000.0) + riskPremium();
+            double volatility = 0.18 + (baseInvestmentKrw / 10_000_000_000.0) + riskPremium().doubleValue();
             double debtRatio = 10.0 + (baseInvestmentKrw / 50_000_000_000.0);
             return new CreditRiskInput(
                     BigDecimal.valueOf(leverage).setScale(2, RoundingMode.HALF_UP),
@@ -327,11 +360,29 @@ public class ValuationRiskService {
                     BigDecimal.valueOf(debtRatio).setScale(2, RoundingMode.HALF_UP));
         }
 
-        private double riskPremium() {
+        private BigDecimal riskPremium() {
             return switch (riskLevel) {
-                case "높음" -> 0.08;
-                case "중간" -> 0.04;
-                default -> 0.01;
+                case "높음" -> new BigDecimal("0.08");
+                case "중간" -> new BigDecimal("0.04");
+                default -> new BigDecimal("0.01");
+            };
+        }
+
+        private String headquarterCode() {
+            return switch (headquarter) {
+                case "언더라이팅본부" -> "UND";
+                case "상품개발본부" -> "PROD";
+                case "영업본부" -> "SALES";
+                case "IT본부" -> "IT";
+                default -> "CORP";
+            };
+        }
+
+        private String interpretation() {
+            return switch (riskLevel) {
+                case "높음" -> "현금흐름 변동성이 높아 보수적 할인율과 하방 시나리오를 우선 검토";
+                case "중간" -> "기준 시나리오 중심으로 승인 조건을 검토하되 하방 보호장치 필요";
+                default -> "현금흐름 안정 구간으로 기준 시나리오 중심 의사결정 가능";
             };
         }
     }

--- a/backend/src/test/java/com/costwise/service/ValuationRiskServiceTest.java
+++ b/backend/src/test/java/com/costwise/service/ValuationRiskServiceTest.java
@@ -107,6 +107,7 @@ class ValuationRiskServiceTest {
         assertEquals("13", result.projectId());
         assertEquals("디지털 플랫폼 구축", result.projectName());
         assertNotNull(result.projectValuation());
+        assertNotNull(result.valuationBasis());
         assertNotNull(result.stockValuation());
         assertNotNull(result.bondValuation());
         assertNotNull(result.derivativeValuation());
@@ -114,6 +115,9 @@ class ValuationRiskServiceTest {
         assertNotNull(result.creditRisk());
         assertTrue(result.projectValuation().npv().compareTo(BigDecimal.ZERO) > 0);
         assertEquals(5, result.riskMetrics().scenarioValues().size());
+        assertEquals(5, result.valuationBasis().scenarioAssumptions().size());
+        assertNotNull(result.valuationBasis().discountRate());
+        assertNotNull(result.valuationBasis().riskPremium());
     }
 
     @Test

--- a/docs/dev-logs/2026-04-23-valuation-basis-phase1.md
+++ b/docs/dev-logs/2026-04-23-valuation-basis-phase1.md
@@ -1,0 +1,29 @@
+# Valuation Basis Phase 1
+
+## 기준 브랜치
+
+- 기준: `dev` (`7f161da`)
+- 작업 브랜치: `feat/issue-51-valuation-basis-phase1`
+- 선택 이유: #51을 단계적으로 진행하기 위해, 평가 근거 데이터/시나리오 구조를 API와 화면에 먼저 노출
+
+## 워킹트리 비교
+
+- 변경 전:
+  - `/api/valuation-risk/projects/{id}`는 평가 수치 중심 응답이며 할인율/리스크프리미엄/해석/시나리오 근거 메타데이터가 부족
+  - 프론트 금융평가 탭은 결과 수치 위주로 표시되어 평가 근거 설명력이 제한됨
+- 변경 후:
+  - `ValuationRiskResponse`에 `valuationBasis`(discountRate, riskPremium, ownerDepartment, interpretation, scenarioAssumptions) 추가
+  - `ValuationRiskService`에서 프로젝트 리스크 수준 기반 할인율/리스크프리미엄과 시나리오 가정 구조를 함께 생성
+  - 프론트 상세 모델(`ProjectDetail.valuation`)에 평가근거 필드 반영
+  - 금융평가 탭에 평가 근거/시나리오 가정 섹션 추가
+
+## 검증
+
+- `backend`: `.\\gradlew.bat test` 통과
+- `frontend`: `npm run lint` 통과
+- `frontend`: `npm run build` 통과
+
+## 리스크/후속
+
+- #51의 “프로젝트 평가/금융상품 평가의 공통·개별 모델 정교화”는 후속 단계에서 입력 모델/API 분리 수준으로 확장 필요
+- 현재 시나리오 가정은 서비스 내부 생성값이므로, 저장된 시나리오 입력과 직접 연결하는 작업은 추가 필요

--- a/frontend/src/app/portfolioData.ts
+++ b/frontend/src/app/portfolioData.ts
@@ -77,6 +77,15 @@ export type ProjectDetail = {
     convexity: number;
     creditRiskScore: number;
     creditGrade: string;
+    discountRate: number;
+    riskPremium: number;
+    interpretation: string;
+    assumptions: Array<{
+      label: string;
+      npvKrw: number;
+      probability: number;
+      note: string;
+    }>;
   };
   scenarioReturns: Array<{
     label: '낙관' | '기준' | '비관';
@@ -825,6 +834,18 @@ type ValuationRiskApiResponse = {
     score?: number | string;
     ratingBand?: string;
   };
+  valuationBasis?: {
+    discountRate?: number | string;
+    riskPremium?: number | string;
+    ownerDepartment?: string;
+    interpretation?: string;
+    scenarioAssumptions?: Array<{
+      label?: string;
+      npv?: number | string;
+      probability?: number | string;
+      note?: string;
+    }>;
+  };
 };
 
 type AuditLogListApiResponse = {
@@ -984,7 +1005,25 @@ function adaptProjectDetail(
       ),
       creditGrade:
         ratingLabel(valuationRisk.creditRisk?.ratingBand) ??
-        defaults.valuation.creditGrade
+        defaults.valuation.creditGrade,
+      discountRate: toNumber(
+        valuationRisk.valuationBasis?.discountRate,
+        defaults.valuation.discountRate
+      ),
+      riskPremium: toNumber(
+        valuationRisk.valuationBasis?.riskPremium,
+        defaults.valuation.riskPremium
+      ),
+      interpretation:
+        valuationRisk.valuationBasis?.interpretation ??
+        defaults.valuation.interpretation,
+      assumptions:
+        valuationRisk.valuationBasis?.scenarioAssumptions?.map((item) => ({
+          label: item.label ?? '-',
+          npvKrw: toNumber(item.npv, 0),
+          probability: toNumber(item.probability, 0),
+          note: item.note ?? ''
+        })) ?? defaults.valuation.assumptions
     },
     scenarioReturns: buildScenarioReturns(npvKrw, scenarioValues),
     workflow: {
@@ -1111,7 +1150,11 @@ function buildDetailDefaultsFromProject(
       duration: Number((1.5 + project.paybackYears * 0.5).toFixed(2)),
       convexity: Number((3 + project.paybackYears * 0.8).toFixed(2)),
       creditRiskScore: 72,
-      creditGrade: 'A'
+      creditGrade: 'A',
+      discountRate: 0.115,
+      riskPremium: 0.04,
+      interpretation: '기준 시나리오 중심으로 평가',
+      assumptions: []
     },
     scenarioReturns: buildScenarioReturns(project.npvKrw, []),
     workflow: {
@@ -1227,7 +1270,14 @@ export function buildProjectDetail(projectCode: string): ProjectDetail {
             ? 'A'
             : creditRiskScore >= 65
               ? 'BBB'
-              : 'BB'
+              : 'BB',
+      discountRate: 0.115,
+      riskPremium: seed.risk === '높음' ? 0.08 : seed.risk === '중간' ? 0.04 : 0.01,
+      interpretation:
+        seed.risk === '높음'
+          ? '보수적 할인율 기준 재검토 필요'
+          : '기준 시나리오 중심으로 평가',
+      assumptions: []
     },
     scenarioReturns: [
       {

--- a/frontend/src/views/workspace/WorkspaceView.tsx
+++ b/frontend/src/views/workspace/WorkspaceView.tsx
@@ -404,6 +404,36 @@ export function WorkspaceView({
                 value={`${selectedDetail.valuation.convexity}`}
               />
             </section>
+            <section className="cockpit-support-grid" aria-label="평가 근거와 시나리오 가정">
+              <article className="workflow-note">
+                <strong>평가 근거</strong>
+                <p>
+                  할인율 {formatPercent(selectedDetail.valuation.discountRate)} ·
+                  리스크 프리미엄{' '}
+                  {formatPercent(selectedDetail.valuation.riskPremium)}
+                </p>
+                <p>{selectedDetail.valuation.interpretation}</p>
+              </article>
+              <article className="workflow-note">
+                <strong>시나리오 가정</strong>
+                {selectedDetail.valuation.assumptions.length === 0 ? (
+                  <p>등록된 시나리오 가정이 없습니다.</p>
+                ) : (
+                  <ol className="audit-list">
+                    {selectedDetail.valuation.assumptions.map((item) => (
+                      <li key={`${item.label}-${item.note}`}>
+                        <strong>{item.label}</strong>
+                        <span>
+                          NPV {formatKrwCompact(item.npvKrw)} · 확률{' '}
+                          {formatPercent(item.probability)}
+                        </span>
+                        <small>{item.note || '-'}</small>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </article>
+            </section>
           </>
         ) : null}
 


### PR DESCRIPTION
## 요약

#51 1차로 금융평가 결과에 대한 근거 데이터(할인율/리스크프리미엄/시나리오 가정/해석)를 API와 화면에서 직접 확인 가능하도록 보강했습니다.

## 변경 내용

- 백엔드 `ValuationRiskResponse` 확장
  - `valuationBasis` 추가: `discountRate`, `riskPremium`, `ownerDepartment`, `interpretation`, `scenarioAssumptions`
- 백엔드 `ValuationRiskService` 보강
  - 리스크 수준 기반 할인율/프리미엄 계산
  - 시나리오 가정(낙관/기준/보수/스트레스/최악) 구조 생성
- 프론트 상세 모델(`ProjectDetail.valuation`) 확장
  - 할인율/리스크프리미엄/해석/시나리오 가정 필드 반영
- 금융평가 탭 UI 보강
  - 평가 근거 섹션
  - 시나리오 가정 리스트
- 문서
  - `docs/dev-logs/2026-04-23-valuation-basis-phase1.md` 추가

## 이유

- #51 완료조건 중 “평가값이 입력 근거 기반으로 설명 가능”과 “시나리오 비교/리스크 해석 연결”을 우선 충족하기 위한 단계입니다.

## 검증

- [x] 관련 테스트를 실행했습니다.
- [ ] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
- [x] 인접한 흐름에서 회귀가 없는지 확인했습니다.

실행 결과:
- `backend`: `.\\gradlew.bat test` 통과
- `frontend`: `npm run lint` 통과
- `frontend`: `npm run build` 통과

## 스크린샷 또는 로그

- UI 스크린샷 미첨부
- 테스트/빌드 로그는 로컬 실행으로 확인

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [x] 후속 작업이 필요하면 별도 이슈로 분리했습니다. (`#51` 후속: 입력 모델/API 분리 심화)

## 브랜치

- [x] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
- [x] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.

관련 이슈: Refs #51
