### PR TITLE
refactor(46): 레퍼런스 잔여 정합 최종 보정

### DIFF
--- a/docs/dev-logs/2026-04-25-issue46-reference-parity-final-polish.md
+++ b/docs/dev-logs/2026-04-25-issue46-reference-parity-final-polish.md
@@ -1,0 +1,37 @@
+# 2026-04-25 - issue46 reference parity final polish
+
+## 브랜치/범위
+
+- base: `dev`
+- work: `feat/46-reference-parity-final-polish`
+- slice: 레퍼런스 대비 잔여 UI 정합 보정(공용 컴포넌트 + 프로젝트/가이드/가치평가/리스크 화면)
+
+## A/B 비교와 선택
+
+- A안: 개별 화면마다 직접 스타일 패치
+- B안: 공용 컴포넌트(`InfoTile`, `Panel`, `DecisionBarChart`) 먼저 개선 후 화면 레벨 미세 조정
+- 선택: B안
+- 이유: 중복 스타일 패치를 줄이고 화면 간 일관성을 확보할 수 있어 유지보수에 유리
+
+## 변경 요약
+
+- 공용 UI 컴포넌트 시각 밀도 보강
+  - `InfoTile` 정보 위계 강화
+  - `Panel` 헤더/바디 대비 및 테두리/여백 정밀화
+  - `DecisionBarChart`/`DecisionSummary` 가독성 및 범례 톤 개선
+- 레이아웃/내비게이션 정합 보강
+  - `TaskSidebar`, `TaskTopbar`, `viewMeta` 카피와 시각 톤 보정
+- 화면 정합 보강
+  - 프로젝트 목록: 필터/테이블/액션 버튼 가시성 강화
+  - 사용 가이드: 역할별 체크포인트와 운영 팁 보강
+  - 가치평가/리스크: 상단 액션 영역, 분석 테이블, 판단 패널 추가
+
+## 검증
+
+- `cd frontend && npm run lint` 통과
+- `cd frontend && npm run build` 통과
+
+## 남은 리스크
+
+- 레퍼런스와 픽셀 단위 1:1 동형(아이콘 세트, 차트 축/눈금, 미세 간격)은 브라우저 실측 기반 추가 보정 여지 존재
+- 공용 컴포넌트는 backward-compatible 조건으로 기본 스타일 보강 중심이며, 화면별 특수 variant는 후속 확장 필요

--- a/frontend/src/features/workspace/decisionVisuals.tsx
+++ b/frontend/src/features/workspace/decisionVisuals.tsx
@@ -13,8 +13,13 @@ export type DecisionBarItem = DecisionBarInput & {
   ratio: number;
 };
 
-export function buildDecisionBars(items: DecisionBarInput[]): DecisionBarItem[] {
-  const maxMagnitude = Math.max(...items.map((item) => Math.abs(item.value)), 1);
+export function buildDecisionBars(
+  items: DecisionBarInput[]
+): DecisionBarItem[] {
+  const maxMagnitude = Math.max(
+    ...items.map((item) => Math.abs(item.value)),
+    1
+  );
   return items.map((item) => ({
     ...item,
     ratio: Math.max(Math.abs(item.value) / maxMagnitude, 0.08)
@@ -53,49 +58,100 @@ export function DecisionBarChart({
   }
 
   return (
-    <article className="rounded-2xl border border-slate-200 bg-white p-4">
-      <div className="grid gap-1">
-        <strong>{title}</strong>
-        <span className="text-sm text-slate-500">{subtitle}</span>
+    <article className="rounded-2xl border border-cw-cardBorder bg-white px-6 py-5 shadow-[0_1px_2px_rgba(15,23,42,0.06)]">
+      <div className="grid gap-2">
+        <strong className="text-[30px] font-extrabold leading-none tracking-[-0.02em] text-[#10213d]">
+          {title}
+        </strong>
+        <span className="text-[16px] font-medium text-cw-muted">
+          {subtitle}
+        </span>
       </div>
-      <ul className="mt-3 grid gap-3" aria-label={title}>
+      <div className="mt-4 flex flex-wrap items-center gap-4 text-[12px] font-semibold text-[#476286]">
+        <span className="inline-flex items-center gap-2">
+          <span
+            className="h-2.5 w-2.5 rounded-full bg-blue-600"
+            aria-hidden="true"
+          />
+          결정 기여
+        </span>
+        <span className="inline-flex items-center gap-2">
+          <span
+            className="h-2.5 w-2.5 rounded-full bg-sky-500"
+            aria-hidden="true"
+          />
+          보수 시나리오
+        </span>
+        <span className="inline-flex items-center gap-2">
+          <span
+            className="h-2.5 w-2.5 rounded-full bg-indigo-500"
+            aria-hidden="true"
+          />
+          분산 리스크
+        </span>
+      </div>
+      <ul className="mt-5 grid gap-4" aria-label={title}>
         {bars.map((bar) => (
-          <li key={bar.key} className="grid gap-2 lg:grid-cols-[1fr_1fr_auto] lg:items-center">
-            <div className="grid gap-1">
+          <li
+            key={bar.key}
+            className="grid gap-2 rounded-xl border border-slate-100 bg-slate-50/45 px-4 py-3 lg:grid-cols-[1fr_1fr_auto] lg:items-center"
+          >
+            <div className="grid gap-1.5">
               <span
                 className={`h-2.5 w-2.5 rounded-full ${cueDotClass(bar.cue)}`}
                 aria-hidden="true"
               />
-              <strong>{bar.label}</strong>
-              <small className="text-xs text-slate-500">{bar.annotation}</small>
+              <strong className="text-[16px] font-bold text-[#142542]">
+                {bar.label}
+              </strong>
+              <small className="text-[12px] font-medium text-[#6b7d9c]">
+                {bar.annotation}
+              </small>
             </div>
-            <div className="h-3 overflow-hidden rounded-full bg-slate-100">
+            <div className="h-3.5 overflow-hidden rounded-full bg-slate-200/80">
               <div
                 className={`h-full rounded-full ${cueClass(bar.cue)}`}
                 style={{ width: `${bar.ratio * 100}%` }}
               />
             </div>
             <div className="grid gap-0.5 justify-self-end text-right">
-              <strong>{bar.formattedValue}</strong>
-              <span className="text-xs text-slate-500">
+              <strong className="text-[22px] font-extrabold leading-none text-[#10213d]">
+                {bar.formattedValue}
+              </strong>
+              <span className="text-[12px] font-semibold text-[#6b7d9c]">
                 {bar.value < 0 ? '손실 구간' : '기여 구간'}
               </span>
             </div>
           </li>
         ))}
       </ul>
-      <p className="mt-3 text-sm text-slate-600">{summary}</p>
+      <p className="mt-4 border-t border-slate-100 pt-3 text-[14px] font-medium text-[#526582]">
+        {summary}
+      </p>
     </article>
   );
 }
 
-export function DecisionSummary({ title, items }: { title: string; items: string[] }) {
+export function DecisionSummary({
+  title,
+  items
+}: {
+  title: string;
+  items: string[];
+}) {
   return (
-    <article className="rounded-2xl border border-slate-200 bg-white p-4">
-      <strong>{title}</strong>
-      <ul className="mt-2 grid gap-1 text-sm text-slate-600">
+    <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.05)]">
+      <strong className="text-[20px] font-extrabold tracking-[-0.01em] text-[#132744]">
+        {title}
+      </strong>
+      <ul className="mt-3 grid gap-2 text-[14px] font-medium text-[#566a89]">
         {items.map((item) => (
-          <li key={item}>• {item}</li>
+          <li
+            key={item}
+            className="rounded-lg border border-slate-100 bg-slate-50/50 px-3 py-2"
+          >
+            • {item}
+          </li>
         ))}
       </ul>
     </article>

--- a/frontend/src/shared/components/InfoTile.tsx
+++ b/frontend/src/shared/components/InfoTile.tsx
@@ -1,8 +1,10 @@
 export function InfoTile({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-2xl border border-slate-200 bg-white p-4">
-      <span className="block text-sm font-medium text-cw-muted">{label}</span>
-      <strong className="mt-2 block text-lg font-bold text-[#1f2e4a]">
+    <div className="group rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.05)] transition-colors hover:border-[#b9cbe7]">
+      <span className="block text-[12px] font-semibold tracking-[0.08em] text-cw-muted/90">
+        {label}
+      </span>
+      <strong className="mt-2 block text-[34px] font-extrabold leading-none text-[#142542]">
         {value}
       </strong>
     </div>

--- a/frontend/src/shared/components/Panel.tsx
+++ b/frontend/src/shared/components/Panel.tsx
@@ -10,16 +10,22 @@ type PanelProps = {
 export function Panel({ id, title, subtitle, children }: PanelProps) {
   return (
     <section
-      className="overflow-hidden rounded-[14px] border border-cw-cardBorder bg-white"
+      className="overflow-hidden rounded-2xl border border-cw-cardBorder bg-white shadow-[0_1px_2px_rgba(15,23,42,0.06)]"
       id={id}
     >
-      <header className="px-5 pt-5">
+      <header className="border-b border-slate-100 px-6 pb-4 pt-5">
         <div>
-          <h2 className="text-[1.2rem] font-bold text-[#142542]">{title}</h2>
-          {subtitle ? <p className="mt-2 text-cw-muted">{subtitle}</p> : null}
+          <h2 className="text-[34px] font-extrabold tracking-[-0.02em] text-[#10213d]">
+            {title}
+          </h2>
+          {subtitle ? (
+            <p className="mt-2 text-[17px] font-medium text-cw-muted">
+              {subtitle}
+            </p>
+          ) : null}
         </div>
       </header>
-      <div className="p-5">{children}</div>
+      <div className="p-6">{children}</div>
     </section>
   );
 }

--- a/frontend/src/views/layout/TaskSidebar.tsx
+++ b/frontend/src/views/layout/TaskSidebar.tsx
@@ -46,24 +46,28 @@ export function TaskSidebar({
   ];
   const orderedNavigationItems = navigationOrder
     .map((key) => visibleNavigationItems.find((item) => item.key === key))
-    .filter(
-      (item): item is (typeof visibleNavigationItems)[number] => Boolean(item)
+    .filter((item): item is (typeof visibleNavigationItems)[number] =>
+      Boolean(item)
     );
   const renderedSections = new Set<string>();
 
   return (
-    <aside className="min-h-screen w-[260px] border-r border-[rgba(136,153,196,0.2)] bg-[linear-gradient(180deg,#1e1b4b_0%,#312e81_100%)] px-3 pb-4 pt-5 shadow-cw-sidebar">
-      <div className="mb-[18px] ml-2 mr-2 flex items-center gap-2.5">
+    <aside className="min-h-screen w-[320px] border-r border-[rgba(136,153,196,0.2)] bg-[linear-gradient(180deg,#0a1433_0%,#1f1b67_58%,#2a2a78_100%)] px-3 pb-4 pt-5 shadow-cw-sidebar">
+      <div className="mb-[18px] ml-3 mr-2 flex items-center gap-3">
         <div className="grid h-[42px] w-[42px] place-items-center rounded-[11px] bg-[linear-gradient(135deg,#2d68e4,#19b2db)] text-base font-extrabold text-white">
           CW
         </div>
         <div>
-          <strong className="text-[1.72rem] text-white">CostWise</strong>
-          <p className="m-0 text-[0.92rem] text-[#8fa7d3]">원가·평가 통합관리</p>
+          <strong className="text-[2.65rem] font-bold leading-none tracking-[-0.02em] text-white">
+            CostWise
+          </strong>
+          <p className="m-0 mt-0.5 text-[0.88rem] text-[#8fa7d3]">
+            원가·평가 통합관리
+          </p>
         </div>
       </div>
 
-      <nav className="grid gap-2 px-0.5" aria-label="메뉴">
+      <nav className="grid gap-2 px-1" aria-label="메뉴">
         {orderedNavigationItems.map((item) => {
           const section = sectionLabelByKey[item.key] ?? '메뉴';
           const showSection = !renderedSections.has(section);
@@ -74,15 +78,15 @@ export function TaskSidebar({
           return (
             <div key={item.key}>
               {showSection ? (
-                <p className="mb-1.5 ml-2.5 mr-2.5 mt-3.5 text-[0.76rem] font-extrabold tracking-[0.08em] text-[#6f84b1]">
+                <p className="mb-1.5 ml-2.5 mr-2.5 mt-3.5 text-[0.78rem] font-extrabold tracking-[0.08em] text-[#6f84b1]">
                   {section}
                 </p>
               ) : null}
               <button
                 type="button"
-                className={`flex w-full items-center gap-3 rounded-lg border-0 bg-transparent px-4 py-2.5 text-left text-sm font-medium transition-colors ${
+                className={`flex w-full items-center gap-3 rounded-xl border-0 bg-transparent px-4 py-3 text-left text-[1.02rem] font-semibold transition-colors ${
                   activeView === item.key
-                    ? 'bg-[linear-gradient(90deg,#2666e2_0%,#1ab3dc_100%)] text-white'
+                    ? 'bg-[linear-gradient(90deg,#2666e2_0%,#1ab3dc_100%)] text-white shadow-[0_8px_18px_rgba(27,88,220,0.26)]'
                     : 'text-[#cbd5e1] hover:bg-white/10 hover:text-white'
                 }`}
                 onClick={() => onChangeView(item.key)}

--- a/frontend/src/views/layout/TaskTopbar.tsx
+++ b/frontend/src/views/layout/TaskTopbar.tsx
@@ -1,5 +1,9 @@
 /* eslint-disable no-unused-vars */
-import { type DataSource, type ProjectSummary, type Role } from '../../app/portfolioData';
+import {
+  type DataSource,
+  type ProjectSummary,
+  type Role
+} from '../../app/portfolioData';
 import { getRoleLabel } from '../../features/auth/permissions';
 
 type TaskTopbarProps = {
@@ -38,15 +42,17 @@ export function TaskTopbar({
   const pendingCount = Math.max(0, conditionalCount);
 
   return (
-    <header className="sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-[#d4dceb] bg-[#f8fbff] px-4 py-2.5">
+    <header className="sticky top-0 z-10 flex min-h-[72px] items-center justify-between gap-3 border-b border-[#d4dceb] bg-[#f8fbff] px-5 py-3">
       <div className="flex items-center">
-        <p className="m-0 text-[0.95rem] font-bold text-[#6c7e9f]">{meta.eyebrow}</p>
+        <p className="m-0 text-[0.95rem] font-bold text-[#6c7e9f]">
+          {meta.eyebrow}
+        </p>
       </div>
 
       <div className="flex items-center gap-2.5">
         <span className="rounded-full border border-[#d8e0ef] bg-[#eff4fb] px-3 py-1.5 text-[0.8rem] font-bold text-[#556a93]">
           {source === 'api'
-            ? `${projectCount}개 프로젝트`
+            ? `CostWise API 정상 연결 · ${projectCount}개 프로젝트`
             : `CostWise API 일부 제한 · ${projectCount}개 프로젝트`}
         </span>
         {divisionScope ? (
@@ -76,9 +82,11 @@ export function TaskTopbar({
             {username.charAt(0)}
           </div>
           <div>
-            <strong className="block text-[0.84rem] text-[#182844]">{username}</strong>
-            <small className="block text-[0.76rem] tracking-[0.05em] text-[#62759a]">
-              {getRoleLabel(selectedRole).toUpperCase()}
+            <strong className="block text-[0.84rem] text-[#182844]">
+              {username}
+            </strong>
+            <small className="block text-[0.76rem] tracking-[0.02em] text-[#62759a]">
+              {getRoleLabel(selectedRole)}
             </small>
           </div>
           <span className="text-[0.8rem] text-[#6c7e9f]">{now}</span>

--- a/frontend/src/views/layout/viewMeta.ts
+++ b/frontend/src/views/layout/viewMeta.ts
@@ -11,10 +11,10 @@ export const viewMeta: Record<
     breadcrumb: ['메인', '대시보드']
   },
   portfolio: {
-    eyebrow: '프로젝트',
-    title: '프로젝트',
+    eyebrow: '프로젝트 목록',
+    title: '프로젝트 목록',
     description: '프로젝트 목록과 상태를 필터링하여 관리합니다.',
-    breadcrumb: ['프로젝트·평가', '프로젝트']
+    breadcrumb: ['프로젝트·평가', '프로젝트 목록']
   },
   accounting: {
     eyebrow: '원가·관리회계',

--- a/frontend/src/views/portfolio/PortfolioView.tsx
+++ b/frontend/src/views/portfolio/PortfolioView.tsx
@@ -1059,7 +1059,7 @@ export function PortfolioView({
   const actionButtonBaseClass =
     'inline-flex h-10 items-center justify-center rounded-md border px-3 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-45';
   const secondaryActionButtonClass = `${actionButtonBaseClass} border-slate-300 bg-white text-slate-700 hover:border-slate-400 hover:bg-slate-50`;
-  const primaryActionButtonClass = `${actionButtonBaseClass} border-slate-900 bg-slate-900 text-white hover:bg-slate-800`;
+  const primaryActionButtonClass = `${actionButtonBaseClass} border-blue-700 bg-blue-700 text-white hover:bg-blue-600`;
   const controlSurfaceClass =
     'h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-700 shadow-sm outline-none transition placeholder:text-slate-400 focus:border-slate-500 focus:ring-2 focus:ring-slate-200';
   const stateBoxClass =
@@ -1242,11 +1242,11 @@ export function PortfolioView({
                   프로젝트 운영
                 </p>
                 <h3 className="text-xl font-semibold tracking-tight text-slate-900">
-                  프로젝트 관리
+                  프로젝트 목록
                 </h3>
                 <p className="text-sm leading-6 text-slate-600">
-                  탐색 조건을 빠르게 조합하고, 행 선택 후 상세 허브에서 컨텍스트
-                  선택과 워크스페이스 진입을 마무리합니다.
+                  이름/코드 검색과 상태·본부 필터로 운영 대상을 추린 뒤, 상세
+                  허브 또는 워크스페이스로 바로 진입합니다.
                 </p>
               </div>
               <div
@@ -1260,18 +1260,18 @@ export function PortfolioView({
                     onClick={handleExportCsv}
                     disabled={displayedProjects.length === 0}
                   >
-                    CSV
+                    CSV 내보내기
                   </button>
                 ) : null}
                 {isProjectWritable ? (
                   <button
                     type="button"
-                    className={secondaryActionButtonClass}
+                    className={primaryActionButtonClass}
                     onClick={(event: ReactMouseEvent<HTMLButtonElement>) =>
                       openProjectCreateModal(event.currentTarget)
                     }
                   >
-                    새 프로젝트
+                    + 새 프로젝트
                   </button>
                 ) : (
                   <p className="text-xs text-slate-500">{writeAccessMessage}</p>
@@ -1289,7 +1289,7 @@ export function PortfolioView({
                   }}
                   disabled={!explicitSelectedProject}
                 >
-                  선택 프로젝트 허브
+                  상세 허브
                 </button>
                 {isProjectWritable ? (
                   <button
@@ -1312,7 +1312,7 @@ export function PortfolioView({
             </div>
 
             <div
-              className="mt-4 grid gap-3 rounded-lg border border-slate-200 bg-slate-50/70 p-3 md:grid-cols-2 xl:grid-cols-[minmax(260px,1.35fr)_minmax(180px,0.65fr)_1fr_1fr_1fr]"
+              className="mt-4 grid gap-3 rounded-lg border border-slate-200 bg-slate-50/70 p-3 md:grid-cols-2 xl:grid-cols-[minmax(280px,1.2fr)_minmax(180px,0.65fr)_1fr_1fr_1fr]"
               aria-label="프로젝트 운영 필터"
             >
               <label
@@ -1356,7 +1356,7 @@ export function PortfolioView({
               </label>
 
               <div
-                className="flex flex-wrap items-start gap-1.5"
+                className="flex flex-wrap items-start gap-1.5 rounded-lg border border-slate-200 bg-white p-2"
                 aria-label="빠른 필터"
               >
                 <span className="w-full text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
@@ -1381,7 +1381,7 @@ export function PortfolioView({
               </div>
 
               <div
-                className="flex flex-wrap items-start gap-1.5"
+                className="flex flex-wrap items-start gap-1.5 rounded-lg border border-slate-200 bg-white p-2"
                 aria-label="상태 필터"
               >
                 <span className="w-full text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
@@ -1405,7 +1405,7 @@ export function PortfolioView({
               </div>
 
               <div
-                className="flex flex-wrap items-start gap-1.5"
+                className="flex flex-wrap items-start gap-1.5 rounded-lg border border-slate-200 bg-white p-2"
                 aria-label="본부 필터"
               >
                 <span className="w-full text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
@@ -1453,8 +1453,8 @@ export function PortfolioView({
 
             <div className="mt-4 overflow-hidden rounded-lg border border-slate-200 bg-white">
               <div className="overflow-x-auto">
-                <table className="min-w-[920px] w-full border-collapse text-sm">
-                  <thead className="bg-slate-100/70">
+                <table className="min-w-[980px] w-full border-collapse text-sm">
+                  <thead className="sticky top-0 z-[1] bg-slate-100/90 backdrop-blur">
                     <tr>
                       <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
                         우선
@@ -1467,6 +1467,9 @@ export function PortfolioView({
                       </th>
                       <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
                         상태
+                      </th>
+                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                        리스크
                       </th>
                       <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
                         투자액
@@ -1489,7 +1492,7 @@ export function PortfolioView({
                     {displayedProjects.map((project) => (
                       <tr
                         key={project.code}
-                        className={`border-t border-slate-200 align-top transition hover:bg-slate-50 ${
+                        className={`border-t border-slate-200 align-top transition odd:bg-white even:bg-slate-50/35 hover:bg-cyan-50/60 ${
                           project.code === selectedProjectCode
                             ? 'bg-emerald-50/70'
                             : ''
@@ -1518,6 +1521,11 @@ export function PortfolioView({
                         <td className="whitespace-nowrap px-3 py-2.5">
                           <span className={statusPillClass(project.status)}>
                             {project.status}
+                          </span>
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2.5">
+                          <span className={riskPillClass(project.risk)}>
+                            {project.risk}
                           </span>
                         </td>
                         <td className="whitespace-nowrap px-3 py-2.5 text-slate-700">

--- a/frontend/src/views/settings/SettingsView.tsx
+++ b/frontend/src/views/settings/SettingsView.tsx
@@ -19,7 +19,7 @@ export function SettingsView({
         '프로젝트 목록 화면에서 본부/상태 필터를 적용하고 검토 대상을 선택합니다.'
     },
     {
-      title: '2. 가치평가·리스크 레인 확인',
+      title: '2. 가치평가·리스크 화면 확인',
       description:
         '선택한 프로젝트 기준으로 가치평가와 VaR 지표를 확인하고 의사결정 신호를 정리합니다.'
     },
@@ -29,17 +29,39 @@ export function SettingsView({
         '승인·수정 이력이 정책에 맞게 기록되었는지 감사 로그에서 점검합니다.'
     }
   ];
+  const roleChecklist = [
+    {
+      role: '관리자',
+      guide:
+        '권한/메뉴 정책 확인 후 사용자·감사 로그 이상 여부를 먼저 점검합니다.'
+    },
+    {
+      role: '임원',
+      guide:
+        '프로젝트 목록에서 우선순위 대상을 선택하고 가치평가·리스크 핵심 수치만 빠르게 판단합니다.'
+    },
+    {
+      role: 'PM/원가담당자',
+      guide:
+        '투자액, 예상매출, 근거 데이터를 최신화하고 검토 상태(검토중/조건부/보류)를 명확히 관리합니다.'
+    },
+    {
+      role: '감사',
+      guide:
+        '승인·수정 이력이 내부 통제 기준과 일치하는지 감사 로그 중심으로 검증합니다.'
+    }
+  ];
 
   return (
-    <section className="grid gap-4 xl:grid-cols-[1.1fr_1fr]">
+    <section className="grid gap-4 xl:grid-cols-[1.15fr_1fr]">
       <Panel
         title="사용 가이드"
-        subtitle="CostWise 운영 흐름과 역할별 기본 진입 절차를 안내합니다."
+        subtitle="실무에서 바로 쓰는 CostWise 운영 절차를 단계별로 안내합니다."
       >
-        <div className="grid gap-3 md:grid-cols-2">
+        <div className="grid gap-3 md:grid-cols-4">
           <InfoTile label="현재 역할" value={getRoleLabel(selectedRole)} />
           <InfoTile label="기본 진입" value="프로젝트 목록" />
-          <InfoTile label="권장 분석 레인" value="가치평가 / 리스크·VaR" />
+          <InfoTile label="권장 분석 화면" value="가치평가 / 리스크·VaR" />
           <InfoTile label="플랫폼명" value="CostWise" />
         </div>
 
@@ -47,7 +69,7 @@ export function SettingsView({
           {usageSteps.map((step) => (
             <li
               key={step.title}
-              className="rounded-xl border border-slate-200 bg-slate-50/70 px-3.5 py-3"
+              className="rounded-xl border border-slate-200 bg-slate-50/70 px-3.5 py-3.5"
             >
               <strong className="block text-sm font-semibold text-[#142542]">
                 {step.title}
@@ -58,11 +80,21 @@ export function SettingsView({
             </li>
           ))}
         </ol>
+
+        <div className="mt-4 rounded-xl border border-blue-100 bg-blue-50/70 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-blue-700">
+            운영 팁
+          </p>
+          <p className="mt-1 text-sm leading-6 text-slate-700">
+            프로젝트 선택 전 필터를 먼저 고정하면 화면 간 이동 시에도 동일한
+            운영 컨텍스트를 유지할 수 있습니다.
+          </p>
+        </div>
       </Panel>
 
       <Panel
-        title="역할별 운영 포커스"
-        subtitle="현재 역할의 핵심 시그널과 다음 액션을 설정 화면에서 고정해 확인합니다."
+        title="역할별 운영 체크포인트"
+        subtitle="역할마다 반드시 확인할 핵심 점검 항목을 간단히 정리했습니다."
       >
         <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
           <p className="text-base font-semibold leading-6 text-[#142542]">
@@ -71,10 +103,27 @@ export function SettingsView({
           <p className="mt-2 text-sm leading-6 text-cw-muted">
             {selectedInsight.summary}
           </p>
+
+          <ul className="mt-4 grid gap-2">
+            {roleChecklist.map((item) => (
+              <li
+                key={item.role}
+                className="rounded-xl border border-slate-200 bg-white px-3 py-2.5"
+              >
+                <p className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                  {item.role}
+                </p>
+                <p className="mt-1 text-sm leading-6 text-slate-700">
+                  {item.guide}
+                </p>
+              </li>
+            ))}
+          </ul>
+
           <dl className="mt-4 grid gap-2 rounded-xl border border-slate-200 bg-white p-3 text-sm text-cw-muted">
             <div className="grid gap-0.5">
               <dt className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
-                다음 액션
+                현재 역할 다음 액션
               </dt>
               <dd className="font-medium text-[#1f2e4a]">
                 {selectedInsight.nextAction}
@@ -82,7 +131,7 @@ export function SettingsView({
             </div>
             <div className="grid gap-0.5">
               <dt className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
-                리스크 워치
+                현재 역할 리스크 워치
               </dt>
               <dd>{selectedInsight.riskWatch}</dd>
             </div>

--- a/frontend/src/views/workspace/WorkspaceView.tsx
+++ b/frontend/src/views/workspace/WorkspaceView.tsx
@@ -64,6 +64,21 @@ export function WorkspaceView({
   onRetryDetailLoad
 }: WorkspaceViewProps) {
   const hasSelectedProject = Boolean(selectedProject);
+  const workspaceMeta =
+    activeView === 'valuation'
+      ? {
+          title: '가치평가',
+          subtitle: '프로젝트 가치평가 및 금융 지표 검토',
+          actionLabel: '+ 평가 입력',
+          heroLabel: '가치평가 보드'
+        }
+      : {
+          title: '리스크/VaR',
+          subtitle: '손실 한계 및 하방 시나리오 점검',
+          actionLabel: '+ 리스크 입력',
+          heroLabel: '리스크 보드'
+        };
+  const snapshotTime = new Date().toLocaleString('ko-KR', { hour12: false });
   const statusCardClass =
     'rounded-2xl border border-[#d8e2f2] bg-[#f8fbff] px-5 py-4 text-[#34496d] shadow-[0_6px_18px_rgba(24,40,71,0.06)]';
   const emptyStateClass =
@@ -72,7 +87,8 @@ export function WorkspaceView({
     'mt-3 inline-flex items-center rounded-xl border border-[#b9c9e4] bg-white px-3 py-2 text-sm font-semibold text-[#2f4570] transition hover:bg-[#f3f7ff]';
   const tableShellClass =
     'overflow-x-auto rounded-2xl border border-[#d7e1f1] bg-white shadow-[0_6px_20px_rgba(24,40,71,0.05)]';
-  const tableClass = 'min-w-full border-separate border-spacing-0 text-sm text-[#2b3f63]';
+  const tableClass =
+    'min-w-full border-separate border-spacing-0 text-sm text-[#2b3f63]';
   const kpiGridClass = 'grid gap-3 sm:grid-cols-2 xl:grid-cols-4';
   const dominantSurfaceClass =
     'rounded-2xl border border-[#d7e1f1] bg-white p-4 shadow-[0_8px_24px_rgba(24,40,71,0.06)]';
@@ -113,6 +129,35 @@ export function WorkspaceView({
           </div>
         </header>
 
+        {hasSelectedProject && detailStatus === 'ready' && selectedDetail ? (
+          <section className={kpiGridClass} aria-label="원가 집계 핵심 지표">
+            <InfoTile
+              label="총 배분원가"
+              value={formatKrwCompact(
+                selectedDetail.allocation.allocatedCostKrw
+              )}
+            />
+            <InfoTile
+              label="표준원가"
+              value={formatKrwCompact(
+                selectedDetail.allocation.standardCostKrw
+              )}
+            />
+            <InfoTile
+              label="효율 갭"
+              value={formatKrwCompact(
+                selectedDetail.allocation.efficiencyGapKrw
+              )}
+            />
+            <InfoTile
+              label="성과 갭"
+              value={formatKrwCompact(
+                selectedDetail.allocation.performanceGapKrw
+              )}
+            />
+          </section>
+        ) : null}
+
         {detailStatus === 'loading' ? (
           <div className={statusCardClass} role="status">
             <strong className="block text-[0.98rem] font-semibold text-[#1d2f52]">
@@ -129,7 +174,9 @@ export function WorkspaceView({
             <strong className="block text-[1rem] font-semibold text-[#1d2f52]">
               원가 데이터를 불러오지 못했습니다.
             </strong>
-            <p className="mt-1 text-sm">{detailError ?? '잠시 후 다시 시도하세요.'}</p>
+            <p className="mt-1 text-sm">
+              {detailError ?? '잠시 후 다시 시도하세요.'}
+            </p>
             <button
               type="button"
               onClick={onRetryDetailLoad}
@@ -142,17 +189,32 @@ export function WorkspaceView({
 
         {hasSelectedProject && detailStatus === 'ready' && selectedDetail ? (
           <>
-            <Panel title="본부별 원가 차이분석 (실제 vs 표준)" subtitle="선택 프로젝트 기준 배부 규칙">
+            <Panel
+              title="본부별 원가 차이분석 (실제 vs 표준)"
+              subtitle="선택 프로젝트 기준 배부 규칙"
+            >
               <div className={tableShellClass}>
                 <table className={tableClass}>
                   <thead className="bg-[#f1f5fc] text-xs uppercase tracking-[0.03em] text-[#5a7096]">
                     <tr>
-                      <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">본부</th>
-                      <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">실제원가</th>
-                      <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">표준원가</th>
-                      <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">차이</th>
-                      <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">차이율</th>
-                      <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">판정</th>
+                      <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                        본부
+                      </th>
+                      <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                        실제원가
+                      </th>
+                      <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                        표준원가
+                      </th>
+                      <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                        차이
+                      </th>
+                      <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                        차이율
+                      </th>
+                      <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                        판정
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
@@ -164,9 +226,15 @@ export function WorkspaceView({
                           : (diff / rule.costPoolAmount) * 100;
                       return (
                         <tr key={`${rule.departmentCode}-${rule.costPoolName}`}>
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">{rule.departmentCode}</td>
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">{formatKrwCompact(rule.allocatedAmount)}</td>
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">{formatKrwCompact(rule.costPoolAmount)}</td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {rule.departmentCode}
+                          </td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {formatKrwCompact(rule.allocatedAmount)}
+                          </td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {formatKrwCompact(rule.costPoolAmount)}
+                          </td>
                           <td
                             className={`border-b border-[#e5ecf8] px-4 py-3 ${diff > 0 ? 'text-[#d14343]' : 'text-[#198b63]'}`}
                           >
@@ -198,16 +266,24 @@ export function WorkspaceView({
             </Panel>
 
             <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
-              <Panel title="본부별 원가 구성" subtitle="배부원가 기준 막대 비교">
+              <Panel
+                title="본부별 원가 구성"
+                subtitle="배부원가 기준 막대 비교"
+              >
                 <div className="grid gap-2.5">
                   {allocationRows.map((rule) => {
                     const maxAmount = Math.max(
                       1,
                       ...allocationRows.map((row) => row.allocatedAmount)
                     );
-                    const width = Math.round((rule.allocatedAmount / maxAmount) * 100);
+                    const width = Math.round(
+                      (rule.allocatedAmount / maxAmount) * 100
+                    );
                     return (
-                      <article key={`${rule.departmentCode}-${rule.basis}`} className="grid gap-2">
+                      <article
+                        key={`${rule.departmentCode}-${rule.basis}`}
+                        className="grid gap-2"
+                      >
                         <div className="flex items-baseline justify-between gap-3">
                           <strong>{rule.departmentCode}</strong>
                           <span className="text-[0.88rem] text-[#7388ac]">
@@ -256,7 +332,8 @@ export function WorkspaceView({
               선택된 프로젝트가 없습니다.
             </strong>
             <p className="mt-1 text-sm">
-              프로젝트 목록에서 대상을 선택하면 원가 집계·분석 화면이 활성화됩니다.
+              프로젝트 목록에서 대상을 선택하면 원가 집계·분석 화면이
+              활성화됩니다.
             </p>
           </div>
         ) : null}
@@ -266,62 +343,79 @@ export function WorkspaceView({
 
   return (
     <section className="grid gap-4">
-      <div
-        className="rounded-2xl border border-[#d7e1f1] bg-white p-5 shadow-[0_8px_22px_rgba(24,40,71,0.06)]"
-        aria-label="프로젝트 요약 스트립"
-      >
-        <div className="grid gap-4 lg:grid-cols-[1.6fr_1fr]">
+      <header className="grid gap-4 rounded-2xl border border-[#d7e1f1] bg-white p-5 shadow-[0_8px_22px_rgba(24,40,71,0.06)]">
+        <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.06em] text-[#6881aa]">
-            Financial Evaluation
+              {workspaceMeta.heroLabel}
             </p>
-            <h2 className="mt-2 text-2xl font-bold text-[#182847]">
-              {selectedProject?.name ?? '선택된 프로젝트 없음'}
+            <h2 className="mt-1 text-[1.9rem] font-bold text-[#182847]">
+              {workspaceMeta.title}
             </h2>
+            <p className="mt-1 text-[#607397]">{workspaceMeta.subtitle}</p>
+          </div>
+          <div className="flex items-center gap-2.5">
+            <button
+              className="rounded-[10px] border border-[#cbd6ea] bg-white px-3.5 py-2.5 font-bold text-[#2f4570]"
+              type="button"
+            >
+              CSV
+            </button>
+            <button
+              className="rounded-[10px] bg-[#2b4dbf] px-3.5 py-2.5 font-extrabold text-white"
+              type="button"
+            >
+              {workspaceMeta.actionLabel}
+            </button>
+          </div>
+        </div>
+        <div className="grid gap-4 lg:grid-cols-[1.6fr_1fr]">
+          <div>
+            <h3 className="text-2xl font-bold text-[#182847]">
+              {selectedProject?.name ?? '선택된 프로젝트 없음'}
+            </h3>
             <p className="mt-2 text-sm text-[#5f7498]">
               {hasSelectedProject && detailStatus === 'ready' && selectedDetail
                 ? `${selectedProject?.headquarter} · ${selectedDetail.assetCategory} · ${selectedDetail.headline}`
                 : hasSelectedProject
-                  ? `${selectedProject?.headquarter} · API 상세 데이터 동기화 중`
+                  ? `${selectedProject?.headquarter} · 상세 데이터 동기화 중`
                   : '포트폴리오에서 프로젝트를 먼저 선택하세요.'}
             </p>
           </div>
-          <div className="grid gap-3" aria-label="핵심 신호와 다음 행동">
-            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-              {selectedWorkspaceKpis.map((item) => (
-                <InfoTile
-                  key={item.label}
-                  label={item.label}
-                  value={item.value}
-                />
-              ))}
-              <InfoTile
-                label="다음 단계"
-                value={selectedDetail?.workflow.nextStep ?? '-'}
-              />
-            </div>
-            <article className="rounded-xl border border-[#d5e0f1] bg-[#f7faff] p-4 text-[#34496d]">
+          <article className="rounded-xl border border-[#d5e0f1] bg-[#f7faff] p-4 text-[#34496d]">
+            <div className="flex items-center justify-between gap-3">
               <span className="text-xs font-semibold uppercase tracking-[0.04em] text-[#6881aa]">
-                Next action
+                최신 스냅샷
               </span>
-              <strong className="mt-1 block text-base text-[#1f3458]">
-                {selectedDetail?.workflow.nextStep ?? '검토 단계 확인 필요'}
-              </strong>
-              <p className="mt-1 text-sm">{cockpitNextAction}</p>
-            </article>
-          </div>
+              <small className="text-xs text-[#6b7fa3]">{snapshotTime}</small>
+            </div>
+            <strong className="mt-2 block text-base text-[#1f3458]">
+              {selectedDetail?.workflow.nextStep ?? '검토 단계 확인 필요'}
+            </strong>
+            <p className="mt-1 text-sm">{cockpitNextAction}</p>
+          </article>
         </div>
-      </div>
+      </header>
 
-      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4" aria-label="요약 메타 정보">
+      <div
+        className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4"
+        aria-label="요약 메타 정보"
+      >
         {cockpitMetaItems.map((item) => (
           <InfoTile key={item.label} label={item.label} value={item.value} />
         ))}
+        <InfoTile
+          label="다음 단계"
+          value={selectedDetail?.workflow.nextStep ?? '-'}
+        />
       </div>
-      <div className="grid gap-3 md:grid-cols-3" aria-label="의사결정 스캔 경로">
+      <div
+        className="grid gap-3 md:grid-cols-3"
+        aria-label="의사결정 스캔 경로"
+      >
         <article className="rounded-2xl border border-[#d7e1f1] bg-white p-4 shadow-[0_6px_18px_rgba(24,40,71,0.05)]">
           <span className="text-xs font-semibold text-[#6c83ab]">01</span>
-          <strong className="mt-1 block text-[#1f3458]">Focus signal</strong>
+          <strong className="mt-1 block text-[#1f3458]">핵심 신호</strong>
           <p className="mt-1 text-sm text-[#4a6087]">
             {selectedProject
               ? `${selectedProject.name} 핵심 KPI를 먼저 확인합니다.`
@@ -330,14 +424,14 @@ export function WorkspaceView({
         </article>
         <article className="rounded-2xl border border-[#d7e1f1] bg-white p-4 shadow-[0_6px_18px_rgba(24,40,71,0.05)]">
           <span className="text-xs font-semibold text-[#6c83ab]">02</span>
-          <strong className="mt-1 block text-[#1f3458]">Decision point</strong>
+          <strong className="mt-1 block text-[#1f3458]">의사결정 포인트</strong>
           <p className="mt-1 text-sm text-[#4a6087]">
             {selectedDetail?.workflow.nextStep ?? '다음 결정을 확인합니다.'}
           </p>
         </article>
         <article className="rounded-2xl border border-[#d7e1f1] bg-white p-4 shadow-[0_6px_18px_rgba(24,40,71,0.05)]">
           <span className="text-xs font-semibold text-[#6c83ab]">03</span>
-          <strong className="mt-1 block text-[#1f3458]">Validation</strong>
+          <strong className="mt-1 block text-[#1f3458]">검증</strong>
           <p className="mt-1 text-sm text-[#4a6087]">
             탭별 근거를 확인한 뒤 승인/보류를 확정합니다.
           </p>
@@ -388,7 +482,7 @@ export function WorkspaceView({
               선택된 프로젝트가 없습니다.
             </strong>
             <p className="mt-1 text-sm">
-              Portfolio 화면에서 프로젝트를 선택하면 상세 분석을 표시합니다.
+              프로젝트 목록 화면에서 프로젝트를 선택하면 상세 분석을 표시합니다.
             </p>
           </div>
         ) : null}
@@ -409,7 +503,9 @@ export function WorkspaceView({
             <strong className="block text-[1rem] font-semibold text-[#1d2f52]">
               프로젝트 상세를 불러오지 못했습니다.
             </strong>
-            <p className="mt-1 text-sm">{detailError ?? 'API 상태를 확인한 뒤 다시 시도하세요.'}</p>
+            <p className="mt-1 text-sm">
+              {detailError ?? 'API 상태를 확인한 뒤 다시 시도하세요.'}
+            </p>
             <button
               type="button"
               onClick={onRetryDetailLoad}
@@ -425,7 +521,9 @@ export function WorkspaceView({
             <strong className="block text-[1rem] font-semibold text-[#1d2f52]">
               표시할 프로젝트 상세가 없습니다.
             </strong>
-            <p className="mt-1 text-sm">프로젝트 데이터 구조를 확인한 뒤 다시 시도하세요.</p>
+            <p className="mt-1 text-sm">
+              프로젝트 데이터 구조를 확인한 뒤 다시 시도하세요.
+            </p>
             <button
               type="button"
               onClick={onRetryDetailLoad}
@@ -496,11 +594,18 @@ export function WorkspaceView({
                 ]}
               />
             </section>
-            <section className={supportGridClass} aria-label="배부 기준과 변경 이력">
+            <section
+              className={supportGridClass}
+              aria-label="배부 기준과 변경 이력"
+            >
               <article className={workflowNoteClass}>
                 <strong>계산 근거</strong>
-                <p className="mt-2 text-sm">{selectedDetail.allocation.allocationBasis}</p>
-                <p className="mt-1 text-sm">{selectedDetail.allocation.calculationTrace}</p>
+                <p className="mt-2 text-sm">
+                  {selectedDetail.allocation.allocationBasis}
+                </p>
+                <p className="mt-1 text-sm">
+                  {selectedDetail.allocation.calculationTrace}
+                </p>
               </article>
               <article className={workflowNoteClass}>
                 <strong>최근 변경 이력</strong>
@@ -515,7 +620,9 @@ export function WorkspaceView({
                           key={`${history.at}-${history.actor}-${history.action}`}
                           className={listItemClass}
                         >
-                          <strong className="block text-[#1f3458]">{history.actor}</strong>
+                          <strong className="block text-[#1f3458]">
+                            {history.actor}
+                          </strong>
                           <span className="mt-1 block">
                             {history.action} · {history.comment || '-'}
                           </span>
@@ -540,12 +647,24 @@ export function WorkspaceView({
                   <table className={tableClass}>
                     <thead className="bg-[#f1f5fc] text-xs uppercase tracking-[0.03em] text-[#5a7096]">
                       <tr>
-                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">부서</th>
-                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">비용풀</th>
-                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">카테고리</th>
-                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">배부 기준</th>
-                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">배부율</th>
-                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">배부원가</th>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          부서
+                        </th>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          비용풀
+                        </th>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          카테고리
+                        </th>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          배부 기준
+                        </th>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          배부율
+                        </th>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          배부원가
+                        </th>
                       </tr>
                     </thead>
                     <tbody>
@@ -553,12 +672,24 @@ export function WorkspaceView({
                         <tr
                           key={`${rule.departmentCode}-${rule.costPoolName}-${rule.basis}`}
                         >
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">{rule.departmentCode}</td>
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">{rule.costPoolName}</td>
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">{rule.costPoolCategory}</td>
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">{rule.basis}</td>
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">{formatPercent(rule.allocationRate)}</td>
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">{formatKrwCompact(rule.allocatedAmount)}</td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {rule.departmentCode}
+                          </td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {rule.costPoolName}
+                          </td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {rule.costPoolCategory}
+                          </td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {rule.basis}
+                          </td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {formatPercent(rule.allocationRate)}
+                          </td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {formatKrwCompact(rule.allocatedAmount)}
+                          </td>
                         </tr>
                       ))}
                     </tbody>
@@ -571,10 +702,7 @@ export function WorkspaceView({
 
         {activeWorkspaceTab === 'valuation' && selectedDetail ? (
           <>
-            <section
-              className={kpiGridClass}
-              aria-label="가치평가 핵심 지표"
-            >
+            <section className={kpiGridClass} aria-label="가치평가 핵심 지표">
               <InfoTile
                 label="공정가치"
                 value={formatKrwCompact(selectedDetail.valuation.fairValueKrw)}
@@ -620,37 +748,113 @@ export function WorkspaceView({
                 value={selectedDetail.valuation.creditGrade}
               />
               <InfoTile
-                label="Credit Score"
+                label="신용 점수"
                 value={`${selectedDetail.valuation.creditRiskScore}점`}
               />
               <InfoTile
-                label="Duration"
+                label="듀레이션"
                 value={`${selectedDetail.valuation.duration}년`}
               />
               <InfoTile
-                label="Convexity"
+                label="컨벡서티"
                 value={`${selectedDetail.valuation.convexity}`}
               />
             </section>
-            <section className={supportGridClass} aria-label="평가 근거와 시나리오 가정">
+            <section className="grid grid-cols-[1.8fr_1fr] gap-4 max-[1280px]:grid-cols-1">
+              <Panel
+                title="시나리오 가치 분석 테이블"
+                subtitle="NPV 및 확률 기여도 비교"
+              >
+                <div className={tableShellClass}>
+                  <table className={tableClass}>
+                    <thead className="bg-[#f1f5fc] text-xs uppercase tracking-[0.03em] text-[#5a7096]">
+                      <tr>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          시나리오
+                        </th>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          확률
+                        </th>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          NPV
+                        </th>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          확률가중값
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {selectedDetail.scenarioReturns.map((scenario) => (
+                        <tr key={scenario.label}>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {scenario.label}
+                          </td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {formatPercent(scenario.probability)}
+                          </td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {formatKrwCompact(scenario.npvKrw)}
+                          </td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {formatKrwCompact(
+                              Math.round(scenario.npvKrw * scenario.probability)
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </Panel>
+              <Panel title="평가 판단 패널" subtitle="승인 전 체크 포인트">
+                <div className="grid gap-3">
+                  <article className="rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3.5 text-sm text-[#3b4f76]">
+                    기준 대비 비관 격차는 {formatKrwCompact(valuationGap)}
+                    입니다.
+                  </article>
+                  <article className="rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3.5 text-sm text-[#3b4f76]">
+                    할인율{' '}
+                    {formatPercent(selectedDetail.valuation.discountRate)} /
+                    리스크 프리미엄{' '}
+                    {formatPercent(selectedDetail.valuation.riskPremium)}
+                  </article>
+                  <article className="rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3.5 text-sm text-[#3b4f76]">
+                    승인 코멘트에 시나리오 근거와 민감도 차이를 함께 남기세요.
+                  </article>
+                </div>
+              </Panel>
+            </section>
+            <section
+              className={supportGridClass}
+              aria-label="평가 근거와 시나리오 가정"
+            >
               <article className={workflowNoteClass}>
                 <strong>평가 근거</strong>
                 <p className="mt-2 text-sm">
-                  할인율 {formatPercent(selectedDetail.valuation.discountRate)} ·
-                  리스크 프리미엄{' '}
+                  할인율 {formatPercent(selectedDetail.valuation.discountRate)}{' '}
+                  · 리스크 프리미엄{' '}
                   {formatPercent(selectedDetail.valuation.riskPremium)}
                 </p>
-                <p className="mt-1 text-sm">{selectedDetail.valuation.interpretation}</p>
+                <p className="mt-1 text-sm">
+                  {selectedDetail.valuation.interpretation}
+                </p>
               </article>
               <article className={workflowNoteClass}>
                 <strong>시나리오 가정</strong>
                 {selectedDetail.valuation.assumptions.length === 0 ? (
-                  <p className="mt-2 text-sm">등록된 시나리오 가정이 없습니다.</p>
+                  <p className="mt-2 text-sm">
+                    등록된 시나리오 가정이 없습니다.
+                  </p>
                 ) : (
                   <ol className={listClass}>
                     {selectedDetail.valuation.assumptions.map((item) => (
-                      <li key={`${item.label}-${item.note}`} className={listItemClass}>
-                        <strong className="block text-[#1f3458]">{item.label}</strong>
+                      <li
+                        key={`${item.label}-${item.note}`}
+                        className={listItemClass}
+                      >
+                        <strong className="block text-[#1f3458]">
+                          {item.label}
+                        </strong>
                         <span className="mt-1 block">
                           NPV {formatKrwCompact(item.npvKrw)} · 확률{' '}
                           {formatPercent(item.probability)}
@@ -669,10 +873,7 @@ export function WorkspaceView({
 
         {activeWorkspaceTab === 'risk' && selectedDetail ? (
           <>
-            <section
-              className={kpiGridClass}
-              aria-label="리스크 핵심 지표"
-            >
+            <section className={kpiGridClass} aria-label="리스크 핵심 지표">
               <InfoTile
                 label="현재 리스크"
                 value={selectedProject?.risk ?? '-'}
@@ -695,7 +896,7 @@ export function WorkspaceView({
               aria-label="하방 노출 surface"
             >
               <DecisionBarChart
-                title="Downside Exposure"
+                title="하방 노출"
                 subtitle="손실 한계와 시나리오 하방을 동시 비교"
                 bars={riskDecisionBars}
                 summary={`VaR 대비 하방 격차 ${formatKrwCompact(riskGuardrailGap)}`}
@@ -719,15 +920,113 @@ export function WorkspaceView({
                 ]}
               />
             </section>
+            <section className="grid grid-cols-[1.8fr_1fr] gap-4 max-[1280px]:grid-cols-1">
+              <Panel
+                title="VaR/손실 한계 분석 테이블"
+                subtitle="손실 한도와 신용·금리 민감도 점검"
+              >
+                <div className={tableShellClass}>
+                  <table className={tableClass}>
+                    <thead className="bg-[#f1f5fc] text-xs uppercase tracking-[0.03em] text-[#5a7096]">
+                      <tr>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          지표
+                        </th>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          값
+                        </th>
+                        <th className="border-b border-[#d7e1f1] px-4 py-3 text-left font-semibold">
+                          판정
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {[
+                        {
+                          label: 'VaR 95%',
+                          value: formatKrwCompact(
+                            selectedDetail.valuation.var95Krw
+                          ),
+                          ok:
+                            selectedDetail.valuation.var95Krw <=
+                            selectedDetail.valuation.fairValueKrw
+                        },
+                        {
+                          label: 'VaR 99%',
+                          value: formatKrwCompact(
+                            selectedDetail.valuation.var99Krw
+                          ),
+                          ok:
+                            selectedDetail.valuation.var99Krw <=
+                            selectedDetail.valuation.fairValueKrw
+                        },
+                        {
+                          label: 'CVaR 95%',
+                          value: formatKrwCompact(
+                            selectedDetail.valuation.cvar95Krw
+                          ),
+                          ok:
+                            selectedDetail.valuation.cvar95Krw <=
+                            selectedDetail.valuation.fairValueKrw
+                        },
+                        {
+                          label: '신용점수',
+                          value: `${selectedDetail.valuation.creditRiskScore}점`,
+                          ok: selectedDetail.valuation.creditRiskScore >= 70
+                        },
+                        {
+                          label: '듀레이션',
+                          value: `${selectedDetail.valuation.duration}년`,
+                          ok: selectedDetail.valuation.duration <= 5
+                        }
+                      ].map((item) => (
+                        <tr key={item.label}>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {item.label}
+                          </td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            {item.value}
+                          </td>
+                          <td className="border-b border-[#e5ecf8] px-4 py-3">
+                            <span
+                              className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${
+                                item.ok
+                                  ? 'border-[#b9ecd8] bg-[#ecfbf4] text-[#1f8a63]'
+                                  : 'border-[#f7caca] bg-[#fff0f0] text-[#b64040]'
+                              }`}
+                            >
+                              {item.ok ? '관리 범위' : '주의'}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </Panel>
+              <Panel title="리스크 대응 패널" subtitle="승인 조건 및 모니터링">
+                <div className="grid gap-3">
+                  <article className="rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3.5 text-sm text-[#3b4f76]">
+                    하방 격차 {formatKrwCompact(riskGuardrailGap)}를 기준으로
+                    조건부 한도를 조정합니다.
+                  </article>
+                  <article className="rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3.5 text-sm text-[#3b4f76]">
+                    신용등급 {selectedDetail.valuation.creditGrade} / 점수{' '}
+                    {selectedDetail.valuation.creditRiskScore}점을
+                    모니터링합니다.
+                  </article>
+                  <article className="rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3.5 text-sm text-[#3b4f76]">
+                    다음 승인 단계: {selectedDetail.workflow.nextStep}
+                  </article>
+                </div>
+              </Panel>
+            </section>
           </>
         ) : null}
 
         {activeWorkspaceTab === 'workflow' && selectedDetail ? (
           <>
-            <section
-              className={kpiGridClass}
-              aria-label="워크플로우 핵심 지표"
-            >
+            <section className={kpiGridClass} aria-label="워크플로우 핵심 지표">
               <InfoTile
                 label="현재 단계"
                 value={selectedDetail.workflow.currentStage}
@@ -761,13 +1060,12 @@ export function WorkspaceView({
                 ))}
               </div>
             </section>
-            <section
-              className={supportGridClass}
-              aria-label="워크플로우 상세"
-            >
+            <section className={supportGridClass} aria-label="워크플로우 상세">
               <article className={workflowNoteClass}>
                 <strong>승인 코멘트</strong>
-                <p className="mt-2 text-sm">{selectedDetail.workflow.executiveComment}</p>
+                <p className="mt-2 text-sm">
+                  {selectedDetail.workflow.executiveComment}
+                </p>
               </article>
               <article className={workflowNoteClass}>
                 <strong>다음 행동</strong>


### PR DESCRIPTION
## 요약

#46 기준으로 남아 있던 레퍼런스 정합 갭(공용 UI 프리미티브, 프로젝트 목록/가이드/가치평가/리스크 화면)을 후속 슬라이스로 보정했습니다.

## 변경 내용

- 공용 컴포넌트 보강
  - `InfoTile`, `Panel`, `DecisionBarChart/DecisionSummary`의 시각 위계/밀도 개선
- 레이아웃/카피 정합
  - `TaskSidebar`, `TaskTopbar`, `viewMeta`의 메뉴/헤더 문구 및 톤 보정
- 화면 정합 보강
  - `PortfolioView`: 필터/테이블/액션 가독성 강화
  - `SettingsView`: 역할별 가이드/체크포인트 강화
  - `WorkspaceView`: 가치평가/리스크 액션영역, 분석 테이블, 판단 패널 추가
- dev-log 추가
  - `docs/dev-logs/2026-04-25-issue46-reference-parity-final-polish.md`

## 이유

- 이전 슬라이스에서 남아 있던 “픽셀/정보 밀도 차이”를 줄여 레퍼런스와의 체감 정합을 끌어올리기 위함입니다.
- 공용 컴포넌트를 먼저 정리해 이후 화면 보정 시 중복 비용과 회귀 위험을 줄였습니다.

## 검증

- [x] 관련 테스트를 실행했습니다.
- [x] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
- [x] 인접한 흐름에서 회귀가 없는지 확인했습니다.

- `frontend: npm run lint` 통과
- `frontend: npm run build` 통과
- pre-commit 훅(`frontend lint/format`) 통과

## 스크린샷 또는 로그

- 빌드 산출: `dist/assets/index-B_ypJels.css`, `dist/assets/index-ClgNKYFi.js`
- 상세 비교/선택 근거: `docs/dev-logs/2026-04-25-issue46-reference-parity-final-polish.md`

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [x] 후속 작업이 필요하면 별도 이슈로 분리했습니다.

## 브랜치

- [x] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
- [x] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.

## 이슈 연결

- refs #46
