### PR TITLE
[#46] 시드 SQL 안정화 + pre-commit prettier 범위 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ This is the canonical entry point for the repository. Start here, then follow th
 - Do not edit `harness_tmp/`.
 - Do not change unrelated files.
 - Do not commit unverified changes.
+- Do not bypass verification shortcuts such as `--no-verify`; fix the root cause and make checks pass.
 - Do not expose secrets or service keys to the browser.
 - Do not open a PR without the required dev log for a non-trivial change.
 

--- a/docs/dev-logs/2026-04-24-issue46-db-seed-and-precommit-hardening.md
+++ b/docs/dev-logs/2026-04-24-issue46-db-seed-and-precommit-hardening.md
@@ -1,0 +1,46 @@
+# 2026-04-24 issue46 db seed and pre-commit hardening
+
+## Context
+- Issue: #46 follow-up
+- Goal:
+  - Apply reference dummy dataset to Supabase and make it queryable from app APIs.
+  - Remove tech debt around repository-wide prettier failures in pre-commit.
+  - Document rule to avoid `--no-verify` bypass.
+
+## A/B comparison
+- A) Keep pre-commit `npm run format:check` on whole frontend tree
+  - Pros: simple
+  - Cons: fails on unrelated legacy files and blocks scoped commits
+- B) Run prettier check only on staged frontend files
+  - Pros: checks remain strict for changed files, no unrelated global failure
+  - Cons: requires small hook logic
+- Selected: B
+
+## Changes
+- `supabase/seed.sql`
+  - Fixed ambiguous column reference in `cost_pools` insert (`p.description`) so seed runs on real DB.
+- `.githooks/pre-commit`
+  - Prettier check changed from repository-wide to staged frontend targets only.
+  - `npm run lint` remains enforced for frontend changes.
+- `AGENTS.md`
+  - Added explicit rule: do not bypass checks with `--no-verify`; fix root causes.
+
+## Verification
+- Supabase DB apply and query checks:
+  - migrations `002/003/004` applied
+  - `seed.sql` applied
+  - row counts verified:
+    - `projects=20`
+    - `departments=5`
+    - `users=5`
+    - `workflow_states=20`
+    - `audit_logs=20`
+- Frontend:
+  - `npm run lint` pass
+  - `npm run build` pass
+- Backend:
+  - `./gradlew.bat test` pass
+
+## Risks
+- Existing untracked workspace artifacts remain and are intentionally excluded from this slice.
+- If DB schema was partially migrated in another environment, `001_init.sql` may not be idempotent and should be handled by migration history tooling.

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -167,7 +167,7 @@ select
   category,
   amount,
   'KRW',
-  description
+  p.description
 from (
   select
     sp.id,


### PR DESCRIPTION
## 작업 내용
- Supabase seed 적용 중 발생하던 description ambiguous 오류를 수정했습니다.
- pre-commit의 prettier 검사를 저장소 전역이 아니라 staged frontend 파일만 대상으로 실행하도록 변경했습니다.
- AGENTS.md에 --no-verify 우회 금지 규칙을 명시했습니다.
- 레퍼런스 더미데이터를 Supabase DB에 적재하고 건수를 검증했습니다.

## 검증
- frontend: npm run lint, npm run build 통과
- backend: ./gradlew.bat test 통과
- Supabase row count: projects=20, departments=5, users=5, workflow_states=20, audit_logs=20

## 비고
- 관련 dev-log: docs/dev-logs/2026-04-24-issue46-db-seed-and-precommit-hardening.md