### PR TITLE
refactor: #46 users 화면 Tailwind 전환 및 스타일 분리

### DIFF
--- a/docs/dev-logs/2026-04-24-issue46-users-tailwind-slice.md
+++ b/docs/dev-logs/2026-04-24-issue46-users-tailwind-slice.md
@@ -1,0 +1,35 @@
+# 2026-04-24 - Issue #46 Users Tailwind Slice
+
+## Context
+
+- Branch: `feat/46-tailwind-next-slice`
+- Scope: `frontend/src/views/users/*` only
+- Goal: follow file/folder split principle while migrating Users screen styling to Tailwind utilities.
+
+## A/B Comparison
+
+### Option A
+
+- Keep all style strings and UI composition inside `UsersView.tsx`.
+- Pros: fastest one-file change.
+- Cons: violates split principle and keeps view overly dense.
+
+### Option B (selected)
+
+- Split reusable style utilities into `usersView.styles.ts`.
+- Keep behavior/data flow in `UsersView.tsx` and move visual tokens/class bundles to a dedicated module.
+- Pros: clearer ownership and easier next-step decomposition (sections/components).
+
+## Decision
+
+- Selected Option B to align with established frontend file/folder split conventions.
+
+## Validation
+
+- `frontend: npm run lint` passed
+- `frontend: npm run build` passed
+
+## Notes
+
+- No backend/API contract changes.
+- UI behavior and CRUD flow preserved; this slice is styling-structure focused.

--- a/frontend/src/views/users/UsersView.tsx
+++ b/frontend/src/views/users/UsersView.tsx
@@ -14,6 +14,19 @@ import {
 } from '../../app/portfolioData';
 import { canManageUsers } from '../../features/auth/permissions';
 import { Panel } from '../../shared/components/Panel';
+import {
+  controlSurfaceClass,
+  formActionsClass,
+  formClass,
+  formFieldClass,
+  formFieldLabelClass,
+  formFieldWideClass,
+  formGridClass,
+  primaryActionButtonClass,
+  secondaryActionButtonClass,
+  stateBoxClass,
+  tonePillClass
+} from './usersView.styles';
 
 const defaultFormState: UpsertUserRequest = {
   email: '',
@@ -219,114 +232,141 @@ export function UsersView({
   }
 
   return (
-    <section className="reviews-grid">
+    <section className="grid gap-4 lg:grid-cols-2">
       <Panel
         title="User directory"
         subtitle="역할/본부/상태 기준으로 계정을 운영하고 변경 내역을 감사 로그와 연결합니다."
       >
-        <div className="audit-status" aria-live="polite">
-          <span className={`status-pill status-pill--${canManage ? 'active' : 'mid'}`}>
+        <div
+          className="mb-4 flex items-start gap-3 rounded-xl border border-slate-200 bg-slate-50/70 px-3 py-2.5"
+          aria-live="polite"
+        >
+          <span className={tonePillClass(canManage ? 'active' : 'mid')}>
             {canManage ? '관리 권한' : '읽기 권한'}
           </span>
-          <p>
+          <p className="text-sm leading-5 text-cw-muted">
             {divisionScope
               ? `본부 스코프(${divisionScope})에 맞는 사용자만 표시합니다.`
               : '전체 본부 사용자를 표시합니다.'}
           </p>
         </div>
 
-        <div className="table-actions">
+        <div className="mb-4 flex flex-wrap items-center gap-2.5">
           {canManage ? (
-            <button type="button" onClick={openCreateModal}>
+            <button
+              type="button"
+              className={primaryActionButtonClass}
+              onClick={openCreateModal}
+            >
               사용자 등록
             </button>
           ) : null}
-          <button type="button" onClick={() => setUsersReloadKey((current) => current + 1)}>
+          <button
+            type="button"
+            className={secondaryActionButtonClass}
+            onClick={() => setUsersReloadKey((current) => current + 1)}
+          >
             목록 새로고침
           </button>
-          <button type="button" onClick={() => setAuditReloadKey((current) => current + 1)}>
+          <button
+            type="button"
+            className={secondaryActionButtonClass}
+            onClick={() => setAuditReloadKey((current) => current + 1)}
+          >
             감사 로그 새로고침
           </button>
         </div>
 
         {usersStatus === 'loading' ? (
-          <div className="audit-state" role="status">
+          <div className={stateBoxClass} role="status">
             <strong>사용자 목록을 불러오는 중입니다.</strong>
             <p>권한과 본부 스코프를 확인하고 있습니다.</p>
           </div>
         ) : null}
 
         {usersStatus === 'error' ? (
-          <div className="empty-state">
+          <div className={stateBoxClass}>
             <strong>사용자 목록을 불러오지 못했습니다.</strong>
-            <p>{usersError ?? '잠시 후 다시 시도하세요.'}</p>
+            <p className="m-0 text-sm text-slate-600">
+              {usersError ?? '잠시 후 다시 시도하세요.'}
+            </p>
           </div>
         ) : null}
 
         {usersStatus === 'ready' ? (
-          <div className="table-shell table-shell--operations">
-            <table className="data-table data-table--operations">
+          <div className="rounded-xl border border-slate-200 bg-white">
+            <div className="overflow-x-auto">
+              <table className="min-w-[980px] table-auto border-collapse">
               <thead>
                 <tr>
-                  <th scope="col">사용자</th>
-                  <th scope="col">역할</th>
-                  <th scope="col">본부</th>
-                  <th scope="col">상태</th>
-                  <th scope="col">MFA</th>
-                  <th scope="col">업데이트</th>
-                  <th scope="col">작업</th>
+                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">사용자</th>
+                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">역할</th>
+                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">본부</th>
+                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">상태</th>
+                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">MFA</th>
+                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">업데이트</th>
+                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">작업</th>
                 </tr>
               </thead>
-              <tbody>
+                  <tbody>
                 {visibleUsers.map((user) => (
-                  <tr key={user.id}>
-                    <td>
-                      <strong>{user.displayName}</strong>
-                      <p className="table-subtle">{user.email}</p>
-                    </td>
-                    <td>{user.role}</td>
-                    <td>{user.division}</td>
-                    <td>
-                      <span className={`status-pill status-pill--${statusTone(user.status)}`}>
-                        {user.status}
-                      </span>
-                    </td>
-                    <td>{user.mfaEnabled ? 'Enabled' : 'Disabled'}</td>
-                    <td>{formatUserTimestamp(user.updatedAt ?? user.createdAt)}</td>
-                    <td>
-                      <div className="table-actions">
-                        <button
-                          type="button"
-                          onClick={() => openEditModal(user)}
-                          disabled={!canManage}
-                        >
-                          수정
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleDelete(user)}
-                          disabled={!canManage}
-                        >
-                          삭제
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
+                    <tr key={user.id} className="border-t border-slate-200 align-top hover:bg-slate-50">
+                      <td className="px-3 py-2.5">
+                        <strong>{user.displayName}</strong>
+                        <p className="mt-0.5 text-xs text-slate-500">{user.email}</p>
+                      </td>
+                      <td className="px-3 py-2.5 text-slate-700">{user.role}</td>
+                      <td className="px-3 py-2.5 text-slate-700">{user.division}</td>
+                      <td className="px-3 py-2.5">
+                        <span className={tonePillClass(statusTone(user.status))}>
+                          {user.status}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2.5 text-slate-700">
+                        {user.mfaEnabled ? 'Enabled' : 'Disabled'}
+                      </td>
+                      <td className="px-3 py-2.5 text-slate-700">
+                        {formatUserTimestamp(user.updatedAt ?? user.createdAt)}
+                      </td>
+                      <td className="px-3 py-2.5">
+                        <div className="flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            className={secondaryActionButtonClass}
+                            onClick={() => openEditModal(user)}
+                            disabled={!canManage}
+                          >
+                            수정
+                          </button>
+                          <button
+                            type="button"
+                            className={`${secondaryActionButtonClass} border-rose-300 text-rose-700 hover:bg-rose-50`}
+                            onClick={() => handleDelete(user)}
+                            disabled={!canManage}
+                          >
+                            삭제
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
                 ))}
               </tbody>
             </table>
+            </div>
 
             {visibleUsers.length === 0 ? (
-              <div className="empty-state">
+              <div className="m-3 grid gap-2 rounded-lg border border-slate-200 bg-slate-50 p-4">
                 <strong>표시할 사용자가 없습니다.</strong>
-                <p>본부 스코프 또는 필터 조건을 확인하세요.</p>
+                <p className="m-0 text-sm text-slate-600">
+                  본부 스코프 또는 필터 조건을 확인하세요.
+                </p>
               </div>
             ) : null}
           </div>
         ) : null}
 
         {deleteError ? (
-          <p className="table-subtle" role="alert">
+          <p className="mt-2 text-xs text-rose-700" role="alert">
             {deleteError}
           </p>
         ) : null}
@@ -337,33 +377,40 @@ export function UsersView({
         subtitle="사용자 생성/수정/삭제는 USER-MGMT 도메인 감사 로그에 기록됩니다."
       >
         {auditStatus === 'loading' ? (
-          <div className="audit-state" role="status">
+          <div className={stateBoxClass} role="status">
             <strong>감사 로그를 불러오는 중입니다.</strong>
             <p>최근 20건의 사용자 관리 이벤트를 조회하고 있습니다.</p>
           </div>
         ) : null}
 
         {auditStatus === 'error' ? (
-          <div className="empty-state">
+          <div className={stateBoxClass}>
             <strong>감사 로그를 불러오지 못했습니다.</strong>
-            <p>{auditError ?? '잠시 후 다시 시도하세요.'}</p>
+            <p className="m-0 text-sm text-slate-600">
+              {auditError ?? '잠시 후 다시 시도하세요.'}
+            </p>
           </div>
         ) : null}
 
         {auditStatus === 'ready' && auditEvents.length === 0 ? (
-          <div className="empty-state">
+          <div className={stateBoxClass}>
             <strong>아직 기록된 사용자 감사 로그가 없습니다.</strong>
-            <p>사용자 CRUD 작업을 수행하면 이력에 누적됩니다.</p>
+            <p className="m-0 text-sm text-slate-600">
+              사용자 CRUD 작업을 수행하면 이력에 누적됩니다.
+            </p>
           </div>
         ) : null}
 
         {auditStatus === 'ready' && auditEvents.length > 0 ? (
-          <ol className="audit-list audit-list--wide">
+          <ol className="overflow-hidden rounded-xl border border-slate-200 bg-white">
             {auditEvents.map((event) => (
-              <li key={`${event.actor}-${event.action}-${event.at}`}>
-                <strong>{event.actor}</strong>
-                <span>{event.action}</span>
-                <small>
+              <li
+                key={`${event.actor}-${event.action}-${event.at}`}
+                className="grid gap-1 border-b border-slate-200 px-3 py-2.5 text-sm last:border-b-0"
+              >
+                <strong className="font-semibold text-[#142542]">{event.actor}</strong>
+                <span className="text-cw-muted">{event.action}</span>
+                <small className="text-xs text-cw-muted">
                   {event.domain} · {formatDateTime(event.at)}
                 </small>
               </li>
@@ -373,32 +420,40 @@ export function UsersView({
       </Panel>
 
       {isModalOpen ? (
-        <div className="portfolio-modal" role="presentation">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6"
+          role="presentation"
+        >
           <button
             type="button"
-            className="portfolio-modal__backdrop"
+            className="absolute inset-0 bg-slate-950/60 backdrop-blur-[2px]"
             aria-label="사용자 편집 닫기"
             onClick={closeModal}
           />
           <section
-            className="portfolio-modal__card"
+            className="relative z-10 w-full max-w-4xl max-h-[90vh] overflow-y-auto rounded-xl border border-slate-200 bg-white p-4 shadow-2xl sm:p-6"
             role="dialog"
             aria-modal="true"
             aria-labelledby={modalMode === 'create' ? 'users-create-title' : 'users-edit-title'}
           >
-            <div className="portfolio-modal__header">
+            <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 pb-4">
               <div>
-                <p className="portfolio-modal__eyebrow">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">
                   {modalMode === 'create' ? 'New user' : editingUser?.email}
                 </p>
-                <h3 id={modalMode === 'create' ? 'users-create-title' : 'users-edit-title'}>
+                <h3
+                  id={modalMode === 'create' ? 'users-create-title' : 'users-edit-title'}
+                  className="mt-1 text-xl font-semibold tracking-tight text-slate-900"
+                >
                   {modalMode === 'create' ? '사용자 등록' : '사용자 수정'}
                 </h3>
-                <p>권한/본부/상태를 설정하면 USER-MGMT 감사 로그에 자동 기록됩니다.</p>
+                <p className="mt-1 text-sm leading-6 text-slate-600">
+                  권한/본부/상태를 설정하면 USER-MGMT 감사 로그에 자동 기록됩니다.
+                </p>
               </div>
               <button
                 type="button"
-                className="portfolio-modal__close"
+                className="inline-flex h-9 items-center rounded-md border border-slate-300 px-3 text-xs font-semibold text-slate-600 transition hover:border-slate-400 hover:bg-slate-50"
                 aria-label="모달 닫기"
                 onClick={closeModal}
               >
@@ -406,11 +461,12 @@ export function UsersView({
               </button>
             </div>
 
-            <form className="portfolio-edit-form" onSubmit={handleSubmit}>
-              <div className="portfolio-edit-form__grid">
-                <label className="portfolio-edit-form__field portfolio-edit-form__field--wide">
-                  <span>이메일</span>
+            <form className={formClass} onSubmit={handleSubmit}>
+              <div className={formGridClass}>
+                <label className={formFieldWideClass}>
+                  <span className={formFieldLabelClass}>이메일</span>
                   <input
+                    className={controlSurfaceClass}
                     type="email"
                     value={formState.email}
                     onChange={(event) =>
@@ -423,9 +479,10 @@ export function UsersView({
                   />
                 </label>
 
-                <label className="portfolio-edit-form__field">
-                  <span>이름</span>
+                <label className={formFieldClass}>
+                  <span className={formFieldLabelClass}>이름</span>
                   <input
+                    className={controlSurfaceClass}
                     type="text"
                     value={formState.displayName}
                     onChange={(event) =>
@@ -438,9 +495,10 @@ export function UsersView({
                   />
                 </label>
 
-                <label className="portfolio-edit-form__field">
-                  <span>역할</span>
+                <label className={formFieldClass}>
+                  <span className={formFieldLabelClass}>역할</span>
                   <select
+                    className={controlSurfaceClass}
                     value={formState.role}
                     onChange={(event) =>
                       setFormState((current) => ({
@@ -458,9 +516,10 @@ export function UsersView({
                   </select>
                 </label>
 
-                <label className="portfolio-edit-form__field">
-                  <span>본부</span>
+                <label className={formFieldClass}>
+                  <span className={formFieldLabelClass}>본부</span>
                   <input
+                    className={controlSurfaceClass}
                     type="text"
                     list="users-division-options"
                     value={formState.division}
@@ -479,9 +538,10 @@ export function UsersView({
                   </datalist>
                 </label>
 
-                <label className="portfolio-edit-form__field">
-                  <span>상태</span>
+                <label className={formFieldClass}>
+                  <span className={formFieldLabelClass}>상태</span>
                   <select
+                    className={controlSurfaceClass}
                     value={formState.status}
                     onChange={(event) =>
                       setFormState((current) => ({
@@ -499,9 +559,10 @@ export function UsersView({
                   </select>
                 </label>
 
-                <label className="portfolio-edit-form__field">
-                  <span>MFA</span>
+                <label className={formFieldClass}>
+                  <span className={formFieldLabelClass}>MFA</span>
                   <select
+                    className={controlSurfaceClass}
                     value={formState.mfaEnabled ? 'enabled' : 'disabled'}
                     onChange={(event) =>
                       setFormState((current) => ({
@@ -516,14 +577,14 @@ export function UsersView({
                 </label>
               </div>
 
-              <div className="portfolio-edit-form__actions">
-                <p className="portfolio-edit-form__hint" role="alert">
+              <div className={formActionsClass}>
+                <p className="m-0 text-sm leading-6 text-slate-600" role="alert">
                   {submitError ?? '필수 입력값을 확인한 뒤 저장하세요.'}
                 </p>
-                <div className="portfolio-edit-form__action-group">
+                <div className="flex flex-wrap items-center gap-2.5">
                   <button
                     type="button"
-                    className="portfolio-action portfolio-action--secondary"
+                    className={secondaryActionButtonClass}
                     onClick={closeModal}
                     disabled={isSubmitting}
                   >
@@ -531,7 +592,7 @@ export function UsersView({
                   </button>
                   <button
                     type="submit"
-                    className="portfolio-action portfolio-action--primary"
+                    className={primaryActionButtonClass}
                     disabled={isSubmitting}
                   >
                     {isSubmitting

--- a/frontend/src/views/users/usersView.styles.ts
+++ b/frontend/src/views/users/usersView.styles.ts
@@ -1,0 +1,34 @@
+export type UserStatusTone = 'active' | 'low' | 'mid' | 'high';
+
+export const stateBoxClass =
+  'grid gap-2 rounded-lg border border-slate-200 bg-slate-50 p-4';
+export const stateButtonClass =
+  'inline-flex h-9 items-center rounded-md border border-slate-300 bg-white px-3 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100';
+export const actionButtonBaseClass =
+  'inline-flex h-10 items-center justify-center rounded-md border px-3 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-45';
+export const secondaryActionButtonClass = `${actionButtonBaseClass} border-slate-300 bg-white text-slate-700 hover:border-slate-400 hover:bg-slate-50`;
+export const primaryActionButtonClass = `${actionButtonBaseClass} border-slate-900 bg-slate-900 text-white hover:bg-slate-800`;
+export const controlSurfaceClass =
+  'h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-700 shadow-sm outline-none transition placeholder:text-slate-400 focus:border-slate-500 focus:ring-2 focus:ring-slate-200';
+export const formClass = 'mt-4 grid gap-4';
+export const formGridClass = 'grid gap-3 sm:grid-cols-2';
+export const formFieldClass =
+  'grid gap-2 rounded-xl border border-slate-200 bg-white px-3 py-3';
+export const formFieldWideClass = `${formFieldClass} sm:col-span-2`;
+export const formFieldLabelClass =
+  'text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500';
+export const formActionsClass =
+  'flex flex-col gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-3 sm:flex-row sm:items-center sm:justify-between';
+
+export function tonePillClass(tone: UserStatusTone) {
+  if (tone === 'low') {
+    return 'inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-0.5 text-xs font-semibold text-emerald-700';
+  }
+  if (tone === 'mid') {
+    return 'inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs font-semibold text-amber-700';
+  }
+  if (tone === 'high') {
+    return 'inline-flex items-center rounded-full border border-rose-200 bg-rose-50 px-2.5 py-0.5 text-xs font-semibold text-rose-700';
+  }
+  return 'inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-2.5 py-0.5 text-xs font-semibold text-blue-700';
+}


### PR DESCRIPTION
﻿## 요약

#46 후속 슬라이스로 사용자 관리 화면을 Tailwind 기반으로 전환하고, 파일/폴더 분리 원칙에 맞춰 스타일 책임을 분리했습니다.

## 변경 내용

- `UsersView` 스타일 의존 클래스(`reviews-grid`, `portfolio-modal*`, `portfolio-edit-form*`, `empty-state`, `audit-state` 등)를 Tailwind 유틸리티로 치환
- `frontend/src/views/users/usersView.styles.ts` 추가
  - 버튼/상태 박스/폼 레이아웃/톤 배지 스타일 유틸 분리
- `UsersView.tsx`는 상태/이벤트/CRUD 로직 중심으로 유지하고 표현 레이어 분리
- dev-log 추가
  - `docs/dev-logs/2026-04-24-issue46-users-tailwind-slice.md`

## 이유

Tailwind 전환 이후에도 사용자 화면은 대형 global.css 클래스에 강하게 결합되어 있었고, 한 파일 내 스타일 상수/표현 로직이 커져 유지보수성이 낮았습니다. 이번 슬라이스로 파일 분리 원칙을 적용해 다음 단계 컴포넌트 분해 기반을 마련했습니다.

## 검증

- [x] 관련 테스트를 실행했습니다.
  - `frontend: npm run lint`
  - `frontend: npm run build`
- [x] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
  - 사용자 목록/상태 배지/모달 폼 구조
- [x] 인접한 흐름에서 회귀가 없는지 확인했습니다.
  - 사용자 생성·수정·삭제 진입 동선 및 감사 로그 섹션 렌더링

## 스크린샷 또는 로그

- ESLint 통과 로그
- Vite production build 성공 로그

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다. (dev-log)
- [x] 후속 작업이 필요하면 별도 이슈로 분리했습니다. (#46 후속 슬라이스)

## 브랜치

- [x] 작업은 집중된 `feat/*` 브랜치에서 진행했습니다.
- [x] 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.
