### PR TITLE
feat(frontend): reference 기반 핵심 페이지 UI 정렬

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ frontend/node_modules/
 frontend/dist/
 frontend/build/
 frontend/*.tsbuildinfo
+frontend/.env.local
+frontend/dev-server.err.log
+frontend/dev-server.out.log
 backend/build/
 backend/.gradle/
 backend/.gradle-user/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "finance-platform-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.5.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -987,6 +988,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1996,6 +2003,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "chart.js": "^4.5.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {},
-  },
-}
+    autoprefixer: {}
+  }
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,7 @@ import {
 import { filterAndSortProjects } from './features/portfolio/explorerFilters';
 import { buildDecisionBars } from './features/workspace/decisionVisuals';
 import { DashboardView } from './views/dashboard/DashboardView';
+import { AccountingView } from './views/accounting/AccountingView';
 import { TaskSidebar } from './views/layout/TaskSidebar';
 import { TaskTopbar } from './views/layout/TaskTopbar';
 import { viewMeta } from './views/layout/viewMeta';
@@ -843,9 +844,17 @@ export function App() {
             />
           ) : null}
 
-          {activeView === 'accounting' ||
-          activeView === 'valuation' ||
-          activeView === 'risk' ? (
+          {activeView === 'accounting' ? (
+            <AccountingView
+              selectedProject={selectedProject}
+              selectedDetail={selectedDetail}
+              detailStatus={selectedDetailStatus}
+              detailError={selectedDetailError}
+              onRetryDetailLoad={retryDetailLoad}
+            />
+          ) : null}
+
+          {activeView === 'valuation' || activeView === 'risk' ? (
             <WorkspaceView
               activeView={activeView}
               selectedProject={selectedProject}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -742,7 +742,8 @@ export function App() {
 
   function handleLogin(username: string, password: string) {
     const resolved = demoAccounts.find(
-      (account) => account.username === username && account.password === password
+      (account) =>
+        account.username === username && account.password === password
     );
 
     if (!resolved) {
@@ -754,7 +755,10 @@ export function App() {
       displayName: resolved.displayName,
       role: resolved.role
     };
-    window.localStorage.setItem('costwise_session', JSON.stringify(nextSession));
+    window.localStorage.setItem(
+      'costwise_session',
+      JSON.stringify(nextSession)
+    );
     setSession(nextSession);
     setSelectedRole(nextSession.role);
     return true;
@@ -770,7 +774,7 @@ export function App() {
   }
 
   return (
-    <div className="grid min-h-screen bg-cw-page lg:grid-cols-[260px_1fr]">
+    <div className="grid min-h-screen bg-cw-page lg:grid-cols-[306px_minmax(0,1fr)]">
       <a
         className="absolute left-2.5 top-2.5 z-50 -translate-y-[140%] rounded-full bg-white px-3.5 py-2.5 text-cw-text no-underline transition-transform duration-150 focus:translate-y-0"
         href="#main-content"
@@ -799,7 +803,10 @@ export function App() {
           onLogout={handleLogout}
         />
 
-        <main id="main-content" className="grid gap-4 px-[22px] pb-[26px] pt-[18px]">
+        <main
+          id="main-content"
+          className="grid gap-4 px-[22px] pb-[26px] pt-[18px]"
+        >
           {activeView === 'dashboard' ? (
             <DashboardView
               decisionSignals={decisionSignals}
@@ -836,7 +843,9 @@ export function App() {
             />
           ) : null}
 
-          {activeView === 'accounting' || activeView === 'valuation' || activeView === 'risk' ? (
+          {activeView === 'accounting' ||
+          activeView === 'valuation' ||
+          activeView === 'risk' ? (
             <WorkspaceView
               activeView={activeView}
               selectedProject={selectedProject}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -775,7 +775,7 @@ export function App() {
   }
 
   return (
-    <div className="grid min-h-screen bg-cw-page lg:grid-cols-[306px_minmax(0,1fr)]">
+    <div className="grid min-h-screen overflow-x-hidden bg-cw-page lg:grid-cols-[292px_minmax(0,1fr)]">
       <a
         className="absolute left-2.5 top-2.5 z-50 -translate-y-[140%] rounded-full bg-white px-3.5 py-2.5 text-cw-text no-underline transition-transform duration-150 focus:translate-y-0"
         href="#main-content"
@@ -789,7 +789,7 @@ export function App() {
         onChangeView={setActiveView}
       />
 
-      <div className="min-h-screen">
+      <div className="min-h-screen min-w-0 overflow-x-hidden">
         <TaskTopbar
           selectedRole={selectedRole}
           username={session.displayName}
@@ -804,10 +804,7 @@ export function App() {
           onLogout={handleLogout}
         />
 
-        <main
-          id="main-content"
-          className="grid gap-4 px-[22px] pb-[26px] pt-[18px]"
-        >
+        <main id="main-content" className="grid gap-4 px-5 pb-6 pt-4">
           {activeView === 'dashboard' ? (
             <DashboardView
               decisionSignals={decisionSignals}

--- a/frontend/src/app/portfolioData.ts
+++ b/frontend/src/app/portfolioData.ts
@@ -1,9 +1,4 @@
-export type Role =
-  | 'ADMIN'
-  | 'EXECUTIVE'
-  | 'PM'
-  | 'ACCOUNTANT'
-  | 'AUDITOR';
+export type Role = 'ADMIN' | 'EXECUTIVE' | 'PM' | 'ACCOUNTANT' | 'AUDITOR';
 
 export type RiskLevel = '낮음' | '중간' | '높음';
 
@@ -516,7 +511,8 @@ export const roleInsights: Record<Role, RoleInsight> = {
     summary:
       '역할별 탐색 범위와 프로젝트 운영 흐름을 함께 보며, 필요 시 운영 기준과 컨텍스트를 조정합니다.',
     decisionFocus: '권한 정책, 운영 안정성, 예외 대응',
-    riskWatch: '역할 경계가 불명확하면 승인 근거와 편집 책임이 섞일 수 있습니다.',
+    riskWatch:
+      '역할 경계가 불명확하면 승인 근거와 편집 책임이 섞일 수 있습니다.',
     nextAction: '운영 정책 점검 및 권한 예외 검토'
   },
   EXECUTIVE: {
@@ -532,7 +528,8 @@ export const roleInsights: Record<Role, RoleInsight> = {
     summary:
       '본부별 프로젝트 수, 투자 규모, 평균 NPV를 비교하고 어떤 프로젝트를 먼저 추진할지 판단합니다.',
     decisionFocus: '프로젝트 우선순위, 본부 포트폴리오, 일정 리스크',
-    riskWatch: '본부 단위 맥락 없이 개별 프로젝트만 보면 우선순위가 왜곡될 수 있습니다.',
+    riskWatch:
+      '본부 단위 맥락 없이 개별 프로젝트만 보면 우선순위가 왜곡될 수 있습니다.',
     nextAction: '우선순위 코멘트 정리 및 프로젝트 조정'
   },
   ACCOUNTANT: {
@@ -548,7 +545,8 @@ export const roleInsights: Record<Role, RoleInsight> = {
     summary:
       '감사 로그, 검토 상태, 승인 근거를 분리해서 보고 변경 없이 증적과 맥락이 일치하는지 확인합니다.',
     decisionFocus: '감사 이력, 승인 근거, 변경 추적',
-    riskWatch: '운영 화면에서 수정 권한이 섞이면 감사 독립성이 약해질 수 있습니다.',
+    riskWatch:
+      '운영 화면에서 수정 권한이 섞이면 감사 독립성이 약해질 수 있습니다.',
     nextAction: '증적 검토 결과 기록 및 후속 확인 요청'
   }
 };
@@ -690,7 +688,9 @@ export async function loadAuditEventsByProjectId(
   events: AuditEvent[];
   source: DataSource;
 }> {
-  const resolvedLimit = Number.isFinite(limit) ? Math.max(1, Math.round(limit)) : 20;
+  const resolvedLimit = Number.isFinite(limit)
+    ? Math.max(1, Math.round(limit))
+    : 20;
 
   try {
     const response = await apiFetch(
@@ -762,13 +762,16 @@ export async function updateUserAccount(
   request: UpsertUserRequest
 ): Promise<UserAccount> {
   try {
-    const response = await apiFetch(`/api/users/${encodeURIComponent(userId)}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(request)
-    });
+    const response = await apiFetch(
+      `/api/users/${encodeURIComponent(userId)}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(request)
+      }
+    );
 
     if (!response.ok) {
       const errorMessage = await readApiErrorMessage(response);
@@ -786,9 +789,12 @@ export async function updateUserAccount(
 
 export async function deleteUserAccount(userId: string): Promise<void> {
   try {
-    const response = await apiFetch(`/api/users/${encodeURIComponent(userId)}`, {
-      method: 'DELETE'
-    });
+    const response = await apiFetch(
+      `/api/users/${encodeURIComponent(userId)}`,
+      {
+        method: 'DELETE'
+      }
+    );
 
     if (!response.ok) {
       const errorMessage = await readApiErrorMessage(response);
@@ -1208,9 +1214,14 @@ function adaptProjectDetail(
           : defaults.allocation.allocationBasis,
       calculationTrace:
         '표준원가=인력+직접비+표준배부, 실제원가=배부원가+내부대체가액, 성과갭=영업현금흐름-배부원가',
-      rules: allocationRules.length > 0 ? allocationRules : defaults.allocation.rules,
+      rules:
+        allocationRules.length > 0
+          ? allocationRules
+          : defaults.allocation.rules,
       changeHistory:
-        changeHistory.length > 0 ? changeHistory : defaults.allocation.changeHistory
+        changeHistory.length > 0
+          ? changeHistory
+          : defaults.allocation.changeHistory
     },
     valuation: {
       fairValueKrw: toNumber(
@@ -1530,7 +1541,8 @@ export function buildProjectDetail(projectCode: string): ProjectDetail {
               ? 'BBB'
               : 'BB',
       discountRate: 0.115,
-      riskPremium: seed.risk === '높음' ? 0.08 : seed.risk === '중간' ? 0.04 : 0.01,
+      riskPremium:
+        seed.risk === '높음' ? 0.08 : seed.risk === '중간' ? 0.04 : 0.01,
       interpretation:
         seed.risk === '높음'
           ? '보수적 할인율 기준 재검토 필요'

--- a/frontend/src/features/auth/permissions.ts
+++ b/frontend/src/features/auth/permissions.ts
@@ -19,11 +19,43 @@ const roleLabels: Record<Role, string> = {
 };
 
 const menuAccessByRole: Record<Role, readonly MenuAccessKey[]> = {
-  ADMIN: ['dashboard', 'portfolio', 'accounting', 'valuation', 'risk', 'users', 'audit', 'settings'],
-  EXECUTIVE: ['dashboard', 'portfolio', 'accounting', 'valuation', 'risk', 'settings'],
+  ADMIN: [
+    'dashboard',
+    'portfolio',
+    'accounting',
+    'valuation',
+    'risk',
+    'users',
+    'audit',
+    'settings'
+  ],
+  EXECUTIVE: [
+    'dashboard',
+    'portfolio',
+    'accounting',
+    'valuation',
+    'risk',
+    'settings'
+  ],
   PM: ['dashboard', 'portfolio', 'accounting', 'valuation', 'risk', 'settings'],
-  ACCOUNTANT: ['dashboard', 'portfolio', 'accounting', 'valuation', 'risk', 'settings'],
-  AUDITOR: ['dashboard', 'portfolio', 'accounting', 'valuation', 'risk', 'users', 'audit', 'settings']
+  ACCOUNTANT: [
+    'dashboard',
+    'portfolio',
+    'accounting',
+    'valuation',
+    'risk',
+    'settings'
+  ],
+  AUDITOR: [
+    'dashboard',
+    'portfolio',
+    'accounting',
+    'valuation',
+    'risk',
+    'users',
+    'audit',
+    'settings'
+  ]
 };
 
 const projectWriteRoles = new Set<Role>(['ADMIN', 'PM', 'ACCOUNTANT']);

--- a/frontend/src/features/portfolio/explorerFilters.ts
+++ b/frontend/src/features/portfolio/explorerFilters.ts
@@ -1,7 +1,10 @@
 import type { ProjectSummary } from '../../app/portfolioData';
 import type { ExplorerQuickFilterKey, ExplorerSortKey } from './explorerState';
 
-export const explorerSortOptions: Array<{ key: ExplorerSortKey; label: string }> = [
+export const explorerSortOptions: Array<{
+  key: ExplorerSortKey;
+  label: string;
+}> = [
   { key: 'priority', label: '우선순위 순' },
   { key: 'npv', label: 'NPV 높은순' },
   { key: 'irr', label: 'IRR 높은순' },
@@ -16,8 +19,16 @@ export const explorerQuickFilterOptions: Array<{
 }> = [
   { key: 'all', label: '전체', helper: '전체 프로젝트' },
   { key: 'needs-review', label: '즉시 검토', helper: '승인 전 검토 대상' },
-  { key: 'accounting-focus', label: '관리회계 중심', helper: '원가·배분 우선 후보' },
-  { key: 'valuation-focus', label: '재무평가 중심', helper: '사업성 검토 우선 후보' },
+  {
+    key: 'accounting-focus',
+    label: '관리회계 중심',
+    helper: '원가·배분 우선 후보'
+  },
+  {
+    key: 'valuation-focus',
+    label: '재무평가 중심',
+    helper: '사업성 검토 우선 후보'
+  },
   { key: 'shortlist', label: '고우선순위', helper: '숏리스트 후보' }
 ];
 
@@ -40,12 +51,16 @@ export function filterAndSortProjects(
 
   return projects
     .filter((project) => {
-      if (input.headquarterFilter !== 'all' && project.headquarter !== input.headquarterFilter) {
+      if (
+        input.headquarterFilter !== 'all' &&
+        project.headquarter !== input.headquarterFilter
+      ) {
         return false;
       }
 
       if (normalizedSearchTerm) {
-        const haystack = `${project.name} ${project.code} ${project.headquarter}`.toLowerCase();
+        const haystack =
+          `${project.name} ${project.code} ${project.headquarter}`.toLowerCase();
         if (!haystack.includes(normalizedSearchTerm)) {
           return false;
         }
@@ -60,14 +75,19 @@ export function filterAndSortProjects(
       }
 
       if (input.quickFilter === 'accounting-focus') {
-        return project.assetCategory === '프로젝트' || project.status === '검토중';
+        return (
+          project.assetCategory === '프로젝트' || project.status === '검토중'
+        );
       }
 
       if (input.quickFilter === 'valuation-focus') {
         return project.npvKrw > 0 && project.irr >= 0.14;
       }
 
-      return project.rank <= 5 || (project.status === '승인' && project.risk !== '높음');
+      return (
+        project.rank <= 5 ||
+        (project.status === '승인' && project.risk !== '높음')
+      );
     })
     .sort((left, right) => {
       if (input.sort === 'npv') {

--- a/frontend/src/features/portfolio/explorerState.ts
+++ b/frontend/src/features/portfolio/explorerState.ts
@@ -1,4 +1,8 @@
-import { defaultPortfolioSummary, navigationItems, type ProjectStatus } from '../../app/portfolioData';
+import {
+  defaultPortfolioSummary,
+  navigationItems,
+  type ProjectStatus
+} from '../../app/portfolioData';
 
 export type NavigationKey = (typeof navigationItems)[number]['key'];
 export type ExplorerSortKey = 'priority' | 'npv' | 'irr' | 'payback' | 'risk';
@@ -29,16 +33,22 @@ export function parseExplorerState(search: string): {
   const rawProjectCode = query.get('project');
 
   const view: NavigationKey =
-    rawView && navigationItems.some((item) => item.key === normalizeLegacyView(rawView))
+    rawView &&
+    navigationItems.some((item) => item.key === normalizeLegacyView(rawView))
       ? (normalizeLegacyView(rawView) as NavigationKey)
       : 'dashboard';
-  const sort: ExplorerSortKey = isExplorerSortKey(rawSort) ? rawSort : defaultExplorerSort;
-  const quickFilter: ExplorerQuickFilterKey = isExplorerQuickFilterKey(rawQuickFilter)
+  const sort: ExplorerSortKey = isExplorerSortKey(rawSort)
+    ? rawSort
+    : defaultExplorerSort;
+  const quickFilter: ExplorerQuickFilterKey = isExplorerQuickFilterKey(
+    rawQuickFilter
+  )
     ? rawQuickFilter
     : defaultExplorerQuickFilter;
   const headquarter = rawHeadquarter?.trim() ? rawHeadquarter : 'all';
   const searchTerm = rawSearch?.trim() ?? '';
-  const projectCode = rawProjectCode?.trim() || defaultPortfolioSummary.projects[0]?.code || '';
+  const projectCode =
+    rawProjectCode?.trim() || defaultPortfolioSummary.projects[0]?.code || '';
 
   return {
     view,
@@ -75,10 +85,18 @@ export function statusTone(status: ProjectStatus) {
 }
 
 function isExplorerSortKey(value: string | null): value is ExplorerSortKey {
-  return value === 'priority' || value === 'npv' || value === 'irr' || value === 'payback' || value === 'risk';
+  return (
+    value === 'priority' ||
+    value === 'npv' ||
+    value === 'irr' ||
+    value === 'payback' ||
+    value === 'risk'
+  );
 }
 
-function isExplorerQuickFilterKey(value: string | null): value is ExplorerQuickFilterKey {
+function isExplorerQuickFilterKey(
+  value: string | null
+): value is ExplorerQuickFilterKey {
   return (
     value === 'all' ||
     value === 'needs-review' ||

--- a/frontend/src/shared/components/InfoTile.tsx
+++ b/frontend/src/shared/components/InfoTile.tsx
@@ -1,10 +1,10 @@
 export function InfoTile({ label, value }: { label: string; value: string }) {
   return (
-    <div className="group rounded-2xl border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#fbfdff_100%)] px-5 py-4 shadow-[0_2px_8px_rgba(15,23,42,0.05)] transition-all hover:border-[#b9cbe7] hover:shadow-[0_4px_14px_rgba(15,23,42,0.08)]">
-      <span className="block text-[0.7rem] font-extrabold tracking-[0.1em] text-cw-muted/90">
+    <div className="group rounded-2xl border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#f8fbff_100%)] px-6 py-5 shadow-[0_6px_18px_rgba(15,23,42,0.06)] transition-all hover:border-[#b9cbe7] hover:shadow-[0_10px_26px_rgba(15,23,42,0.09)]">
+      <span className="block text-[0.78rem] font-extrabold tracking-[0.08em] text-cw-muted/90">
         {label}
       </span>
-      <strong className="mt-2.5 block text-[1.8rem] font-extrabold leading-none text-[#142542]">
+      <strong className="mt-3 block text-[2.2rem] font-extrabold leading-none tracking-[-0.02em] text-[#142542]">
         {value}
       </strong>
     </div>

--- a/frontend/src/shared/components/InfoTile.tsx
+++ b/frontend/src/shared/components/InfoTile.tsx
@@ -1,10 +1,10 @@
 export function InfoTile({ label, value }: { label: string; value: string }) {
   return (
-    <div className="group rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.05)] transition-colors hover:border-[#b9cbe7]">
-      <span className="block text-[12px] font-semibold tracking-[0.08em] text-cw-muted/90">
+    <div className="group rounded-2xl border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#fbfdff_100%)] px-5 py-4 shadow-[0_2px_8px_rgba(15,23,42,0.05)] transition-all hover:border-[#b9cbe7] hover:shadow-[0_4px_14px_rgba(15,23,42,0.08)]">
+      <span className="block text-[0.7rem] font-extrabold tracking-[0.1em] text-cw-muted/90">
         {label}
       </span>
-      <strong className="mt-2 block text-[34px] font-extrabold leading-none text-[#142542]">
+      <strong className="mt-2.5 block text-[1.8rem] font-extrabold leading-none text-[#142542]">
         {value}
       </strong>
     </div>

--- a/frontend/src/shared/components/InfoTile.tsx
+++ b/frontend/src/shared/components/InfoTile.tsx
@@ -1,10 +1,10 @@
 export function InfoTile({ label, value }: { label: string; value: string }) {
   return (
-    <div className="group rounded-2xl border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#f8fbff_100%)] px-6 py-5 shadow-[0_6px_18px_rgba(15,23,42,0.06)] transition-all hover:border-[#b9cbe7] hover:shadow-[0_10px_26px_rgba(15,23,42,0.09)]">
-      <span className="block text-[0.78rem] font-extrabold tracking-[0.08em] text-cw-muted/90">
+    <div className="group rounded-2xl border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#f8fbff_100%)] px-5 py-4 shadow-[0_4px_14px_rgba(15,23,42,0.055)] transition-all hover:border-[#b9cbe7] hover:shadow-[0_8px_20px_rgba(15,23,42,0.08)]">
+      <span className="block text-[0.74rem] font-extrabold tracking-[0.07em] text-cw-muted/90">
         {label}
       </span>
-      <strong className="mt-3 block text-[2.2rem] font-extrabold leading-none tracking-[-0.02em] text-[#142542]">
+      <strong className="mt-2.5 block text-[1.85rem] font-extrabold leading-none tracking-[-0.015em] text-[#142542]">
         {value}
       </strong>
     </div>

--- a/frontend/src/shared/components/MetricCard.tsx
+++ b/frontend/src/shared/components/MetricCard.tsx
@@ -11,7 +11,12 @@ const toneStyles: Record<NonNullable<MetricCardProps['tone']>, string> = {
   warning: 'metric-card--warning'
 };
 
-export function MetricCard({ label, value, detail, tone = 'primary' }: MetricCardProps) {
+export function MetricCard({
+  label,
+  value,
+  detail,
+  tone = 'primary'
+}: MetricCardProps) {
   return (
     <section className={`metric-card ${toneStyles[tone]}`}>
       <div className="metric-card__label">{label}</div>

--- a/frontend/src/shared/components/Panel.tsx
+++ b/frontend/src/shared/components/Panel.tsx
@@ -10,22 +10,22 @@ type PanelProps = {
 export function Panel({ id, title, subtitle, children }: PanelProps) {
   return (
     <section
-      className="overflow-hidden rounded-2xl border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#fcfdff_100%)] shadow-[0_2px_8px_rgba(15,23,42,0.06)]"
+      className="overflow-hidden rounded-3xl border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#fbfcff_100%)] shadow-[0_8px_24px_rgba(15,23,42,0.06)]"
       id={id}
     >
-      <header className="border-b border-slate-100 px-6 pb-3.5 pt-4.5">
+      <header className="border-b border-slate-100 px-7 pb-4 pt-5">
         <div>
-          <h2 className="text-[1.35rem] font-extrabold tracking-[-0.01em] text-[#10213d]">
+          <h2 className="text-[1.9rem] font-extrabold tracking-[-0.02em] text-[#132445]">
             {title}
           </h2>
           {subtitle ? (
-            <p className="mt-1.5 text-[0.95rem] font-medium leading-relaxed text-cw-muted">
+            <p className="mt-2 text-[1.05rem] font-medium leading-relaxed text-cw-muted">
               {subtitle}
             </p>
           ) : null}
         </div>
       </header>
-      <div className="p-6 pt-5">{children}</div>
+      <div className="p-7 pt-5">{children}</div>
     </section>
   );
 }

--- a/frontend/src/shared/components/Panel.tsx
+++ b/frontend/src/shared/components/Panel.tsx
@@ -10,22 +10,22 @@ type PanelProps = {
 export function Panel({ id, title, subtitle, children }: PanelProps) {
   return (
     <section
-      className="overflow-hidden rounded-2xl border border-cw-cardBorder bg-white shadow-[0_1px_2px_rgba(15,23,42,0.06)]"
+      className="overflow-hidden rounded-2xl border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#fcfdff_100%)] shadow-[0_2px_8px_rgba(15,23,42,0.06)]"
       id={id}
     >
-      <header className="border-b border-slate-100 px-6 pb-4 pt-5">
+      <header className="border-b border-slate-100 px-6 pb-3.5 pt-4.5">
         <div>
-          <h2 className="text-[34px] font-extrabold tracking-[-0.02em] text-[#10213d]">
+          <h2 className="text-[1.35rem] font-extrabold tracking-[-0.01em] text-[#10213d]">
             {title}
           </h2>
           {subtitle ? (
-            <p className="mt-2 text-[17px] font-medium text-cw-muted">
+            <p className="mt-1.5 text-[0.95rem] font-medium leading-relaxed text-cw-muted">
               {subtitle}
             </p>
           ) : null}
         </div>
       </header>
-      <div className="p-6">{children}</div>
+      <div className="p-6 pt-5">{children}</div>
     </section>
   );
 }

--- a/frontend/src/shared/components/Panel.tsx
+++ b/frontend/src/shared/components/Panel.tsx
@@ -10,17 +10,17 @@ type PanelProps = {
 export function Panel({ id, title, children }: PanelProps) {
   return (
     <section
-      className="overflow-hidden rounded-2xl border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#fbfcff_100%)] shadow-[0_4px_14px_rgba(15,23,42,0.06)]"
+      className="overflow-hidden rounded-[22px] border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#fbfcff_100%)] shadow-[0_8px_24px_rgba(15,23,42,0.05)]"
       id={id}
     >
-      <header className="border-b border-slate-100 px-6 pb-3.5 pt-4.5">
+      <header className="border-b border-slate-100 px-7 pb-3.5 pt-5">
         <div>
-          <h2 className="text-[2rem] font-extrabold tracking-[-0.02em] text-[#132445]">
+          <h2 className="m-0 text-[1.82rem] font-extrabold leading-[1.08] tracking-[-0.02em] text-[#132445]">
             {title}
           </h2>
         </div>
       </header>
-      <div className="p-6 pt-5">{children}</div>
+      <div className="p-7 pt-5">{children}</div>
     </section>
   );
 }

--- a/frontend/src/shared/components/Panel.tsx
+++ b/frontend/src/shared/components/Panel.tsx
@@ -7,7 +7,7 @@ type PanelProps = {
   children: ReactNode;
 };
 
-export function Panel({ id, title, subtitle, children }: PanelProps) {
+export function Panel({ id, title, children }: PanelProps) {
   return (
     <section
       className="overflow-hidden rounded-2xl border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#fbfcff_100%)] shadow-[0_4px_14px_rgba(15,23,42,0.06)]"
@@ -18,11 +18,6 @@ export function Panel({ id, title, subtitle, children }: PanelProps) {
           <h2 className="text-[2rem] font-extrabold tracking-[-0.02em] text-[#132445]">
             {title}
           </h2>
-          {subtitle ? (
-            <p className="mt-1.5 text-[1.02rem] font-medium leading-relaxed text-cw-muted">
-              {subtitle}
-            </p>
-          ) : null}
         </div>
       </header>
       <div className="p-6 pt-5">{children}</div>

--- a/frontend/src/shared/components/Panel.tsx
+++ b/frontend/src/shared/components/Panel.tsx
@@ -10,22 +10,22 @@ type PanelProps = {
 export function Panel({ id, title, subtitle, children }: PanelProps) {
   return (
     <section
-      className="overflow-hidden rounded-3xl border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#fbfcff_100%)] shadow-[0_8px_24px_rgba(15,23,42,0.06)]"
+      className="overflow-hidden rounded-2xl border border-cw-cardBorder bg-[linear-gradient(180deg,#ffffff_0%,#fbfcff_100%)] shadow-[0_4px_14px_rgba(15,23,42,0.06)]"
       id={id}
     >
-      <header className="border-b border-slate-100 px-7 pb-4 pt-5">
+      <header className="border-b border-slate-100 px-6 pb-3.5 pt-4.5">
         <div>
-          <h2 className="text-[1.9rem] font-extrabold tracking-[-0.02em] text-[#132445]">
+          <h2 className="text-[2rem] font-extrabold tracking-[-0.02em] text-[#132445]">
             {title}
           </h2>
           {subtitle ? (
-            <p className="mt-2 text-[1.05rem] font-medium leading-relaxed text-cw-muted">
+            <p className="mt-1.5 text-[1.02rem] font-medium leading-relaxed text-cw-muted">
               {subtitle}
             </p>
           ) : null}
         </div>
       </header>
-      <div className="p-7 pt-5">{children}</div>
+      <div className="p-6 pt-5">{children}</div>
     </section>
   );
 }

--- a/frontend/src/shared/components/ProgressBar.tsx
+++ b/frontend/src/shared/components/ProgressBar.tsx
@@ -12,26 +12,38 @@ const toneStyles: Record<NonNullable<ProgressBarProps['tone']>, string> = {
   rose: 'bg-[linear-gradient(90deg,#dc6271,#f2a3ac)]'
 };
 
-export function ProgressBar({ label, value, max, tone = 'violet' }: ProgressBarProps) {
-  const percentage = max > 0 ? Math.min(100, Math.round((value / max) * 100)) : 0;
+export function ProgressBar({
+  label,
+  value,
+  max,
+  tone = 'violet'
+}: ProgressBarProps) {
+  const percentage =
+    max > 0 ? Math.min(100, Math.round((value / max) * 100)) : 0;
 
   return (
     <div
-      className="grid items-center gap-3 lg:grid-cols-[1fr_minmax(150px,240px)_auto]"
+      className="grid items-center gap-3.5 lg:grid-cols-[minmax(140px,1fr)_minmax(170px,260px)_auto]"
       aria-label={`${label} ${value.toLocaleString('ko-KR')}만원 (${percentage}%)`}
     >
       <div className="grid gap-1">
-        <span className="text-[0.88rem] text-slate-500">{label}</span>
-        <strong>{value.toLocaleString('ko-KR')}만원</strong>
+        <span className="text-[0.78rem] font-semibold tracking-[0.04em] text-slate-500">
+          {label}
+        </span>
+        <strong className="text-[0.96rem] text-[#132441]">
+          {value.toLocaleString('ko-KR')}만원
+        </strong>
       </div>
-      <div className="h-2.5 overflow-hidden rounded-full bg-slate-200">
+      <div className="h-2.5 overflow-hidden rounded-full bg-slate-200/90 ring-1 ring-slate-200">
         <div
           className={`h-full rounded-full ${toneStyles[tone]}`}
           style={{ width: `${percentage}%` }}
           aria-hidden="true"
         />
       </div>
-      <div className="text-[0.88rem] text-slate-500">{percentage}%</div>
+      <div className="text-[0.82rem] font-semibold text-slate-500">
+        {percentage}%
+      </div>
     </div>
   );
 }

--- a/frontend/src/views/accounting/AccountingView.tsx
+++ b/frontend/src/views/accounting/AccountingView.tsx
@@ -10,6 +10,17 @@ type AccountingViewProps = {
   onRetryDetailLoad(): void;
 };
 
+type AccountingTransaction = {
+  date: string;
+  period: string;
+  department: string;
+  project: string;
+  item: string;
+  actual: string;
+  standard: string;
+  note: string;
+};
+
 const departmentLabelByCode: Record<string, string> = {
   HQ01: '주식운용본부',
   HQ02: '채권운용본부',
@@ -17,6 +28,89 @@ const departmentLabelByCode: Record<string, string> = {
   HQ04: '파생상품본부',
   HQ05: '리스크관리본부'
 };
+
+const accountingTransactions: AccountingTransaction[] = [
+  {
+    date: '2026-03-25',
+    period: '2026-03',
+    department: '리스크관리본부',
+    project: 'PRJ-2025-018 · IFRS17 시스템 구축',
+    item: '직접인건비',
+    actual: '₩14,000,000',
+    standard: '₩13,500,000',
+    note: 'IFRS17 개발'
+  },
+  {
+    date: '2026-03-20',
+    period: '2026-03',
+    department: '파생상품본부',
+    project: 'PRJ-2025-015 · 통화 옵션 헤지북',
+    item: '직접인건비',
+    actual: '₩10,500,000',
+    standard: '₩10,000,000',
+    note: '통화옵션 운용'
+  },
+  {
+    date: '2026-03-15',
+    period: '2026-03',
+    department: '대체투자본부',
+    project: 'PRJ-2025-010 · 서울권 오피스 리츠',
+    item: '자재비',
+    actual: '₩32,000,000',
+    standard: '₩30,000,000',
+    note: '오피스리츠 감정평가'
+  },
+  {
+    date: '2026-03-10',
+    period: '2026-03',
+    department: '채권운용본부',
+    project: 'PRJ-2025-007 · 해외채권 달러표시',
+    item: '직접인건비',
+    actual: '₩13,500,000',
+    standard: '₩13,000,000',
+    note: '해외채권 분석'
+  },
+  {
+    date: '2026-03-05',
+    period: '2026-03',
+    department: '주식운용본부',
+    project: 'PRJ-2025-004 · ESG 테마 펀드',
+    item: '직접인건비',
+    actual: '₩12,500,000',
+    standard: '₩12,000,000',
+    note: 'ESG펀드 분석'
+  },
+  {
+    date: '2026-02-25',
+    period: '2026-02',
+    department: '파생상품본부',
+    project: 'PRJ-2025-014 · 주가지수 선물 전략',
+    item: '직접인건비',
+    actual: '₩11,000,000',
+    standard: '₩10,500,000',
+    note: '선물 운용 인건비'
+  },
+  {
+    date: '2026-02-22',
+    period: '2026-02',
+    department: '대체투자본부',
+    project: 'PRJ-2025-011 · 해상풍력 프로젝트파이낸싱',
+    item: '외주용역비',
+    actual: '₩45,000,000',
+    standard: '₩45,000,000',
+    note: '해상풍력 외주실사'
+  },
+  {
+    date: '2026-02-20',
+    period: '2026-02',
+    department: '채권운용본부',
+    project: 'PRJ-2025-005 · 국고채 10년 포지션',
+    item: '직접인건비',
+    actual: '₩16,000,000',
+    standard: '₩15,500,000',
+    note: '국고채 운용인건비'
+  }
+];
 
 export function AccountingView({
   selectedProject,
@@ -223,6 +317,65 @@ export function AccountingView({
               </div>
             </Panel>
           </section>
+
+          <Panel title="원가 거래 내역">
+            <div className="mb-3 flex flex-wrap items-center justify-end gap-2.5">
+              <select className="rounded-[10px] border border-[#cbd6ea] bg-white px-3 py-2 text-sm text-[#2f4570]">
+                <option>전체 본부</option>
+                <option>주식운용본부</option>
+                <option>채권운용본부</option>
+                <option>대체투자본부</option>
+                <option>파생상품본부</option>
+                <option>리스크관리본부</option>
+              </select>
+              <input
+                className="rounded-[10px] border border-[#cbd6ea] bg-white px-3 py-2 text-sm text-[#2f4570]"
+                type="month"
+              />
+            </div>
+
+            <div className="max-h-[520px] overflow-auto rounded-xl border border-[#dce5f4] bg-white">
+              <table className="min-w-full text-[0.98rem]">
+                <thead className="sticky top-0 z-[1] bg-[#eef3fb] text-[#5b7097]">
+                  <tr>
+                    <th className="px-4 py-3 text-left">날짜</th>
+                    <th className="px-4 py-3 text-left">기간</th>
+                    <th className="px-4 py-3 text-left">본부</th>
+                    <th className="px-4 py-3 text-left">프로젝트</th>
+                    <th className="px-4 py-3 text-left">원가항목</th>
+                    <th className="px-4 py-3 text-left">실제</th>
+                    <th className="px-4 py-3 text-left">표준</th>
+                    <th className="px-4 py-3 text-left">비고</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {accountingTransactions.map((row) => (
+                    <tr
+                      key={`${row.date}-${row.project}`}
+                      className="border-t border-[#e6edf8]"
+                    >
+                      <td className="px-4 py-3 text-[#2a4168]">{row.date}</td>
+                      <td className="px-4 py-3 text-[#2a4168]">{row.period}</td>
+                      <td className="px-4 py-3 font-semibold text-[#1e2f4c]">
+                        {row.department}
+                      </td>
+                      <td className="px-4 py-3 text-[#2a4168]">
+                        {row.project}
+                      </td>
+                      <td className="px-4 py-3 text-[#2a4168]">{row.item}</td>
+                      <td className="px-4 py-3 font-semibold text-[#1e2f4c]">
+                        {row.actual}
+                      </td>
+                      <td className="px-4 py-3 text-[#7086ac]">
+                        {row.standard}
+                      </td>
+                      <td className="px-4 py-3 text-[#60779f]">{row.note}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Panel>
         </>
       ) : null}
     </section>

--- a/frontend/src/views/accounting/AccountingView.tsx
+++ b/frontend/src/views/accounting/AccountingView.tsx
@@ -233,21 +233,21 @@ export function AccountingView({
 
   return (
     <section className="grid gap-5">
-      <header className="flex flex-wrap items-start justify-between gap-3">
+      <header className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h2 className="m-0 text-[2.45rem] font-extrabold tracking-[-0.02em] text-[#172a4a]">
+          <h2 className="m-0 text-[2.62rem] font-black leading-[1.03] tracking-[-0.025em] text-[#172a4a]">
             원가 집계·분석
           </h2>
         </div>
         <div className="flex items-center gap-2.5">
           <button
-            className="rounded-[10px] border border-[#cbd6ea] bg-white px-3.5 py-2.5 font-bold text-[#2f4570]"
+            className="rounded-[12px] border border-[#cbd6ea] bg-white px-4 py-2.5 text-[1.02rem] font-extrabold tracking-[-0.01em] text-[#2f4570] transition-colors hover:bg-[#f6f9ff]"
             type="button"
           >
             CSV
           </button>
           <button
-            className="rounded-[10px] bg-[#2b4dbf] px-3.5 py-2.5 font-extrabold text-white"
+            className="rounded-[12px] bg-[#2b4dbf] px-4 py-2.5 text-[1.02rem] font-extrabold tracking-[-0.01em] text-white shadow-[0_8px_18px_rgba(43,77,191,0.28)] transition-transform hover:-translate-y-[1px]"
             type="button"
           >
             + 원가 입력
@@ -282,21 +282,21 @@ export function AccountingView({
             <div className="mb-3 flex justify-end">
               <button
                 type="button"
-                className="rounded-xl border border-[#c8d4ea] bg-white px-4 py-2 text-[1rem] font-semibold text-[#2f4570]"
+                className="rounded-xl border border-[#c8d4ea] bg-white px-4 py-2 text-[1rem] font-semibold tracking-[-0.01em] text-[#2f4570] hover:bg-[#f7faff]"
               >
                 2026년 02월
               </button>
             </div>
 
-            <div className="overflow-hidden rounded-2xl border border-[#dce5f4] bg-white shadow-[inset_0_1px_0_#f6f9ff]">
-              <table className="min-w-full text-[1.08rem]">
-                <thead className="bg-[#eef3fb] text-[#5b7097]">
+            <div className="overflow-x-auto rounded-2xl border border-[#dce5f4] bg-white shadow-[inset_0_1px_0_#f6f9ff]">
+              <table className="min-w-full text-[1.03rem]">
+                <thead className="bg-[#eef3fb] text-[0.95rem] font-bold tracking-[0.01em] text-[#5b7097]">
                   <tr>
                     <th className="px-5 py-4 text-left">본부</th>
-                    <th className="px-5 py-4 text-left">실제원가</th>
-                    <th className="px-5 py-4 text-left">표준원가</th>
-                    <th className="px-5 py-4 text-left">차이</th>
-                    <th className="px-5 py-4 text-left">차이율</th>
+                    <th className="px-5 py-4 text-right">실제원가</th>
+                    <th className="px-5 py-4 text-right">표준원가</th>
+                    <th className="px-5 py-4 text-right">차이</th>
+                    <th className="px-5 py-4 text-right">차이율</th>
                     <th className="px-5 py-4 text-left">판정</th>
                   </tr>
                 </thead>
@@ -304,19 +304,19 @@ export function AccountingView({
                   {mergedRows.map((row) => (
                     <tr
                       key={row.department}
-                      className="border-t border-[#e6edf8]"
+                      className="border-t border-[#e6edf8] text-[#2c4269] transition-colors hover:bg-[#f9fbff]"
                     >
                       <td className="px-5 py-4 font-semibold text-[#1e2f4c]">
                         {row.department}
                       </td>
-                      <td className="px-5 py-4">
+                      <td className="px-5 py-4 text-right font-semibold text-[#23355a]">
                         {formatKrwCompact(row.actual)}
                       </td>
-                      <td className="px-5 py-4 text-[#7086ac]">
+                      <td className="px-5 py-4 text-right text-[#7086ac]">
                         {formatKrwCompact(row.standard)}
                       </td>
                       <td
-                        className={`px-5 py-4 font-bold ${
+                        className={`px-5 py-4 text-right font-bold ${
                           row.diff > 0 ? 'text-[#e03131]' : 'text-[#16955f]'
                         }`}
                       >
@@ -324,14 +324,14 @@ export function AccountingView({
                         {formatKrwCompact(row.diff)}
                       </td>
                       <td
-                        className={`px-5 py-4 font-bold ${
+                        className={`px-5 py-4 text-right font-bold ${
                           row.rate > 0 ? 'text-[#e03131]' : 'text-[#16955f]'
                         }`}
                       >
                         {row.rate.toFixed(2)}%
                       </td>
                       <td className="px-5 py-4">
-                        <span className="inline-flex items-center rounded-full bg-[#f7dada] px-3 py-1 text-sm font-bold text-[#b83f3f]">
+                        <span className="inline-flex items-center rounded-full bg-[#f7dada] px-3 py-1 text-[0.9rem] font-bold text-[#b83f3f]">
                           불리
                         </span>
                       </td>
@@ -342,9 +342,15 @@ export function AccountingView({
             </div>
           </Panel>
 
-          <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
+          <section className="grid grid-cols-[minmax(0,1.9fr)_minmax(340px,1fr)] gap-5 max-[1320px]:grid-cols-1">
             <Panel title="본부별 원가 구성">
-              <div className="grid gap-3">
+              <div className="mb-4 flex items-center justify-between rounded-xl border border-[#dbe5f5] bg-[#f8fbff] px-4 py-2.5 text-[0.92rem] text-[#5e749c]">
+                <span>배분원가 기준 막대 비교</span>
+                <strong className="font-bold text-[#25406f]">
+                  프로젝트 원가
+                </strong>
+              </div>
+              <div className="grid gap-3.5">
                 {mergedRows.map((row) => {
                   const width = Math.max(
                     3,
@@ -353,17 +359,19 @@ export function AccountingView({
                   return (
                     <article
                       key={`bar-${row.department}`}
-                      className="grid gap-1.5"
+                      className="grid gap-2 rounded-xl border border-[#e3ebf8] bg-[#fbfdff] px-4 py-3"
                     >
-                      <div className="flex items-center justify-between text-sm text-[#647ca5]">
-                        <strong className="text-[#1e2f4c]">
+                      <div className="flex items-center justify-between text-[0.95rem] text-[#647ca5]">
+                        <strong className="text-[1.02rem] text-[#1e2f4c]">
                           {row.department}
                         </strong>
-                        <span>{formatKrwCompact(row.actual)}</span>
+                        <span className="font-semibold text-[#4e6690]">
+                          {formatKrwCompact(row.actual)}
+                        </span>
                       </div>
-                      <div className="h-3 overflow-hidden rounded-full bg-[#eaf0f9]">
+                      <div className="h-3.5 overflow-hidden rounded-full bg-[#eaf0f9]">
                         <span
-                          className="block h-full rounded-full bg-[#2f57c8]"
+                          className="block h-full rounded-full bg-[linear-gradient(90deg,#3f70db_0%,#1fa7cb_100%)]"
                           style={{ width: `${width}%` }}
                         />
                       </div>
@@ -374,19 +382,19 @@ export function AccountingView({
             </Panel>
 
             <Panel title="원가 배분 시뮬레이터">
-              <div className="grid gap-2.5">
+              <div className="grid gap-3">
                 <input
-                  className="w-full rounded-[10px] border border-[#cbd6ea] px-3 py-2.5"
+                  className="w-full rounded-[12px] border border-[#cbd6ea] px-3.5 py-3 text-[1rem] text-[#243b63] outline-none transition focus:border-[#9fb3da] focus:ring-2 focus:ring-[#dce7fa]"
                   type="number"
                   placeholder="배분할 총 금액 (예: 100000000)"
                 />
                 <textarea
-                  className="w-full rounded-[10px] border border-[#cbd6ea] px-3 py-2.5 font-mono text-[0.84rem]"
+                  className="w-full rounded-[12px] border border-[#cbd6ea] px-3.5 py-3 font-mono text-[0.92rem] text-[#243b63] outline-none transition focus:border-[#9fb3da] focus:ring-2 focus:ring-[#dce7fa]"
                   rows={6}
                   defaultValue='{"PRJ-001":30,"PRJ-002":20,"PRJ-003":50}'
                 />
                 <button
-                  className="rounded-[10px] bg-[#2b4dbf] px-3 py-[11px] font-extrabold text-white"
+                  className="rounded-[12px] bg-[#2b4dbf] px-4 py-3 text-[1.05rem] font-extrabold tracking-[-0.01em] text-white shadow-[0_10px_22px_rgba(43,77,191,0.26)] transition-transform hover:-translate-y-[1px]"
                   type="button"
                 >
                   배분 계산
@@ -397,7 +405,7 @@ export function AccountingView({
 
           <Panel title="원가 거래 내역">
             <div className="mb-3 flex flex-wrap items-center justify-end gap-2.5">
-              <select className="rounded-[10px] border border-[#cbd6ea] bg-white px-3 py-2 text-sm text-[#2f4570]">
+              <select className="rounded-[12px] border border-[#cbd6ea] bg-white px-3.5 py-2.5 text-[0.95rem] font-semibold text-[#2f4570]">
                 <option>전체 본부</option>
                 <option>주식운용본부</option>
                 <option>채권운용본부</option>
@@ -406,22 +414,22 @@ export function AccountingView({
                 <option>리스크관리본부</option>
               </select>
               <input
-                className="rounded-[10px] border border-[#cbd6ea] bg-white px-3 py-2 text-sm text-[#2f4570]"
+                className="rounded-[12px] border border-[#cbd6ea] bg-white px-3.5 py-2.5 text-[0.95rem] font-semibold text-[#2f4570]"
                 type="month"
               />
             </div>
 
             <div className="max-h-[560px] overflow-auto rounded-2xl border border-[#dce5f4] bg-white shadow-[inset_0_1px_0_#f6f9ff]">
-              <table className="min-w-full text-[1rem]">
-                <thead className="sticky top-0 z-[1] bg-[#eef3fb] text-[#5b7097]">
+              <table className="min-w-full text-[0.98rem] text-[#294065]">
+                <thead className="sticky top-0 z-[1] bg-[#eef3fb]/95 text-[0.92rem] font-bold tracking-[0.01em] text-[#5b7097] backdrop-blur">
                   <tr>
                     <th className="px-5 py-4 text-left">날짜</th>
                     <th className="px-5 py-4 text-left">기간</th>
                     <th className="px-5 py-4 text-left">본부</th>
                     <th className="px-5 py-4 text-left">프로젝트</th>
                     <th className="px-5 py-4 text-left">원가항목</th>
-                    <th className="px-5 py-4 text-left">실제</th>
-                    <th className="px-5 py-4 text-left">표준</th>
+                    <th className="px-5 py-4 text-right">실제</th>
+                    <th className="px-5 py-4 text-right">표준</th>
                     <th className="px-5 py-4 text-left">비고</th>
                   </tr>
                 </thead>
@@ -429,7 +437,7 @@ export function AccountingView({
                   {accountingTransactions.map((row) => (
                     <tr
                       key={`${row.date}-${row.project}`}
-                      className="border-t border-[#e6edf8]"
+                      className="border-t border-[#e6edf8] transition-colors hover:bg-[#f9fbff]"
                     >
                       <td className="px-5 py-3.5 text-[#2a4168]">{row.date}</td>
                       <td className="px-5 py-3.5 text-[#2a4168]">
@@ -442,10 +450,10 @@ export function AccountingView({
                         {row.project}
                       </td>
                       <td className="px-5 py-3.5 text-[#2a4168]">{row.item}</td>
-                      <td className="px-5 py-3.5 font-semibold text-[#1e2f4c]">
+                      <td className="px-5 py-3.5 text-right font-semibold text-[#1e2f4c]">
                         {row.actual}
                       </td>
-                      <td className="px-5 py-3.5 text-[#7086ac]">
+                      <td className="px-5 py-3.5 text-right text-[#7086ac]">
                         {row.standard}
                       </td>
                       <td className="px-5 py-3.5 text-[#60779f]">{row.note}</td>

--- a/frontend/src/views/accounting/AccountingView.tsx
+++ b/frontend/src/views/accounting/AccountingView.tsx
@@ -109,6 +109,86 @@ const accountingTransactions: AccountingTransaction[] = [
     actual: '₩16,000,000',
     standard: '₩15,500,000',
     note: '국고채 운용인건비'
+  },
+  {
+    date: '2026-02-15',
+    period: '2026-02',
+    department: '주식운용본부',
+    project: '공통',
+    item: '간접인건비',
+    actual: '₩8,500,000',
+    standard: '₩8,500,000',
+    note: '본부 간접인건비'
+  },
+  {
+    date: '2026-02-10',
+    period: '2026-02',
+    department: '주식운용본부',
+    project: 'PRJ-2025-001 · 삼성전자 전략투자',
+    item: '직접인건비',
+    actual: '₩13,000,000',
+    standard: '₩12,000,000',
+    note: '프로젝트1 직접인건비'
+  },
+  {
+    date: '2026-02-10',
+    period: '2026-02',
+    department: '주식운용본부',
+    project: 'PRJ-2025-003 · 코스닥 성장주 포트폴리오',
+    item: '직접인건비',
+    actual: '₩14,000,000',
+    standard: '₩13,500,000',
+    note: '코스닥펀드 운용'
+  },
+  {
+    date: '2026-01-28',
+    period: '2026-01',
+    department: '리스크관리본부',
+    project: 'PRJ-2025-017 · 전사 리스크 모델 고도화',
+    item: '직접인건비',
+    actual: '₩13,000,000',
+    standard: '₩12,500,000',
+    note: '리스크모델 개발'
+  },
+  {
+    date: '2026-01-25',
+    period: '2026-01',
+    department: '파생상품본부',
+    project: 'PRJ-2025-013 · 금리스왑 헤지',
+    item: '직접인건비',
+    actual: '₩9,000,000',
+    standard: '₩8,500,000',
+    note: '금리스왑 운용'
+  },
+  {
+    date: '2026-01-22',
+    period: '2026-01',
+    department: '대체투자본부',
+    project: 'PRJ-2025-009 · A고속도로 인프라펀드',
+    item: '직접인건비',
+    actual: '₩18,000,000',
+    standard: '₩17,500,000',
+    note: '인프라펀드 관리'
+  },
+  {
+    date: '2026-01-22',
+    period: '2026-01',
+    department: '대체투자본부',
+    project: 'PRJ-2025-009 · A고속도로 인프라펀드',
+    item: '자재비',
+    actual: '₩25,000,000',
+    standard: '₩25,000,000',
+    note: '인프라 실사비용'
+  },
+  {
+    date: '2026-01-20',
+    period: '2026-01',
+    department: '채권운용본부',
+    project: 'PRJ-2025-005 · 국고채 10년 포지션',
+    item: '직접인건비',
+    actual: '₩15,000,000',
+    standard: '₩14,500,000',
+    note: '국고채 포지션 모니터링'
   }
 ];
 
@@ -152,13 +232,13 @@ export function AccountingView({
   const maxActual = Math.max(1, ...mergedRows.map((row) => row.actual));
 
   return (
-    <section className="grid gap-4">
+    <section className="grid gap-5">
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 className="m-0 text-[2.05rem] font-extrabold tracking-[-0.01em] text-[#192a49]">
+          <h2 className="m-0 text-[2.45rem] font-extrabold tracking-[-0.02em] text-[#172a4a]">
             원가 집계·분석
           </h2>
-          <p className="mt-1 text-[1.05rem] text-[#62779d]">
+          <p className="mt-1.5 text-[1.18rem] text-[#5e759f]">
             본부/프로젝트별 원가 집계 및 표준원가 차이분석
           </p>
         </div>
@@ -211,16 +291,16 @@ export function AccountingView({
               </button>
             </div>
 
-            <div className="overflow-hidden rounded-xl border border-[#dce5f4] bg-white">
-              <table className="min-w-full text-[1.02rem]">
+            <div className="overflow-hidden rounded-2xl border border-[#dce5f4] bg-white shadow-[inset_0_1px_0_#f6f9ff]">
+              <table className="min-w-full text-[1.08rem]">
                 <thead className="bg-[#eef3fb] text-[#5b7097]">
                   <tr>
-                    <th className="px-4 py-3 text-left">본부</th>
-                    <th className="px-4 py-3 text-left">실제원가</th>
-                    <th className="px-4 py-3 text-left">표준원가</th>
-                    <th className="px-4 py-3 text-left">차이</th>
-                    <th className="px-4 py-3 text-left">차이율</th>
-                    <th className="px-4 py-3 text-left">판정</th>
+                    <th className="px-5 py-4 text-left">본부</th>
+                    <th className="px-5 py-4 text-left">실제원가</th>
+                    <th className="px-5 py-4 text-left">표준원가</th>
+                    <th className="px-5 py-4 text-left">차이</th>
+                    <th className="px-5 py-4 text-left">차이율</th>
+                    <th className="px-5 py-4 text-left">판정</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -229,17 +309,17 @@ export function AccountingView({
                       key={row.department}
                       className="border-t border-[#e6edf8]"
                     >
-                      <td className="px-4 py-3 font-semibold text-[#1e2f4c]">
+                      <td className="px-5 py-4 font-semibold text-[#1e2f4c]">
                         {row.department}
                       </td>
-                      <td className="px-4 py-3">
+                      <td className="px-5 py-4">
                         {formatKrwCompact(row.actual)}
                       </td>
-                      <td className="px-4 py-3 text-[#7086ac]">
+                      <td className="px-5 py-4 text-[#7086ac]">
                         {formatKrwCompact(row.standard)}
                       </td>
                       <td
-                        className={`px-4 py-3 font-bold ${
+                        className={`px-5 py-4 font-bold ${
                           row.diff > 0 ? 'text-[#e03131]' : 'text-[#16955f]'
                         }`}
                       >
@@ -247,13 +327,13 @@ export function AccountingView({
                         {formatKrwCompact(row.diff)}
                       </td>
                       <td
-                        className={`px-4 py-3 font-bold ${
+                        className={`px-5 py-4 font-bold ${
                           row.rate > 0 ? 'text-[#e03131]' : 'text-[#16955f]'
                         }`}
                       >
                         {row.rate.toFixed(2)}%
                       </td>
-                      <td className="px-4 py-3">
+                      <td className="px-5 py-4">
                         <span className="inline-flex items-center rounded-full bg-[#f7dada] px-3 py-1 text-sm font-bold text-[#b83f3f]">
                           불리
                         </span>
@@ -334,18 +414,18 @@ export function AccountingView({
               />
             </div>
 
-            <div className="max-h-[520px] overflow-auto rounded-xl border border-[#dce5f4] bg-white">
-              <table className="min-w-full text-[0.98rem]">
+            <div className="max-h-[560px] overflow-auto rounded-2xl border border-[#dce5f4] bg-white shadow-[inset_0_1px_0_#f6f9ff]">
+              <table className="min-w-full text-[1rem]">
                 <thead className="sticky top-0 z-[1] bg-[#eef3fb] text-[#5b7097]">
                   <tr>
-                    <th className="px-4 py-3 text-left">날짜</th>
-                    <th className="px-4 py-3 text-left">기간</th>
-                    <th className="px-4 py-3 text-left">본부</th>
-                    <th className="px-4 py-3 text-left">프로젝트</th>
-                    <th className="px-4 py-3 text-left">원가항목</th>
-                    <th className="px-4 py-3 text-left">실제</th>
-                    <th className="px-4 py-3 text-left">표준</th>
-                    <th className="px-4 py-3 text-left">비고</th>
+                    <th className="px-5 py-4 text-left">날짜</th>
+                    <th className="px-5 py-4 text-left">기간</th>
+                    <th className="px-5 py-4 text-left">본부</th>
+                    <th className="px-5 py-4 text-left">프로젝트</th>
+                    <th className="px-5 py-4 text-left">원가항목</th>
+                    <th className="px-5 py-4 text-left">실제</th>
+                    <th className="px-5 py-4 text-left">표준</th>
+                    <th className="px-5 py-4 text-left">비고</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -354,22 +434,24 @@ export function AccountingView({
                       key={`${row.date}-${row.project}`}
                       className="border-t border-[#e6edf8]"
                     >
-                      <td className="px-4 py-3 text-[#2a4168]">{row.date}</td>
-                      <td className="px-4 py-3 text-[#2a4168]">{row.period}</td>
-                      <td className="px-4 py-3 font-semibold text-[#1e2f4c]">
+                      <td className="px-5 py-3.5 text-[#2a4168]">{row.date}</td>
+                      <td className="px-5 py-3.5 text-[#2a4168]">
+                        {row.period}
+                      </td>
+                      <td className="px-5 py-3.5 font-semibold text-[#1e2f4c]">
                         {row.department}
                       </td>
-                      <td className="px-4 py-3 text-[#2a4168]">
+                      <td className="px-5 py-3.5 text-[#2a4168]">
                         {row.project}
                       </td>
-                      <td className="px-4 py-3 text-[#2a4168]">{row.item}</td>
-                      <td className="px-4 py-3 font-semibold text-[#1e2f4c]">
+                      <td className="px-5 py-3.5 text-[#2a4168]">{row.item}</td>
+                      <td className="px-5 py-3.5 font-semibold text-[#1e2f4c]">
                         {row.actual}
                       </td>
-                      <td className="px-4 py-3 text-[#7086ac]">
+                      <td className="px-5 py-3.5 text-[#7086ac]">
                         {row.standard}
                       </td>
-                      <td className="px-4 py-3 text-[#60779f]">{row.note}</td>
+                      <td className="px-5 py-3.5 text-[#60779f]">{row.note}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/frontend/src/views/accounting/AccountingView.tsx
+++ b/frontend/src/views/accounting/AccountingView.tsx
@@ -238,9 +238,6 @@ export function AccountingView({
           <h2 className="m-0 text-[2.45rem] font-extrabold tracking-[-0.02em] text-[#172a4a]">
             원가 집계·분석
           </h2>
-          <p className="mt-1.5 text-[1.18rem] text-[#5e759f]">
-            본부/프로젝트별 원가 집계 및 표준원가 차이분석
-          </p>
         </div>
         <div className="flex items-center gap-2.5">
           <button

--- a/frontend/src/views/accounting/AccountingView.tsx
+++ b/frontend/src/views/accounting/AccountingView.tsx
@@ -1,0 +1,230 @@
+import type { ProjectDetail, ProjectSummary } from '../../app/portfolioData';
+import { formatKrwCompact } from '../../app/format';
+import { Panel } from '../../shared/components/Panel';
+
+type AccountingViewProps = {
+  selectedProject: ProjectSummary | null;
+  selectedDetail: ProjectDetail | null;
+  detailStatus: 'idle' | 'loading' | 'ready' | 'error';
+  detailError: string | null;
+  onRetryDetailLoad(): void;
+};
+
+const departmentLabelByCode: Record<string, string> = {
+  HQ01: '주식운용본부',
+  HQ02: '채권운용본부',
+  HQ03: '대체투자본부',
+  HQ04: '파생상품본부',
+  HQ05: '리스크관리본부'
+};
+
+export function AccountingView({
+  selectedProject,
+  selectedDetail,
+  detailStatus,
+  detailError,
+  onRetryDetailLoad
+}: AccountingViewProps) {
+  const allocationRows = selectedDetail?.allocation.rules ?? [];
+  const mergedRows = Object.values(
+    allocationRows.reduce<
+      Record<
+        string,
+        {
+          department: string;
+          actual: number;
+          standard: number;
+          diff: number;
+          rate: number;
+        }
+      >
+    >((acc, row) => {
+      const department =
+        departmentLabelByCode[row.departmentCode] ?? row.departmentCode;
+      const key = department;
+      if (!acc[key]) {
+        acc[key] = { department, actual: 0, standard: 0, diff: 0, rate: 0 };
+      }
+      acc[key].actual += row.allocatedAmount;
+      acc[key].standard += row.costPoolAmount;
+      return acc;
+    }, {})
+  ).map((row) => {
+    const diff = row.actual - row.standard;
+    const rate = row.standard === 0 ? 0 : (diff / row.standard) * 100;
+    return { ...row, diff, rate };
+  });
+
+  const maxActual = Math.max(1, ...mergedRows.map((row) => row.actual));
+
+  return (
+    <section className="grid gap-4">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="m-0 text-[2.05rem] font-extrabold tracking-[-0.01em] text-[#192a49]">
+            원가 집계·분석
+          </h2>
+          <p className="mt-1 text-[1.05rem] text-[#62779d]">
+            본부/프로젝트별 원가 집계 및 표준원가 차이분석
+          </p>
+        </div>
+        <div className="flex items-center gap-2.5">
+          <button
+            className="rounded-[10px] border border-[#cbd6ea] bg-white px-3.5 py-2.5 font-bold text-[#2f4570]"
+            type="button"
+          >
+            CSV
+          </button>
+          <button
+            className="rounded-[10px] bg-[#2b4dbf] px-3.5 py-2.5 font-extrabold text-white"
+            type="button"
+          >
+            + 원가 입력
+          </button>
+        </div>
+      </header>
+
+      {detailStatus === 'loading' ? (
+        <article className="rounded-2xl border border-[#d8e2f2] bg-white px-5 py-5 text-[#41557b]">
+          원가 상세 데이터를 불러오는 중입니다.
+        </article>
+      ) : null}
+
+      {detailStatus === 'error' ? (
+        <article className="rounded-2xl border border-[#f0c9c9] bg-white px-5 py-5 text-[#7b3333]">
+          <p className="m-0">
+            {detailError ?? '원가 데이터를 불러오지 못했습니다.'}
+          </p>
+          <button
+            className="mt-3 rounded-[10px] border border-[#cfa5a5] bg-[#fff6f6] px-3 py-2 font-semibold"
+            type="button"
+            onClick={onRetryDetailLoad}
+          >
+            다시 시도
+          </button>
+        </article>
+      ) : null}
+
+      {detailStatus === 'ready' && selectedDetail && selectedProject ? (
+        <>
+          <Panel title="본부별 원가 차이분석 (실제 vs 표준)">
+            <div className="mb-3 flex justify-end">
+              <button
+                type="button"
+                className="rounded-xl border border-[#c8d4ea] bg-white px-4 py-2 text-[1rem] font-semibold text-[#2f4570]"
+              >
+                2026년 02월
+              </button>
+            </div>
+
+            <div className="overflow-hidden rounded-xl border border-[#dce5f4] bg-white">
+              <table className="min-w-full text-[1.02rem]">
+                <thead className="bg-[#eef3fb] text-[#5b7097]">
+                  <tr>
+                    <th className="px-4 py-3 text-left">본부</th>
+                    <th className="px-4 py-3 text-left">실제원가</th>
+                    <th className="px-4 py-3 text-left">표준원가</th>
+                    <th className="px-4 py-3 text-left">차이</th>
+                    <th className="px-4 py-3 text-left">차이율</th>
+                    <th className="px-4 py-3 text-left">판정</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {mergedRows.map((row) => (
+                    <tr
+                      key={row.department}
+                      className="border-t border-[#e6edf8]"
+                    >
+                      <td className="px-4 py-3 font-semibold text-[#1e2f4c]">
+                        {row.department}
+                      </td>
+                      <td className="px-4 py-3">
+                        {formatKrwCompact(row.actual)}
+                      </td>
+                      <td className="px-4 py-3 text-[#7086ac]">
+                        {formatKrwCompact(row.standard)}
+                      </td>
+                      <td
+                        className={`px-4 py-3 font-bold ${
+                          row.diff > 0 ? 'text-[#e03131]' : 'text-[#16955f]'
+                        }`}
+                      >
+                        {row.diff > 0 ? '+' : ''}
+                        {formatKrwCompact(row.diff)}
+                      </td>
+                      <td
+                        className={`px-4 py-3 font-bold ${
+                          row.rate > 0 ? 'text-[#e03131]' : 'text-[#16955f]'
+                        }`}
+                      >
+                        {row.rate.toFixed(2)}%
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="inline-flex items-center rounded-full bg-[#f7dada] px-3 py-1 text-sm font-bold text-[#b83f3f]">
+                          불리
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Panel>
+
+          <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
+            <Panel title="본부별 원가 구성">
+              <div className="grid gap-3">
+                {mergedRows.map((row) => {
+                  const width = Math.max(
+                    3,
+                    Math.round((row.actual / maxActual) * 100)
+                  );
+                  return (
+                    <article
+                      key={`bar-${row.department}`}
+                      className="grid gap-1.5"
+                    >
+                      <div className="flex items-center justify-between text-sm text-[#647ca5]">
+                        <strong className="text-[#1e2f4c]">
+                          {row.department}
+                        </strong>
+                        <span>{formatKrwCompact(row.actual)}</span>
+                      </div>
+                      <div className="h-3 overflow-hidden rounded-full bg-[#eaf0f9]">
+                        <span
+                          className="block h-full rounded-full bg-[#2f57c8]"
+                          style={{ width: `${width}%` }}
+                        />
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            </Panel>
+
+            <Panel title="원가 배분 시뮬레이터">
+              <div className="grid gap-2.5">
+                <input
+                  className="w-full rounded-[10px] border border-[#cbd6ea] px-3 py-2.5"
+                  type="number"
+                  placeholder="배분할 총 금액 (예: 100000000)"
+                />
+                <textarea
+                  className="w-full rounded-[10px] border border-[#cbd6ea] px-3 py-2.5 font-mono text-[0.84rem]"
+                  rows={6}
+                  defaultValue='{"PRJ-001":30,"PRJ-002":20,"PRJ-003":50}'
+                />
+                <button
+                  className="rounded-[10px] bg-[#2b4dbf] px-3 py-[11px] font-extrabold text-white"
+                  type="button"
+                >
+                  배분 계산
+                </button>
+              </div>
+            </Panel>
+          </section>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/views/auth/LoginView.tsx
+++ b/frontend/src/views/auth/LoginView.tsx
@@ -34,11 +34,14 @@ export function LoginView({ onLogin }: LoginViewProps) {
             </div>
             <div>
               <strong className="text-[1.8rem] leading-none">CostWise</strong>
-              <p className="m-0 text-[rgba(238,245,255,0.92)]">원가·평가 통합관리 플랫폼</p>
+              <p className="m-0 text-[rgba(238,245,255,0.92)]">
+                원가·평가 통합관리 플랫폼
+              </p>
             </div>
           </div>
           <p className="m-0 text-[rgba(238,245,255,0.92)]">
-            프로젝트 원가관리와 금융상품 가치평가를 하나의 운영 흐름으로 관리합니다.
+            프로젝트 원가관리와 금융상품 가치평가를 하나의 운영 흐름으로
+            관리합니다.
           </p>
         </header>
 
@@ -47,7 +50,9 @@ export function LoginView({ onLogin }: LoginViewProps) {
           onSubmit={handleSubmit}
         >
           <label className="grid gap-1.5">
-            <span className="text-[0.92rem] font-extrabold text-[#233150]">아이디</span>
+            <span className="text-[0.92rem] font-extrabold text-[#233150]">
+              아이디
+            </span>
             <input
               className="w-full rounded-xl border border-[#c8d2e6] px-3 py-[11px]"
               type="text"
@@ -58,7 +63,9 @@ export function LoginView({ onLogin }: LoginViewProps) {
             />
           </label>
           <label className="grid gap-1.5">
-            <span className="text-[0.92rem] font-extrabold text-[#233150]">비밀번호</span>
+            <span className="text-[0.92rem] font-extrabold text-[#233150]">
+              비밀번호
+            </span>
             <input
               className="w-full rounded-xl border border-[#c8d2e6] px-3 py-[11px]"
               type="password"

--- a/frontend/src/views/dashboard/DashboardView.tsx
+++ b/frontend/src/views/dashboard/DashboardView.tsx
@@ -42,16 +42,15 @@ const monthlyTrend = [
 
 const categoryBudgets = [
   { label: 'BOND', value: 150, color: '#3f79ea' },
-  { label: 'DERIVATIVE', value: 95, color: '#17acc8' },
-  { label: 'EQUITY', value: 65, color: '#7a56dc' },
-  { label: 'INFRA', value: 110, color: '#f2a50f' },
-  { label: 'PROJECT', value: 28, color: '#22b659' },
-  { label: 'REAL_ESTATE', value: 45, color: '#e9509c' },
-  { label: 'STOCK', value: 92, color: '#23b2a4' }
+  { label: 'DERIVATIVE', value: 95, color: '#19b1ca' },
+  { label: 'EQUITY', value: 65, color: '#7d5de0' },
+  { label: 'INFRA', value: 110, color: '#f3a108' },
+  { label: 'PROJECT', value: 28, color: '#26be60' },
+  { label: 'REAL_ESTATE', value: 45, color: '#e84f9d' },
+  { label: 'STOCK', value: 92, color: '#22b0a2' }
 ];
 
 export function DashboardView({
-  decisionSignals,
   selectedInsight,
   portfolio,
   priorityProjects,
@@ -71,33 +70,10 @@ export function DashboardView({
         Boolean(item)
     );
 
-  const maxBudget = Math.max(
+  const budgetMax = Math.max(
     1,
     ...orderedHeadquarters.map((item) => item.totalInvestmentKrw)
   );
-  const maxTrend = Math.max(...monthlyTrend.map((item) => item.actual), 1);
-  const minTrend = Math.min(...monthlyTrend.map((item) => item.standard), 0);
-  const trendRange = Math.max(1, maxTrend - minTrend);
-  const chartWidth = 680;
-  const chartHeight = 240;
-  const xStep = chartWidth / Math.max(1, monthlyTrend.length - 1);
-  const actualPoints = monthlyTrend
-    .map((point, index) => {
-      const x = index * xStep;
-      const y =
-        chartHeight - ((point.actual - minTrend) / trendRange) * chartHeight;
-      return `${x},${y}`;
-    })
-    .join(' ');
-  const standardPoints = monthlyTrend
-    .map((point, index) => {
-      const x = index * xStep;
-      const y =
-        chartHeight - ((point.standard - minTrend) / trendRange) * chartHeight;
-      return `${x},${y}`;
-    })
-    .join(' ');
-
   const riskCounts = portfolio.projects.reduce(
     (acc, project) => {
       if (project.risk === '높음') acc.high += 1;
@@ -111,124 +87,141 @@ export function DashboardView({
     1,
     riskCounts.high + riskCounts.mid + riskCounts.low
   );
-  const quickFocus = priorityProjects.slice(0, 5);
-  const maxCategoryBudget = Math.max(
-    ...categoryBudgets.map((item) => item.value),
+
+  const chartWidth = 740;
+  const chartHeight = 310;
+  const tickCount = 5;
+  const valueMax = Math.max(
+    ...monthlyTrend.map((item) => Math.max(item.actual, item.standard)),
     1
   );
+  const paddedMax = Math.ceil(valueMax / 100) * 100;
+  const xStep = chartWidth / Math.max(1, monthlyTrend.length - 1);
+  const scaleY = (value: number) =>
+    chartHeight - (value / paddedMax) * chartHeight;
+  const actualPoints = monthlyTrend
+    .map((item, index) => `${index * xStep},${scaleY(item.actual)}`)
+    .join(' ');
+  const standardPoints = monthlyTrend
+    .map((item, index) => `${index * xStep},${scaleY(item.standard)}`)
+    .join(' ');
+
+  const sortedReviews = [...portfolio.projects]
+    .sort((a, b) => b.rank - a.rank)
+    .slice(0, 8);
 
   return (
-    <section className="grid gap-5">
-      <header className="flex flex-wrap items-start justify-between gap-4">
+    <section className="grid gap-4">
+      <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 className="m-0 text-[2.55rem] font-extrabold tracking-[-0.02em] text-[#172a4a]">
+          <h2 className="m-0 text-[2.05rem] font-extrabold tracking-[-0.015em] text-[#172a4a]">
             통합 대시보드
           </h2>
-          <p className="mt-1.5 text-[1.2rem] leading-snug text-[#5e759f]">
+          <p className="mt-1 text-[1.05rem] text-[#60759f]">
             전사 5개 본부 · 프로젝트 원가/평가 현황
           </p>
         </div>
-        <span className="text-[1.05rem] font-medium text-[#6780aa]">{now}</span>
+        <span className="text-[1rem] text-[#667da8]">{now}</span>
       </header>
 
       <section className="grid grid-cols-4 gap-4 max-[1280px]:grid-cols-2">
-        <article className="rounded-3xl border border-[#d7e0f0] bg-white px-6 py-5 shadow-[0_10px_24px_rgba(13,28,58,0.07)]">
-          <span className="inline-grid h-14 w-14 place-items-center rounded-2xl bg-[#356ee6] text-2xl text-white">
+        <article className="rounded-2xl border border-[#dce4f2] bg-white px-5 py-4 shadow-[0_2px_8px_rgba(12,26,56,0.05)]">
+          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#376de3] text-xl text-white">
             ▦
           </span>
-          <strong className="mt-4 block text-[3rem] font-extrabold leading-none text-[#172a4a]">
+          <strong className="mt-3 block text-[2.15rem] font-extrabold leading-none text-[#192b4b]">
             {portfolio.overview.headquarterCount}
           </strong>
-          <span className="mt-2 block text-[1.3rem] font-bold text-[#526b96]">
+          <span className="mt-2 block text-[1.03rem] font-semibold text-[#526a96]">
             운영 본부
           </span>
-          <p className="mt-1 text-[1.02rem] text-[#8396b6]">5개 본부 가동중</p>
+          <p className="mt-1 text-[0.94rem] text-[#7f92b3]">5개 본부 가동중</p>
         </article>
-        <article className="rounded-3xl border border-[#d7e0f0] bg-white px-6 py-5 shadow-[0_10px_24px_rgba(13,28,58,0.07)]">
-          <span className="inline-grid h-14 w-14 place-items-center rounded-2xl bg-[#1ba8c7] text-2xl text-white">
+        <article className="rounded-2xl border border-[#dce4f2] bg-white px-5 py-4 shadow-[0_2px_8px_rgba(12,26,56,0.05)]">
+          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#1ca9c7] text-xl text-white">
             ⊞
           </span>
-          <strong className="mt-4 block text-[3rem] font-extrabold leading-none text-[#172a4a]">
+          <strong className="mt-3 block text-[2.15rem] font-extrabold leading-none text-[#192b4b]">
             {portfolio.overview.projectCount}
           </strong>
-          <span className="mt-2 block text-[1.3rem] font-bold text-[#526b96]">
+          <span className="mt-2 block text-[1.03rem] font-semibold text-[#526a96]">
             활성 프로젝트
           </span>
-          <p className="mt-1 text-[1.02rem] text-[#8396b6]">
+          <p className="mt-1 text-[0.94rem] text-[#7f92b3]">
             총 20여개 동시 운영
           </p>
         </article>
-        <article className="rounded-3xl border border-[#d7e0f0] bg-white px-6 py-5 shadow-[0_10px_24px_rgba(13,28,58,0.07)]">
-          <span className="inline-grid h-14 w-14 place-items-center rounded-2xl bg-[#23b45e] text-2xl text-white">
+        <article className="rounded-2xl border border-[#dce4f2] bg-white px-5 py-4 shadow-[0_2px_8px_rgba(12,26,56,0.05)]">
+          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#28b95d] text-xl text-white">
             ⛁
           </span>
-          <strong className="mt-4 block text-[3rem] font-extrabold leading-none text-[#172a4a]">
+          <strong className="mt-3 block text-[2.15rem] font-extrabold leading-none text-[#192b4b]">
             {formatKrwCompact(portfolio.overview.totalInvestmentKrw)}
           </strong>
-          <span className="mt-2 block text-[1.3rem] font-bold text-[#526b96]">
+          <span className="mt-2 block text-[1.03rem] font-semibold text-[#526a96]">
             총 예산
           </span>
-          <p className="mt-1 text-[1.02rem] text-[#8396b6]">
+          <p className="mt-1 text-[0.94rem] text-[#7f92b3]">
             집행: {formatKrwCompact(portfolio.overview.totalExpectedRevenueKrw)}
           </p>
         </article>
-        <article className="rounded-3xl border border-[#d7e0f0] bg-white px-6 py-5 shadow-[0_10px_24px_rgba(13,28,58,0.07)]">
-          <span className="inline-grid h-14 w-14 place-items-center rounded-2xl bg-[#ef3b45] text-2xl text-white">
+        <article className="rounded-2xl border border-[#dce4f2] bg-white px-5 py-4 shadow-[0_2px_8px_rgba(12,26,56,0.05)]">
+          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#ef3b45] text-xl text-white">
             ⚠
           </span>
-          <strong className="mt-4 block text-[3rem] font-extrabold leading-none text-[#172a4a]">
+          <strong className="mt-3 block text-[2.15rem] font-extrabold leading-none text-[#192b4b]">
             {portfolio.overview.conditionalCount}
           </strong>
-          <span className="mt-2 block text-[1.3rem] font-bold text-[#526b96]">
+          <span className="mt-2 block text-[1.03rem] font-semibold text-[#526a96]">
             미확인 경보
           </span>
-          <p className="mt-1 text-[1.02rem] text-[#8396b6]">클릭하여 확인</p>
+          <p className="mt-1 text-[0.94rem] text-[#7f92b3]">클릭하여 확인</p>
         </article>
       </section>
 
       <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
         <Panel title="본부별 예산 vs 집행">
-          <div className="mb-4 flex justify-center gap-6 text-[1rem] font-semibold text-[#5e759f]">
+          <div className="mb-4 flex justify-center gap-5 text-[0.97rem] font-semibold text-[#5d749f]">
             <span className="inline-flex items-center gap-2">
-              <span className="h-3.5 w-10 rounded bg-[#3f79ea]" /> 예산
+              <span className="h-3 w-10 rounded bg-[#3f79ea]" />
+              예산
             </span>
             <span className="inline-flex items-center gap-2">
-              <span className="h-3.5 w-10 rounded bg-[#1ba8c7]" /> 집행
+              <span className="h-3 w-10 rounded bg-[#1ca9c7]" />
+              집행
             </span>
           </div>
           <div className="grid gap-3.5">
-            {orderedHeadquarters.map((headquarter) => {
+            {orderedHeadquarters.map((item) => {
               const budgetWidth = Math.max(
-                4,
-                Math.round((headquarter.totalInvestmentKrw / maxBudget) * 100)
+                3,
+                Math.round((item.totalInvestmentKrw / budgetMax) * 100)
               );
               const expenseWidth = Math.max(
-                4,
-                Math.round(
-                  (headquarter.totalExpectedRevenueKrw / maxBudget) * 100
-                )
+                3,
+                Math.round((item.totalExpectedRevenueKrw / budgetMax) * 100)
               );
               return (
-                <article key={headquarter.code} className="grid gap-1.5">
-                  <div className="flex items-center justify-between text-[1rem] text-[#5d759f]">
-                    <strong className="text-[1.2rem] text-[#1a2f53]">
-                      {headquarter.name}
+                <article key={item.code} className="grid gap-1.5">
+                  <div className="flex items-center justify-between text-[0.95rem] text-[#5f759f]">
+                    <strong className="text-[1.08rem] text-[#1d3054]">
+                      {item.name}
                     </strong>
                     <span>
-                      {formatKrwCompact(headquarter.totalInvestmentKrw)} /{' '}
-                      {formatKrwCompact(headquarter.totalExpectedRevenueKrw)}
+                      {formatKrwCompact(item.totalInvestmentKrw)} /{' '}
+                      {formatKrwCompact(item.totalExpectedRevenueKrw)}
                     </span>
                   </div>
                   <div className="grid gap-1.5">
-                    <div className="h-3 overflow-hidden rounded-full bg-[#e8eef8]">
+                    <div className="h-3 overflow-hidden rounded-full bg-[#e7eef8]">
                       <span
                         className="block h-full rounded-full bg-[#3f79ea]"
                         style={{ width: `${budgetWidth}%` }}
                       />
                     </div>
-                    <div className="h-3 overflow-hidden rounded-full bg-[#e8eef8]">
+                    <div className="h-3 overflow-hidden rounded-full bg-[#e7eef8]">
                       <span
-                        className="block h-full rounded-full bg-[#1ba8c7]"
+                        className="block h-full rounded-full bg-[#1ca9c7]"
                         style={{ width: `${expenseWidth}%` }}
                       />
                     </div>
@@ -240,29 +233,30 @@ export function DashboardView({
         </Panel>
 
         <Panel title="리스크 분포">
-          <div className="grid place-items-center gap-4 py-3">
+          <div className="grid place-items-center gap-3 py-2">
             <div
-              className="relative h-[280px] w-[280px] rounded-full after:absolute after:inset-[68px] after:rounded-full after:bg-white after:shadow-[inset_0_0_0_1px_#e4ebf8] after:content-['']"
+              className="relative h-[270px] w-[270px] rounded-full after:absolute after:inset-[66px] after:rounded-full after:bg-white after:content-['']"
               style={{
                 background: `conic-gradient(
                   #e52f2f 0% ${(riskCounts.high / riskTotal) * 100}%,
-                  #f67a13 ${(riskCounts.high / riskTotal) * 100}% ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}%,
+                  #f57a14 ${(riskCounts.high / riskTotal) * 100}% ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}%,
+                  #f2a40c ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}% ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}%,
                   #24be62 ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}% 100%
                 )`
               }}
             />
-            <div className="flex flex-wrap items-center justify-center gap-3 text-[1.02rem] font-semibold text-[#5f749d]">
+            <div className="flex flex-wrap items-center justify-center gap-3 text-[0.98rem] font-semibold text-[#60759f]">
               <span className="inline-flex items-center gap-1.5">
-                <span className="h-3 w-8 rounded bg-[#e52f2f]" /> CRITICAL
+                <span className="h-2.5 w-7 rounded bg-[#e52f2f]" /> CRITICAL
               </span>
               <span className="inline-flex items-center gap-1.5">
-                <span className="h-3 w-8 rounded bg-[#f67a13]" /> HIGH
+                <span className="h-2.5 w-7 rounded bg-[#f57a14]" /> HIGH
               </span>
               <span className="inline-flex items-center gap-1.5">
-                <span className="h-3 w-8 rounded bg-[#f0a20b]" /> MEDIUM
+                <span className="h-2.5 w-7 rounded bg-[#f2a40c]" /> MEDIUM
               </span>
               <span className="inline-flex items-center gap-1.5">
-                <span className="h-3 w-8 rounded bg-[#24be62]" /> LOW
+                <span className="h-2.5 w-7 rounded bg-[#24be62]" /> LOW
               </span>
             </div>
           </div>
@@ -271,45 +265,34 @@ export function DashboardView({
 
       <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
         <Panel title="월별 원가 추이 (실적 vs 표준)">
-          <div className="mb-3 flex items-center justify-center gap-5 text-[1rem] font-semibold text-[#5f749d]">
+          <div className="mb-4 flex justify-center gap-5 text-[0.97rem] font-semibold text-[#5d749f]">
             <span className="inline-flex items-center gap-2">
-              <span className="h-[3px] w-10 rounded bg-[#2f57d8]" />
-              실제원가
+              <span className="h-[3px] w-10 rounded bg-[#2f57d8]" /> 실제원가
             </span>
             <span className="inline-flex items-center gap-2">
-              <span className="h-[3px] w-10 rounded border-2 border-dashed border-[#16a268]" />
+              <span className="h-[3px] w-10 rounded border-2 border-dashed border-[#18a169]" />{' '}
               표준원가
             </span>
           </div>
-          <div className="rounded-2xl border border-[#dce5f4] bg-[#f9fbff] p-4">
+          <div className="rounded-xl border border-[#dce5f4] bg-[#f9fbff] px-3 py-3">
             <svg
-              viewBox={`0 0 ${chartWidth} ${chartHeight + 36}`}
+              viewBox={`0 0 ${chartWidth} ${chartHeight + 38}`}
               className="w-full"
             >
-              <line
-                x1="0"
-                y1={chartHeight}
-                x2={chartWidth}
-                y2={chartHeight}
-                stroke="#d3dded"
-                strokeWidth="1"
-              />
-              <line
-                x1="0"
-                y1={chartHeight * 0.66}
-                x2={chartWidth}
-                y2={chartHeight * 0.66}
-                stroke="#e2e9f5"
-                strokeWidth="1"
-              />
-              <line
-                x1="0"
-                y1={chartHeight * 0.33}
-                x2={chartWidth}
-                y2={chartHeight * 0.33}
-                stroke="#e2e9f5"
-                strokeWidth="1"
-              />
+              {Array.from({ length: tickCount }).map((_, index) => {
+                const y = (chartHeight / (tickCount - 1)) * index;
+                return (
+                  <line
+                    key={`grid-${index}`}
+                    x1="0"
+                    y1={y}
+                    x2={chartWidth}
+                    y2={y}
+                    stroke="#e4ebf6"
+                    strokeWidth="1"
+                  />
+                );
+              })}
               <polyline
                 points={actualPoints}
                 fill="none"
@@ -319,30 +302,26 @@ export function DashboardView({
               <polyline
                 points={standardPoints}
                 fill="none"
-                stroke="#16a268"
+                stroke="#18a169"
                 strokeWidth="4"
                 strokeDasharray="10 8"
               />
-              {monthlyTrend.map((point, index) => {
+              {monthlyTrend.map((item, index) => {
                 const x = index * xStep;
-                const yActual =
-                  chartHeight -
-                  ((point.actual - minTrend) / trendRange) * chartHeight;
-                const yStandard =
-                  chartHeight -
-                  ((point.standard - minTrend) / trendRange) * chartHeight;
+                const yActual = scaleY(item.actual);
+                const yStandard = scaleY(item.standard);
                 return (
-                  <g key={point.month}>
-                    <circle cx={x} cy={yActual} r="5.5" fill="#2f57d8" />
-                    <circle cx={x} cy={yStandard} r="5.5" fill="#16a268" />
+                  <g key={item.month}>
+                    <circle cx={x} cy={yActual} r="5" fill="#2f57d8" />
+                    <circle cx={x} cy={yStandard} r="5" fill="#18a169" />
                     <text
                       x={x}
                       y={chartHeight + 28}
                       textAnchor="middle"
                       fontSize="14"
-                      fill="#62779d"
+                      fill="#62789f"
                     >
-                      {point.month}
+                      {item.month}
                     </text>
                   </g>
                 );
@@ -352,94 +331,141 @@ export function DashboardView({
         </Panel>
 
         <Panel title="유형별 예산">
-          <div className="grid gap-3">
+          <div className="relative mx-auto mt-1 grid h-[310px] w-[310px] place-items-center rounded-full border border-[#dee6f4] bg-[#fafdff]">
+            <div className="absolute inset-[18%] rounded-full border border-[#e2e9f5]" />
+            <div className="absolute inset-[34%] rounded-full border border-[#e2e9f5]" />
+            <div className="absolute inset-[50%] rounded-full border border-[#e2e9f5]" />
+            <div className="absolute h-[2px] w-full bg-[#e2e9f5]" />
+            <div className="absolute h-full w-[2px] bg-[#e2e9f5]" />
+            {categoryBudgets.map((item, index) => {
+              const angle = (360 / categoryBudgets.length) * index - 90;
+              const length =
+                46 +
+                (item.value /
+                  Math.max(...categoryBudgets.map((x) => x.value))) *
+                  86;
+              return (
+                <div
+                  key={item.label}
+                  className="absolute left-1/2 top-1/2 origin-left rounded-full"
+                  style={{
+                    width: `${length}px`,
+                    height: '12px',
+                    transform: `translateY(-50%) rotate(${angle}deg)`,
+                    background: item.color
+                  }}
+                />
+              );
+            })}
+          </div>
+          <div className="mt-3 flex flex-wrap justify-center gap-2 text-[0.9rem] font-semibold text-[#60759f]">
             {categoryBudgets.map((item) => (
-              <article
+              <span
                 key={item.label}
-                className="grid gap-1.5 rounded-xl border border-[#e0e8f5] bg-[#f9fbff] px-3 py-2.5"
+                className="inline-flex items-center gap-1.5"
               >
-                <div className="flex items-center justify-between text-[0.95rem] text-[#5f759f]">
-                  <strong className="text-[#1f3359]">{item.label}</strong>
-                  <span>{item.value.toFixed(1)}억</span>
-                </div>
-                <div className="h-2.5 overflow-hidden rounded-full bg-[#e4ebf6]">
-                  <span
-                    className="block h-full rounded-full"
-                    style={{
-                      width: `${Math.round((item.value / maxCategoryBudget) * 100)}%`,
-                      background: item.color
-                    }}
-                  />
-                </div>
-              </article>
+                <span
+                  className="h-2.5 w-6 rounded"
+                  style={{ background: item.color }}
+                />
+                {item.label}
+              </span>
             ))}
           </div>
         </Panel>
       </section>
 
       <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
-        <Panel title="최근 평가">
-          <div className="grid max-h-[360px] gap-2.5 overflow-y-auto pr-1">
-            {quickFocus.map((project) => (
-              <article
-                key={project.code}
-                className="rounded-xl border border-[#dce5f4] bg-[#f9fbff] px-4 py-3"
-              >
-                <span className="text-xs text-[#6b82aa]">
-                  {project.code} · {project.assetCategory}
-                </span>
-                <strong className="mt-1.5 block text-[1.03rem] text-[#1f3359]">
-                  {project.name}
-                </strong>
-                <p className="mt-1 text-[0.94rem] text-[#657da6]">
-                  NPV {formatKrwCompact(project.npvKrw)} · IRR{' '}
-                  {formatPercent(project.irr)}
-                </p>
-              </article>
-            ))}
+        <Panel title="본부별 현황">
+          <div className="overflow-hidden rounded-xl border border-[#dce5f4] bg-white">
+            <table className="min-w-full text-[0.98rem]">
+              <thead className="bg-[#eef3fb] text-[#5c729a]">
+                <tr>
+                  <th className="px-4 py-3 text-left">코드</th>
+                  <th className="px-4 py-3 text-left">본부</th>
+                  <th className="px-4 py-3 text-left">프로젝트</th>
+                  <th className="px-4 py-3 text-left">예산</th>
+                  <th className="px-4 py-3 text-left">집행</th>
+                  <th className="px-4 py-3 text-left">집행률</th>
+                </tr>
+              </thead>
+              <tbody>
+                {orderedHeadquarters.map((item) => {
+                  const runRate =
+                    item.totalInvestmentKrw === 0
+                      ? 0
+                      : item.totalExpectedRevenueKrw / item.totalInvestmentKrw;
+                  return (
+                    <tr key={item.code} className="border-t border-[#e6edf8]">
+                      <td className="px-4 py-3 font-semibold text-[#21375d]">
+                        {item.code.replace('HQ', 'DIV-')}
+                      </td>
+                      <td className="px-4 py-3 text-[#223a61]">{item.name}</td>
+                      <td className="px-4 py-3 text-[#2c4168]">
+                        {item.projectCount}
+                      </td>
+                      <td className="px-4 py-3 text-[#2c4168]">
+                        {formatKrwCompact(item.totalInvestmentKrw)}
+                      </td>
+                      <td className="px-4 py-3 text-[#2c4168]">
+                        {formatKrwCompact(item.totalExpectedRevenueKrw)}
+                      </td>
+                      <td
+                        className={`px-4 py-3 font-bold ${
+                          runRate > 0.9 ? 'text-[#d73636]' : 'text-[#16965f]'
+                        }`}
+                      >
+                        {formatPercent(runRate)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
         </Panel>
 
-        <Panel title="다음 액션">
-          <article className="rounded-2xl border border-[#dce5f4] bg-[#f9fbff] px-4 py-3">
-            <strong className="text-[1.08rem] text-[#1f3359]">
-              {selectedInsight.decisionFocus}
-            </strong>
-            <p className="mt-2 text-[0.97rem] leading-relaxed text-[#5f759f]">
-              {selectedInsight.nextAction}
-            </p>
-          </article>
-          <div className="mt-3 grid gap-2.5">
-            {decisionSignals.slice(0, 2).map((signal) => (
+        <Panel title="최근 평가">
+          <div className="grid max-h-[420px] gap-2 overflow-y-auto pr-1">
+            {sortedReviews.map((project) => (
               <article
-                key={signal.label}
-                className="rounded-xl border border-[#dce5f4] bg-white px-3 py-2.5 text-[0.93rem]"
+                key={project.code}
+                className="rounded-xl border border-[#dce5f4] bg-[#f9fbff] px-3.5 py-2.5"
               >
-                <span className="text-[#6c82aa]">{signal.label}</span>
-                <strong className="mt-1 block text-[#1f3359]">
-                  {signal.value}
+                <span className="text-xs text-[#6b83ab]">
+                  2026-03-31 · {project.assetCategory.toUpperCase()}
+                </span>
+                <strong className="mt-1 block text-[1rem] text-[#1e3358]">
+                  {project.name}
                 </strong>
+                <p className="mt-1 text-[0.92rem] text-[#667ea7]">
+                  NPV {formatKrwCompact(project.npvKrw)} · IRR{' '}
+                  {formatPercent(project.irr)} · {project.status}
+                </p>
               </article>
             ))}
+            <article className="rounded-xl border border-[#dce5f4] bg-[#f9fbff] px-3.5 py-2.5 text-[0.92rem] text-[#6279a3]">
+              {selectedInsight.nextAction}
+            </article>
             {priorityProjects[0] ? (
-              <div className="flex gap-2">
+              <div className="grid grid-cols-2 gap-2">
                 <button
                   type="button"
                   onClick={() =>
                     onOpenWorkspace('accounting', priorityProjects[0].code)
                   }
-                  className="rounded-lg border border-[#c7d4ea] bg-[#eef3fc] px-3 py-2 text-xs font-semibold text-[#2f57c8]"
+                  className="rounded-lg border border-[#c8d5ea] bg-[#eef3fc] px-2.5 py-2 text-xs font-semibold text-[#2f57c8]"
                 >
-                  원가 보기
+                  원가 워크스페이스
                 </button>
                 <button
                   type="button"
                   onClick={() =>
                     onOpenWorkspace('valuation', priorityProjects[0].code)
                   }
-                  className="rounded-lg border border-[#ccd7ea] bg-white px-3 py-2 text-xs font-semibold text-[#395078]"
+                  className="rounded-lg border border-[#ccd8eb] bg-white px-2.5 py-2 text-xs font-semibold text-[#3a517a]"
                 >
-                  가치평가
+                  가치평가 워크스페이스
                 </button>
               </div>
             ) : null}

--- a/frontend/src/views/dashboard/DashboardView.tsx
+++ b/frontend/src/views/dashboard/DashboardView.tsx
@@ -18,12 +18,48 @@ type DashboardViewProps = {
   ): void;
 };
 
+const hqOrder = [
+  '주식운용본부',
+  '채권운용본부',
+  '대체투자본부',
+  '파생상품본부',
+  '리스크관리본부'
+];
+
+const hqCodeToLabel: Record<string, string> = {
+  HQ01: '주식운용본부',
+  HQ02: '채권운용본부',
+  HQ03: '대체투자본부',
+  HQ04: '파생상품본부',
+  HQ05: '리스크관리본부'
+};
+
 export function DashboardView({
   portfolio,
   selectedInsight,
-  priorityProjects,
   onOpenWorkspace
 }: DashboardViewProps) {
+  const now = new Date().toLocaleString('sv-SE').replace('T', ' ');
+  const headquarterMap = new Map(
+    portfolio.headquarters.map((item) => [
+      hqCodeToLabel[item.code] ?? item.name,
+      item
+    ])
+  );
+  const orderedHeadquarters = hqOrder
+    .map((name) => headquarterMap.get(name))
+    .filter(
+      (item): item is NonNullable<(typeof portfolio.headquarters)[number]> =>
+        Boolean(item)
+    );
+  const totalInvestment = Math.max(
+    1,
+    orderedHeadquarters.reduce(
+      (sum, headquarter) => sum + headquarter.totalInvestmentKrw,
+      0
+    )
+  );
+
   const riskCounts = portfolio.projects.reduce(
     (acc, project) => {
       if (project.risk === '높음') {
@@ -37,159 +73,149 @@ export function DashboardView({
     },
     { high: 0, mid: 0, low: 0 }
   );
-
-  const totalRiskCount = Math.max(
+  const riskTotal = Math.max(
     1,
     riskCounts.high + riskCounts.mid + riskCounts.low
   );
-  const primaryProject = priorityProjects[0] ?? null;
+  const monthlyTrend = [
+    { month: '2026-01', actual: 1120, standard: 1080 },
+    { month: '2026-02', actual: 1065, standard: 1010 },
+    { month: '2026-03', actual: 825, standard: 780 }
+  ];
+  const categoryBudgets = [
+    { label: 'BOND', value: 150 },
+    { label: 'DERIVATIVE', value: 95 },
+    { label: 'EQUITY', value: 65 },
+    { label: 'INFRA', value: 110 },
+    { label: 'PROJECT', value: 28 },
+    { label: 'REAL_ESTATE', value: 45 },
+    { label: 'STOCK', value: 92 }
+  ];
+  const maxCategoryBudget = Math.max(
+    ...categoryBudgets.map((item) => item.value),
+    1
+  );
+  const recentReviews = portfolio.projects.slice(0, 6);
 
   return (
     <section className="grid gap-4">
-      <header className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <p className="m-0 text-xs font-semibold uppercase tracking-[0.1em] text-[#5f7399]">
-              Executive Overview
-            </p>
-            <h2 className="m-0 mt-1 text-[1.9rem] font-bold text-[#182847]">
-              통합 대시보드
-            </h2>
-            <p className="mt-1 text-[#607397]">
-              전사 5개 본부 · 프로젝트 원가/평가 현황
-            </p>
-          </div>
-          {primaryProject ? (
-            <div className="flex flex-wrap gap-2" aria-label="빠른 실행">
-              <button
-                type="button"
-                onClick={() =>
-                  onOpenWorkspace('accounting', primaryProject.code)
-                }
-                className="rounded-xl border border-[rgba(63,121,234,0.24)] bg-[rgba(63,121,234,0.08)] px-3.5 py-2 text-sm font-semibold text-[#2f57c8] transition-colors hover:bg-[rgba(63,121,234,0.14)]"
-              >
-                {primaryProject.code} 원가 워크스페이스
-              </button>
-              <button
-                type="button"
-                onClick={() =>
-                  onOpenWorkspace('valuation', primaryProject.code)
-                }
-                className="rounded-xl border border-[rgba(16,33,61,0.16)] bg-[#f6f8fc] px-3.5 py-2 text-sm font-semibold text-[#22375d] transition-colors hover:bg-[#eef3fb]"
-              >
-                {primaryProject.code} 가치평가 워크스페이스
-              </button>
-            </div>
-          ) : null}
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="m-0 text-[2.05rem] font-extrabold tracking-[-0.01em] text-[#192a49]">
+            통합 대시보드
+          </h2>
+          <p className="mt-1 text-[1.05rem] text-[#62779d]">
+            전사 5개 본부 · 프로젝트 원가/평가 현황
+          </p>
         </div>
+        <span className="text-sm text-[#667ca4]">{now}</span>
       </header>
 
-      <section
-        className="grid grid-cols-4 gap-3.5 max-[1280px]:grid-cols-2"
-        aria-label="핵심 지표"
-      >
+      <section className="grid grid-cols-4 gap-4 max-[1280px]:grid-cols-2">
         <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-          <span className="inline-flex rounded-full bg-[#eef3ff] px-2.5 py-1 text-xs font-semibold text-[#3f63ba]">
-            조직
+          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#2f67e3] text-xl text-white">
+            ▦
           </span>
-          <span className="mt-3 block text-sm font-semibold text-[#5f7399]">
-            운영 본부
-          </span>
-          <strong className="mt-2 block text-[1.85rem] font-bold text-[#172747]">
+          <strong className="mt-3 block text-[2.15rem] font-extrabold text-[#172747]">
             {portfolio.overview.headquarterCount}
           </strong>
-          <p className="mt-2 text-sm text-[#7589ad]">5개 본부 가동중</p>
+          <span className="block text-[1.02rem] font-semibold text-[#536c96]">
+            운영 본부
+          </span>
+          <p className="mt-1 text-[0.9rem] text-[#8092b1]">5개 본부 가동중</p>
         </article>
         <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-          <span className="inline-flex rounded-full bg-[#e8f7ff] px-2.5 py-1 text-xs font-semibold text-[#21739a]">
-            운영
+          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#17a8c8] text-xl text-white">
+            ⊞
           </span>
-          <span className="mt-3 block text-sm font-semibold text-[#5f7399]">
-            활성 프로젝트
-          </span>
-          <strong className="mt-2 block text-[1.85rem] font-bold text-[#172747]">
+          <strong className="mt-3 block text-[2.15rem] font-extrabold text-[#172747]">
             {portfolio.overview.projectCount}
           </strong>
-          <p className="mt-2 text-sm text-[#7589ad]">총 20여개 동시 운영</p>
-        </article>
-        <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-          <span className="inline-flex rounded-full bg-[#ebfff7] px-2.5 py-1 text-xs font-semibold text-[#1d7e61]">
-            재무
+          <span className="block text-[1.02rem] font-semibold text-[#536c96]">
+            활성 프로젝트
           </span>
-          <span className="mt-3 block text-sm font-semibold text-[#5f7399]">
-            총 예산
-          </span>
-          <strong className="mt-2 block text-[1.85rem] font-bold text-[#172747]">
-            {formatKrwCompact(portfolio.overview.totalInvestmentKrw)}
-          </strong>
-          <p className="mt-2 text-sm text-[#7589ad]">
-            집행 기준{' '}
-            {formatKrwCompact(portfolio.overview.totalExpectedRevenueKrw)}
+          <p className="mt-1 text-[0.9rem] text-[#8092b1]">
+            총 20여개 동시 운영
           </p>
         </article>
         <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-          <span className="inline-flex rounded-full bg-[#fff3f1] px-2.5 py-1 text-xs font-semibold text-[#b0503f]">
-            주의
+          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#22b659] text-xl text-white">
+            ⛁
           </span>
-          <span className="mt-3 block text-sm font-semibold text-[#5f7399]">
-            미확인 경보
+          <strong className="mt-3 block text-[2.15rem] font-extrabold text-[#172747]">
+            {formatKrwCompact(portfolio.overview.totalInvestmentKrw)}
+          </strong>
+          <span className="block text-[1.02rem] font-semibold text-[#536c96]">
+            총 예산
           </span>
-          <strong className="mt-2 block text-[1.85rem] font-bold text-[#172747]">
+          <p className="mt-1 text-[0.9rem] text-[#8092b1]">
+            집행: {formatKrwCompact(portfolio.overview.totalExpectedRevenueKrw)}
+          </p>
+        </article>
+        <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#ef3b45] text-xl text-white">
+            ⚠
+          </span>
+          <strong className="mt-3 block text-[2.15rem] font-extrabold text-[#172747]">
             {portfolio.overview.conditionalCount}
           </strong>
-          <p className="mt-2 text-sm text-[#7589ad]">클릭하여 확인</p>
+          <span className="block text-[1.02rem] font-semibold text-[#536c96]">
+            미확인 경보
+          </span>
+          <p className="mt-1 text-[0.9rem] text-[#8092b1]">클릭하여 확인</p>
         </article>
       </section>
 
-      <section className="grid gap-2">
-        <h3 className="m-0 text-lg font-bold text-[#162947]">
-          재무 건전성 모니터링
-        </h3>
-        <p className="m-0 text-sm text-[#6f83a8]">
-          본부별 집행률과 리스크 비중을 한 화면에서 확인합니다.
-        </p>
-      </section>
-
       <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
-        <Panel
-          title="본부별 예산 vs 집행"
-          subtitle="본부 단위 집행 차이를 비교합니다."
-        >
+        <Panel title="본부별 예산 vs 집행">
+          <div className="mb-3 flex items-center justify-center gap-5 text-sm font-semibold text-[#5e739a]">
+            <span className="inline-flex items-center gap-2">
+              <span className="h-3 w-8 rounded bg-[#3f79ea]" />
+              예산
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <span className="h-3 w-8 rounded bg-[#17acc8]" />
+              집행
+            </span>
+          </div>
           <div className="grid gap-3">
-            {portfolio.headquarters.map((headquarter) => {
-              const ratio = Math.min(
-                100,
+            {orderedHeadquarters.map((headquarter) => {
+              const budgetWidth = Math.max(
+                3,
                 Math.round(
-                  (headquarter.totalExpectedRevenueKrw /
-                    Math.max(1, headquarter.totalInvestmentKrw)) *
-                    100
+                  (headquarter.totalInvestmentKrw / totalInvestment) * 100
+                )
+              );
+              const expenseWidth = Math.max(
+                3,
+                Math.round(
+                  (headquarter.totalExpectedRevenueKrw / totalInvestment) * 100
                 )
               );
               return (
-                <article
-                  key={headquarter.code}
-                  className="grid gap-2 rounded-xl border border-slate-200/80 bg-[#f8faff] px-3.5 py-3"
-                >
-                  <div className="flex items-baseline justify-between gap-3">
-                    <strong className="text-[0.94rem] text-[#1d2c4d]">
+                <article key={headquarter.code} className="grid gap-1.5">
+                  <div className="flex items-center justify-between text-[0.88rem] text-[#5f7399]">
+                    <strong className="text-[#1d2c4d]">
                       {headquarter.name}
                     </strong>
-                    <span className="text-[0.88rem] text-[#7388ac]">
-                      {ratio}% 집행
+                    <span>
+                      {formatKrwCompact(headquarter.totalInvestmentKrw)} /{' '}
+                      {formatKrwCompact(headquarter.totalExpectedRevenueKrw)}
                     </span>
                   </div>
-                  <span className="text-[0.82rem] text-[#7388ac]">
-                    예산 {formatKrwCompact(headquarter.totalInvestmentKrw)} ·
-                    집행 {formatKrwCompact(headquarter.totalExpectedRevenueKrw)}
-                  </span>
-                  <div
-                    className="h-3 overflow-hidden rounded-full bg-[#edf2fa]"
-                    aria-hidden="true"
-                  >
-                    <span
-                      className="block h-full rounded-full bg-[linear-gradient(90deg,#3f79ea,#1db0db)]"
-                      style={{ width: `${ratio}%` }}
-                    />
+                  <div className="grid gap-1">
+                    <div className="h-2.5 overflow-hidden rounded-full bg-[#edf2fa]">
+                      <span
+                        className="block h-full rounded-full bg-[#3f79ea]"
+                        style={{ width: `${budgetWidth}%` }}
+                      />
+                    </div>
+                    <div className="h-2.5 overflow-hidden rounded-full bg-[#edf2fa]">
+                      <span
+                        className="block h-full rounded-full bg-[#17acc8]"
+                        style={{ width: `${expenseWidth}%` }}
+                      />
+                    </div>
                   </div>
                 </article>
               );
@@ -197,136 +223,200 @@ export function DashboardView({
           </div>
         </Panel>
 
-        <Panel title="리스크 분포" subtitle="프로젝트 리스크 등급 분포">
-          <div
-            className="grid justify-items-center gap-3 py-2.5"
-            aria-label="리스크 도넛"
-          >
+        <Panel title="리스크 분포">
+          <div className="grid place-items-center gap-3 py-2">
             <div
-              className="relative h-[220px] w-[220px] rounded-full after:absolute after:inset-[30px] after:rounded-full after:bg-white after:content-['']"
+              className="relative h-[270px] w-[270px] rounded-full after:absolute after:inset-[68px] after:rounded-full after:bg-white after:content-['']"
               style={{
                 background: `conic-gradient(
-                #ef4444 0% ${(riskCounts.high / totalRiskCount) * 100}%,
-                #f59e0b ${(riskCounts.high / totalRiskCount) * 100}% ${((riskCounts.high + riskCounts.mid) / totalRiskCount) * 100}%,
-                #22c55e ${((riskCounts.high + riskCounts.mid) / totalRiskCount) * 100}% 100%
-              )`
+                  #e52f2f 0% ${(riskCounts.high / riskTotal) * 100}%,
+                  #fa7a15 ${(riskCounts.high / riskTotal) * 100}% ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}%,
+                  #24be62 ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}% 100%
+                )`
               }}
             />
-            <div className="grid w-full gap-1.5 rounded-xl border border-slate-200 bg-[#f9fbff] px-3 py-2.5 text-[0.82rem] font-semibold text-[#546991]">
-              <span className="flex items-center justify-between">
-                <span className="text-[#d14444]">CRITICAL</span>
-                <span>
-                  {riskCounts.high}건 (
-                  {Math.round((riskCounts.high / totalRiskCount) * 100)}%)
-                </span>
+            <div className="flex flex-wrap items-center justify-center gap-3 text-sm font-semibold text-[#63779f]">
+              <span className="inline-flex items-center gap-1.5">
+                <span className="h-2.5 w-6 rounded bg-[#e52f2f]" />
+                CRITICAL
               </span>
-              <span className="flex items-center justify-between">
-                <span className="text-[#b0791a]">MEDIUM</span>
-                <span>
-                  {riskCounts.mid}건 (
-                  {Math.round((riskCounts.mid / totalRiskCount) * 100)}%)
-                </span>
+              <span className="inline-flex items-center gap-1.5">
+                <span className="h-2.5 w-6 rounded bg-[#fa7a15]" />
+                HIGH
               </span>
-              <span className="flex items-center justify-between">
-                <span className="text-[#278f45]">LOW</span>
-                <span>
-                  {riskCounts.low}건 (
-                  {Math.round((riskCounts.low / totalRiskCount) * 100)}%)
-                </span>
+              <span className="inline-flex items-center gap-1.5">
+                <span className="h-2.5 w-6 rounded bg-[#f0a20b]" />
+                MEDIUM
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <span className="h-2.5 w-6 rounded bg-[#24be62]" />
+                LOW
               </span>
             </div>
           </div>
         </Panel>
       </section>
 
-      <section className="grid gap-2">
-        <h3 className="m-0 text-lg font-bold text-[#162947]">집중 검토 대상</h3>
-        <p className="m-0 text-sm text-[#6f83a8]">
-          우선순위 프로젝트 지표와 즉시 실행 가능한 작업을 제공합니다.
-        </p>
+      <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
+        <Panel title="월별 원가 추이 (실적 vs 표준)">
+          <div className="overflow-hidden rounded-xl border border-[#dbe4f2] bg-[#f9fbff]">
+            <table className="min-w-full text-sm">
+              <thead className="bg-[#eef3fb] text-[#5b7097]">
+                <tr>
+                  <th className="px-4 py-3 text-left">월</th>
+                  <th className="px-4 py-3 text-left">실제원가</th>
+                  <th className="px-4 py-3 text-left">표준원가</th>
+                  <th className="px-4 py-3 text-left">차이율</th>
+                </tr>
+              </thead>
+              <tbody>
+                {monthlyTrend.map((item) => {
+                  const diffRate =
+                    item.standard === 0
+                      ? 0
+                      : (item.actual - item.standard) / item.standard;
+                  return (
+                    <tr key={item.month} className="border-t border-[#e6edf8]">
+                      <td className="px-4 py-3 font-semibold text-[#1f3458]">
+                        {item.month}
+                      </td>
+                      <td className="px-4 py-3 text-[#2d446b]">
+                        {item.actual.toFixed(1)}억
+                      </td>
+                      <td className="px-4 py-3 text-[#2d446b]">
+                        {item.standard.toFixed(1)}억
+                      </td>
+                      <td
+                        className={`px-4 py-3 font-semibold ${
+                          diffRate > 0 ? 'text-[#db3a3a]' : 'text-[#1b9a62]'
+                        }`}
+                      >
+                        {formatPercent(diffRate)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </Panel>
+
+        <Panel title="유형별 예산">
+          <div className="grid gap-2">
+            {categoryBudgets.map((item) => (
+              <article key={item.label} className="grid gap-1">
+                <div className="flex items-center justify-between text-[0.86rem] text-[#5f7399]">
+                  <strong className="text-[#1e2f4c]">{item.label}</strong>
+                  <span>{item.value.toFixed(1)}억</span>
+                </div>
+                <div className="h-2.5 overflow-hidden rounded-full bg-[#eaf0f9]">
+                  <span
+                    className="block h-full rounded-full bg-[linear-gradient(90deg,#3f79ea,#17acc8)]"
+                    style={{
+                      width: `${Math.round((item.value / maxCategoryBudget) * 100)}%`
+                    }}
+                  />
+                </div>
+              </article>
+            ))}
+          </div>
+        </Panel>
       </section>
 
       <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
-        <Panel
-          title="월별 원가 추이 (실적 vs 표준)"
-          subtitle="우선순위 프로젝트 기준"
-        >
-          <ol className="m-0 grid list-none gap-2.5 p-0">
-            {priorityProjects.slice(0, 5).map((project) => (
-              <li
-                key={project.code}
-                className="grid gap-2 rounded-[16px] border border-[rgba(123,137,167,0.16)] bg-[#f8faff] px-4 py-3"
-              >
-                <div className="flex flex-wrap items-start justify-between gap-2.5">
-                  <strong className="text-[0.95rem] font-semibold text-[#20293d]">
-                    {project.code} · {project.name}
-                  </strong>
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-[0.73rem] font-semibold ${
-                      project.risk === '높음'
-                        ? 'bg-red-100 text-red-700'
-                        : project.risk === '중간'
-                          ? 'bg-amber-100 text-amber-700'
-                          : 'bg-emerald-100 text-emerald-700'
-                    }`}
-                  >
-                    리스크 {project.risk}
-                  </span>
-                </div>
-                <div className="grid gap-1 text-[0.83rem] text-[#707a92]">
-                  <span>
-                    투자 {formatKrwCompact(project.investmentKrw)} / NPV{' '}
-                    {formatKrwCompact(project.npvKrw)}
-                  </span>
-                  <small className="text-[#707a92]">
-                    IRR {formatPercent(project.irr)} · 회수{' '}
-                    {project.paybackYears.toFixed(1)}년
-                  </small>
-                </div>
-              </li>
-            ))}
-          </ol>
+        <Panel title="본부별 현황">
+          <div className="overflow-hidden rounded-xl border border-[#dbe4f2] bg-white">
+            <table className="min-w-full text-sm">
+              <thead className="bg-[#eef3fb] text-[#5b7097]">
+                <tr>
+                  <th className="px-4 py-3 text-left">코드</th>
+                  <th className="px-4 py-3 text-left">본부</th>
+                  <th className="px-4 py-3 text-left">프로젝트</th>
+                  <th className="px-4 py-3 text-left">예산</th>
+                  <th className="px-4 py-3 text-left">집행</th>
+                  <th className="px-4 py-3 text-left">집행률</th>
+                </tr>
+              </thead>
+              <tbody>
+                {orderedHeadquarters.map((headquarter) => {
+                  const runRate =
+                    headquarter.totalInvestmentKrw === 0
+                      ? 0
+                      : headquarter.totalExpectedRevenueKrw /
+                        headquarter.totalInvestmentKrw;
+                  return (
+                    <tr
+                      key={headquarter.code}
+                      className="border-t border-[#e6edf8]"
+                    >
+                      <td className="px-4 py-3 font-semibold text-[#22375d]">
+                        {headquarter.code.replace('HQ', 'DIV-')}
+                      </td>
+                      <td className="px-4 py-3 text-[#22375d]">
+                        {headquarter.name}
+                      </td>
+                      <td className="px-4 py-3 text-[#2b3f63]">
+                        {headquarter.projectCount}
+                      </td>
+                      <td className="px-4 py-3 text-[#2b3f63]">
+                        {formatKrwCompact(headquarter.totalInvestmentKrw)}
+                      </td>
+                      <td className="px-4 py-3 text-[#2b3f63]">
+                        {formatKrwCompact(headquarter.totalExpectedRevenueKrw)}
+                      </td>
+                      <td
+                        className={`px-4 py-3 font-bold ${
+                          runRate > 0.9 ? 'text-[#d73333]' : 'text-[#16955f]'
+                        }`}
+                      >
+                        {formatPercent(runRate)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         </Panel>
 
-        <Panel title="다음 의사결정" subtitle="역할 기반 현재 포커스">
-          <article className="grid gap-2 rounded-[20px] border border-[rgba(123,137,167,0.12)] bg-[#f9fafc] p-[18px]">
-            <strong className="text-[0.95rem] font-semibold text-[#20293d]">
-              {selectedInsight.decisionFocus}
-            </strong>
-            <p className="m-0 leading-relaxed text-[#707a92]">
-              {selectedInsight.summary}
-            </p>
-            <p className="m-0 leading-relaxed text-[#707a92]">
-              {selectedInsight.nextAction}
-            </p>
-          </article>
-          <div className="grid gap-2">
-            {priorityProjects.slice(0, 2).map((project) => (
-              <div
+        <Panel title="최근 평가">
+          <div className="grid max-h-[440px] gap-2 overflow-y-auto pr-1">
+            {recentReviews.map((project) => (
+              <article
                 key={project.code}
-                className="grid gap-2 rounded-xl border border-slate-200 bg-white p-2.5"
+                className="rounded-xl border border-[#dbe4f2] bg-[#f9fbff] px-3 py-2.5"
               >
-                <strong className="text-sm text-[#1d2c4d]">
-                  {project.code} · {project.name}
+                <span className="text-xs text-[#6b82aa]">
+                  {project.code} · {project.assetCategory}
+                </span>
+                <strong className="mt-1 block text-[0.96rem] text-[#1e2f4c]">
+                  {project.name}
                 </strong>
-                <div className="flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    onClick={() => onOpenWorkspace('accounting', project.code)}
-                    className="rounded-[12px] border border-[rgba(79,103,246,0.18)] bg-[rgba(79,103,246,0.08)] px-3 py-2 text-xs font-bold text-[#3d52dc] transition-colors hover:bg-[rgba(79,103,246,0.14)]"
-                  >
-                    원가 분석
-                  </button>
+                <p className="mt-1 text-sm text-[#647ca5]">
+                  NPV {formatKrwCompact(project.npvKrw)} · IRR{' '}
+                  {formatPercent(project.irr)} · {project.status}
+                </p>
+                <div className="mt-2 flex gap-2">
                   <button
                     type="button"
                     onClick={() => onOpenWorkspace('valuation', project.code)}
-                    className="rounded-[12px] border border-slate-300 bg-white px-3 py-2 text-xs font-bold text-[#304564] transition-colors hover:bg-slate-50"
+                    className="rounded-lg border border-[#ccd7ea] bg-white px-2.5 py-1.5 text-xs font-semibold text-[#395078]"
                   >
-                    가치평가
+                    평가 상세
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onOpenWorkspace('accounting', project.code)}
+                    className="rounded-lg border border-[#c7d4ea] bg-[#eef3fc] px-2.5 py-1.5 text-xs font-semibold text-[#2f57c8]"
+                  >
+                    원가 보기
                   </button>
                 </div>
-              </div>
+              </article>
             ))}
+            <article className="rounded-xl border border-[#dbe4f2] bg-[#f9fbff] px-3 py-2.5 text-sm text-[#62779d]">
+              {selectedInsight.nextAction}
+            </article>
           </div>
         </Panel>
       </section>

--- a/frontend/src/views/dashboard/DashboardView.tsx
+++ b/frontend/src/views/dashboard/DashboardView.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-vars */
+import { useEffect, useRef } from 'react';
 import { formatKrwCompact, formatPercent } from '../../app/format';
 import type {
   PortfolioSummary,
@@ -6,6 +7,7 @@ import type {
   RoleInsight
 } from '../../app/portfolioData';
 import { Panel } from '../../shared/components/Panel';
+import type { Chart as ChartJS } from 'chart.js';
 
 type DashboardViewProps = {
   decisionSignals: ReadonlyArray<{ label: string; value: string }>;
@@ -56,6 +58,10 @@ export function DashboardView({
   priorityProjects,
   onOpenWorkspace
 }: DashboardViewProps) {
+  const divisionChartRef = useRef<HTMLCanvasElement | null>(null);
+  const riskChartRef = useRef<HTMLCanvasElement | null>(null);
+  const trendChartRef = useRef<HTMLCanvasElement | null>(null);
+  const typeChartRef = useRef<HTMLCanvasElement | null>(null);
   const now = new Date().toLocaleString('sv-SE').replace('T', ' ');
   const headquarterMap = new Map(
     portfolio.headquarters.map((item) => [
@@ -70,10 +76,6 @@ export function DashboardView({
         Boolean(item)
     );
 
-  const budgetMax = Math.max(
-    1,
-    ...orderedHeadquarters.map((item) => item.totalInvestmentKrw)
-  );
   const riskCounts = portfolio.projects.reduce(
     (acc, project) => {
       if (project.risk === '높음') acc.high += 1;
@@ -83,291 +85,350 @@ export function DashboardView({
     },
     { high: 0, mid: 0, low: 0 }
   );
-  const riskTotal = Math.max(
-    1,
-    riskCounts.high + riskCounts.mid + riskCounts.low
-  );
+  useEffect(() => {
+    let mounted = true;
+    const charts: ChartJS[] = [];
 
-  const chartWidth = 740;
-  const chartHeight = 310;
-  const tickCount = 5;
-  const valueMax = Math.max(
-    ...monthlyTrend.map((item) => Math.max(item.actual, item.standard)),
-    1
-  );
-  const paddedMax = Math.ceil(valueMax / 100) * 100;
-  const xStep = chartWidth / Math.max(1, monthlyTrend.length - 1);
-  const scaleY = (value: number) =>
-    chartHeight - (value / paddedMax) * chartHeight;
-  const actualPoints = monthlyTrend
-    .map((item, index) => `${index * xStep},${scaleY(item.actual)}`)
-    .join(' ');
-  const standardPoints = monthlyTrend
-    .map((item, index) => `${index * xStep},${scaleY(item.standard)}`)
-    .join(' ');
+    async function setupCharts() {
+      const { default: Chart } = await import('chart.js/auto');
+      if (!mounted) {
+        return;
+      }
+
+      const divisionCanvas = divisionChartRef.current;
+      if (divisionCanvas) {
+        charts.push(
+          new Chart(divisionCanvas, {
+            type: 'bar',
+            data: {
+              labels: orderedHeadquarters.map((item) => item.name),
+              datasets: [
+                {
+                  label: '예산',
+                  data: orderedHeadquarters.map(
+                    (item) => item.totalInvestmentKrw / 100000000
+                  ),
+                  borderRadius: 8,
+                  maxBarThickness: 30,
+                  backgroundColor: '#3f79ea'
+                },
+                {
+                  label: '집행',
+                  data: orderedHeadquarters.map(
+                    (item) => item.totalExpectedRevenueKrw / 100000000
+                  ),
+                  borderRadius: 8,
+                  maxBarThickness: 30,
+                  backgroundColor: '#19b1ca'
+                }
+              ]
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              interaction: { mode: 'index', intersect: false },
+              plugins: {
+                legend: {
+                  position: 'top',
+                  labels: { boxWidth: 18, boxHeight: 8, useBorderRadius: true }
+                },
+                tooltip: {
+                  callbacks: {
+                    label: (context) => {
+                      const value = Number(context.raw ?? 0);
+                      return `${context.dataset.label}: ${value.toFixed(1)}억`;
+                    }
+                  }
+                }
+              },
+              scales: {
+                y: {
+                  beginAtZero: true,
+                  grid: { color: '#e7edf7' },
+                  ticks: {
+                    callback: (value) => `${value}억`
+                  }
+                },
+                x: {
+                  grid: { display: false }
+                }
+              }
+            }
+          })
+        );
+      }
+
+      const riskCanvas = riskChartRef.current;
+      if (riskCanvas) {
+        const riskData = [0, riskCounts.high, riskCounts.mid, riskCounts.low];
+        charts.push(
+          new Chart(riskCanvas, {
+            type: 'doughnut',
+            data: {
+              labels: ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'],
+              datasets: [
+                {
+                  data: riskData,
+                  backgroundColor: ['#e52f2f', '#f57a14', '#f2a40c', '#24be62'],
+                  borderColor: '#ffffff',
+                  borderWidth: 3,
+                  hoverOffset: 8
+                }
+              ]
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              cutout: '52%',
+              plugins: {
+                legend: {
+                  position: 'bottom',
+                  labels: { boxWidth: 22, boxHeight: 8, useBorderRadius: true }
+                },
+                tooltip: {
+                  callbacks: {
+                    label: (context) => {
+                      const value = Number(context.raw ?? 0);
+                      const total = riskData.reduce(
+                        (sum, item) => sum + item,
+                        0
+                      );
+                      const ratio =
+                        total === 0 ? 0 : ((value / total) * 100).toFixed(1);
+                      return `${context.label}: ${value}건 (${ratio}%)`;
+                    }
+                  }
+                }
+              }
+            }
+          })
+        );
+      }
+
+      const trendCanvas = trendChartRef.current;
+      if (trendCanvas) {
+        const ctx = trendCanvas.getContext('2d');
+        const actualGradient = ctx?.createLinearGradient(0, 0, 0, 300);
+        actualGradient?.addColorStop(0, 'rgba(47,87,216,0.26)');
+        actualGradient?.addColorStop(1, 'rgba(47,87,216,0.02)');
+
+        charts.push(
+          new Chart(trendCanvas, {
+            type: 'line',
+            data: {
+              labels: monthlyTrend.map((item) => item.month),
+              datasets: [
+                {
+                  label: '실제원가',
+                  data: monthlyTrend.map((item) => item.actual),
+                  borderColor: '#2f57d8',
+                  backgroundColor: actualGradient ?? 'rgba(47,87,216,0.18)',
+                  pointRadius: 4,
+                  pointHoverRadius: 6,
+                  borderWidth: 3,
+                  tension: 0.25,
+                  fill: true
+                },
+                {
+                  label: '표준원가',
+                  data: monthlyTrend.map((item) => item.standard),
+                  borderColor: '#18a169',
+                  borderDash: [7, 5],
+                  pointRadius: 4,
+                  pointHoverRadius: 6,
+                  borderWidth: 3,
+                  tension: 0.25,
+                  fill: false
+                }
+              ]
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              interaction: { mode: 'index', intersect: false },
+              plugins: {
+                legend: {
+                  position: 'top',
+                  labels: { boxWidth: 20, boxHeight: 8, useBorderRadius: true }
+                },
+                tooltip: {
+                  callbacks: {
+                    label: (context) =>
+                      `${context.dataset.label}: ${Number(context.raw ?? 0).toFixed(1)}억`
+                  }
+                }
+              },
+              scales: {
+                y: {
+                  beginAtZero: false,
+                  grid: { color: '#e7edf7' },
+                  ticks: {
+                    callback: (value) => `${value}억`
+                  }
+                },
+                x: {
+                  grid: { color: '#edf2fa' }
+                }
+              }
+            }
+          })
+        );
+      }
+
+      const typeCanvas = typeChartRef.current;
+      if (typeCanvas) {
+        charts.push(
+          new Chart(typeCanvas, {
+            type: 'polarArea',
+            data: {
+              labels: categoryBudgets.map((item) => item.label),
+              datasets: [
+                {
+                  data: categoryBudgets.map((item) => item.value * 100000000),
+                  backgroundColor: categoryBudgets.map((item) => item.color),
+                  borderColor: '#ffffff',
+                  borderWidth: 2
+                }
+              ]
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              scales: {
+                r: {
+                  grid: { color: '#e7edf7' },
+                  angleLines: { color: '#e7edf7' },
+                  ticks: {
+                    backdropColor: 'transparent',
+                    callback: (value) =>
+                      Number(value) === 0
+                        ? '0'
+                        : formatKrwCompact(Number(value))
+                  }
+                }
+              },
+              plugins: {
+                legend: {
+                  position: 'bottom',
+                  labels: { boxWidth: 20, boxHeight: 8, useBorderRadius: true }
+                },
+                tooltip: {
+                  callbacks: {
+                    label: (context) =>
+                      `${context.label}: ${formatKrwCompact(Number(context.raw ?? 0))}`
+                  }
+                }
+              }
+            }
+          })
+        );
+      }
+    }
+
+    void setupCharts();
+
+    return () => {
+      mounted = false;
+      charts.forEach((chart) => chart.destroy());
+    };
+  }, [orderedHeadquarters, riskCounts.high, riskCounts.low, riskCounts.mid]);
 
   const sortedReviews = [...portfolio.projects]
     .sort((a, b) => b.rank - a.rank)
     .slice(0, 8);
 
   return (
-    <section className="grid gap-4">
-      <header className="flex flex-wrap items-start justify-between gap-3">
+    <section className="grid gap-5">
+      <header className="flex flex-wrap items-start justify-between gap-2.5 rounded-2xl border border-[#dde6f4] bg-white px-6 py-5 shadow-[0_2px_8px_rgba(12,26,56,0.04)]">
         <div>
-          <h2 className="m-0 text-[2.05rem] font-extrabold tracking-[-0.015em] text-[#172a4a]">
+          <h2 className="m-0 text-[1.72rem] font-extrabold tracking-[-0.012em] text-[#172a4a]">
             통합 대시보드
           </h2>
         </div>
-        <span className="text-[1rem] text-[#667da8]">{now}</span>
+        <span className="text-[0.93rem] font-semibold text-[#6c82a9]">
+          {now}
+        </span>
       </header>
 
       <section className="grid grid-cols-4 gap-4 max-[1280px]:grid-cols-2">
-        <article className="rounded-2xl border border-[#dce4f2] bg-white px-5 py-4 shadow-[0_2px_8px_rgba(12,26,56,0.05)]">
-          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#376de3] text-xl text-white">
+        <article className="rounded-2xl border border-[#dce4f2] bg-white px-5 py-4 shadow-[0_3px_10px_rgba(12,26,56,0.05)]">
+          <span className="inline-grid h-11 w-11 place-items-center rounded-xl bg-[#376de3] text-lg text-white">
             ▦
           </span>
-          <strong className="mt-3 block text-[2.15rem] font-extrabold leading-none text-[#192b4b]">
+          <strong className="mt-3 block text-[2rem] font-extrabold leading-none text-[#192b4b]">
             {portfolio.overview.headquarterCount}
           </strong>
-          <span className="mt-2 block text-[1.03rem] font-semibold text-[#526a96]">
+          <span className="mt-2 block text-[1rem] font-semibold text-[#526a96]">
             운영 본부
           </span>
-          <p className="mt-1 text-[0.94rem] text-[#7f92b3]">5개 본부 가동중</p>
+          <p className="mt-1 text-[0.9rem] text-[#7f92b3]">5개 본부 가동중</p>
         </article>
-        <article className="rounded-2xl border border-[#dce4f2] bg-white px-5 py-4 shadow-[0_2px_8px_rgba(12,26,56,0.05)]">
-          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#1ca9c7] text-xl text-white">
+        <article className="rounded-2xl border border-[#dce4f2] bg-white px-5 py-4 shadow-[0_3px_10px_rgba(12,26,56,0.05)]">
+          <span className="inline-grid h-11 w-11 place-items-center rounded-xl bg-[#1ca9c7] text-lg text-white">
             ⊞
           </span>
-          <strong className="mt-3 block text-[2.15rem] font-extrabold leading-none text-[#192b4b]">
+          <strong className="mt-3 block text-[2rem] font-extrabold leading-none text-[#192b4b]">
             {portfolio.overview.projectCount}
           </strong>
-          <span className="mt-2 block text-[1.03rem] font-semibold text-[#526a96]">
+          <span className="mt-2 block text-[1rem] font-semibold text-[#526a96]">
             활성 프로젝트
           </span>
-          <p className="mt-1 text-[0.94rem] text-[#7f92b3]">
+          <p className="mt-1 text-[0.9rem] text-[#7f92b3]">
             총 20여개 동시 운영
           </p>
         </article>
-        <article className="rounded-2xl border border-[#dce4f2] bg-white px-5 py-4 shadow-[0_2px_8px_rgba(12,26,56,0.05)]">
-          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#28b95d] text-xl text-white">
+        <article className="rounded-2xl border border-[#dce4f2] bg-white px-5 py-4 shadow-[0_3px_10px_rgba(12,26,56,0.05)]">
+          <span className="inline-grid h-11 w-11 place-items-center rounded-xl bg-[#28b95d] text-lg text-white">
             ⛁
           </span>
-          <strong className="mt-3 block text-[2.15rem] font-extrabold leading-none text-[#192b4b]">
+          <strong className="mt-3 block text-[2rem] font-extrabold leading-none text-[#192b4b]">
             {formatKrwCompact(portfolio.overview.totalInvestmentKrw)}
           </strong>
-          <span className="mt-2 block text-[1.03rem] font-semibold text-[#526a96]">
+          <span className="mt-2 block text-[1rem] font-semibold text-[#526a96]">
             총 예산
           </span>
-          <p className="mt-1 text-[0.94rem] text-[#7f92b3]">
+          <p className="mt-1 text-[0.9rem] text-[#7f92b3]">
             집행: {formatKrwCompact(portfolio.overview.totalExpectedRevenueKrw)}
           </p>
         </article>
-        <article className="rounded-2xl border border-[#dce4f2] bg-white px-5 py-4 shadow-[0_2px_8px_rgba(12,26,56,0.05)]">
-          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#ef3b45] text-xl text-white">
+        <article className="rounded-2xl border border-[#dce4f2] bg-white px-5 py-4 shadow-[0_3px_10px_rgba(12,26,56,0.05)]">
+          <span className="inline-grid h-11 w-11 place-items-center rounded-xl bg-[#ef3b45] text-lg text-white">
             ⚠
           </span>
-          <strong className="mt-3 block text-[2.15rem] font-extrabold leading-none text-[#192b4b]">
+          <strong className="mt-3 block text-[2rem] font-extrabold leading-none text-[#192b4b]">
             {portfolio.overview.conditionalCount}
           </strong>
-          <span className="mt-2 block text-[1.03rem] font-semibold text-[#526a96]">
+          <span className="mt-2 block text-[1rem] font-semibold text-[#526a96]">
             미확인 경보
           </span>
-          <p className="mt-1 text-[0.94rem] text-[#7f92b3]">클릭하여 확인</p>
+          <p className="mt-1 text-[0.9rem] text-[#7f92b3]">클릭하여 확인</p>
         </article>
       </section>
 
       <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
         <Panel title="본부별 예산 vs 집행">
-          <div className="mb-4 flex justify-center gap-5 text-[0.97rem] font-semibold text-[#5d749f]">
-            <span className="inline-flex items-center gap-2">
-              <span className="h-3 w-10 rounded bg-[#3f79ea]" />
-              예산
-            </span>
-            <span className="inline-flex items-center gap-2">
-              <span className="h-3 w-10 rounded bg-[#1ca9c7]" />
-              집행
-            </span>
-          </div>
-          <div className="grid gap-3.5">
-            {orderedHeadquarters.map((item) => {
-              const budgetWidth = Math.max(
-                3,
-                Math.round((item.totalInvestmentKrw / budgetMax) * 100)
-              );
-              const expenseWidth = Math.max(
-                3,
-                Math.round((item.totalExpectedRevenueKrw / budgetMax) * 100)
-              );
-              return (
-                <article key={item.code} className="grid gap-1.5">
-                  <div className="flex items-center justify-between text-[0.95rem] text-[#5f759f]">
-                    <strong className="text-[1.08rem] text-[#1d3054]">
-                      {item.name}
-                    </strong>
-                    <span>
-                      {formatKrwCompact(item.totalInvestmentKrw)} /{' '}
-                      {formatKrwCompact(item.totalExpectedRevenueKrw)}
-                    </span>
-                  </div>
-                  <div className="grid gap-1.5">
-                    <div className="h-3 overflow-hidden rounded-full bg-[#e7eef8]">
-                      <span
-                        className="block h-full rounded-full bg-[#3f79ea]"
-                        style={{ width: `${budgetWidth}%` }}
-                      />
-                    </div>
-                    <div className="h-3 overflow-hidden rounded-full bg-[#e7eef8]">
-                      <span
-                        className="block h-full rounded-full bg-[#1ca9c7]"
-                        style={{ width: `${expenseWidth}%` }}
-                      />
-                    </div>
-                  </div>
-                </article>
-              );
-            })}
+          <div className="h-[320px]">
+            <canvas ref={divisionChartRef} />
           </div>
         </Panel>
 
         <Panel title="리스크 분포">
-          <div className="grid place-items-center gap-3 py-2">
-            <div
-              className="relative h-[270px] w-[270px] rounded-full after:absolute after:inset-[66px] after:rounded-full after:bg-white after:content-['']"
-              style={{
-                background: `conic-gradient(
-                  #e52f2f 0% ${(riskCounts.high / riskTotal) * 100}%,
-                  #f57a14 ${(riskCounts.high / riskTotal) * 100}% ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}%,
-                  #f2a40c ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}% ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}%,
-                  #24be62 ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}% 100%
-                )`
-              }}
-            />
-            <div className="flex flex-wrap items-center justify-center gap-3 text-[0.98rem] font-semibold text-[#60759f]">
-              <span className="inline-flex items-center gap-1.5">
-                <span className="h-2.5 w-7 rounded bg-[#e52f2f]" /> CRITICAL
-              </span>
-              <span className="inline-flex items-center gap-1.5">
-                <span className="h-2.5 w-7 rounded bg-[#f57a14]" /> HIGH
-              </span>
-              <span className="inline-flex items-center gap-1.5">
-                <span className="h-2.5 w-7 rounded bg-[#f2a40c]" /> MEDIUM
-              </span>
-              <span className="inline-flex items-center gap-1.5">
-                <span className="h-2.5 w-7 rounded bg-[#24be62]" /> LOW
-              </span>
-            </div>
+          <div className="h-[320px]">
+            <canvas ref={riskChartRef} />
           </div>
         </Panel>
       </section>
 
       <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
         <Panel title="월별 원가 추이 (실적 vs 표준)">
-          <div className="mb-4 flex justify-center gap-5 text-[0.97rem] font-semibold text-[#5d749f]">
-            <span className="inline-flex items-center gap-2">
-              <span className="h-[3px] w-10 rounded bg-[#2f57d8]" /> 실제원가
-            </span>
-            <span className="inline-flex items-center gap-2">
-              <span className="h-[3px] w-10 rounded border-2 border-dashed border-[#18a169]" />{' '}
-              표준원가
-            </span>
-          </div>
-          <div className="rounded-xl border border-[#dce5f4] bg-[#f9fbff] px-3 py-3">
-            <svg
-              viewBox={`0 0 ${chartWidth} ${chartHeight + 38}`}
-              className="w-full"
-            >
-              {Array.from({ length: tickCount }).map((_, index) => {
-                const y = (chartHeight / (tickCount - 1)) * index;
-                return (
-                  <line
-                    key={`grid-${index}`}
-                    x1="0"
-                    y1={y}
-                    x2={chartWidth}
-                    y2={y}
-                    stroke="#e4ebf6"
-                    strokeWidth="1"
-                  />
-                );
-              })}
-              <polyline
-                points={actualPoints}
-                fill="none"
-                stroke="#2f57d8"
-                strokeWidth="4"
-              />
-              <polyline
-                points={standardPoints}
-                fill="none"
-                stroke="#18a169"
-                strokeWidth="4"
-                strokeDasharray="10 8"
-              />
-              {monthlyTrend.map((item, index) => {
-                const x = index * xStep;
-                const yActual = scaleY(item.actual);
-                const yStandard = scaleY(item.standard);
-                return (
-                  <g key={item.month}>
-                    <circle cx={x} cy={yActual} r="5" fill="#2f57d8" />
-                    <circle cx={x} cy={yStandard} r="5" fill="#18a169" />
-                    <text
-                      x={x}
-                      y={chartHeight + 28}
-                      textAnchor="middle"
-                      fontSize="14"
-                      fill="#62789f"
-                    >
-                      {item.month}
-                    </text>
-                  </g>
-                );
-              })}
-            </svg>
+          <div className="h-[320px]">
+            <canvas ref={trendChartRef} />
           </div>
         </Panel>
 
         <Panel title="유형별 예산">
-          <div className="relative mx-auto mt-1 grid h-[310px] w-[310px] place-items-center rounded-full border border-[#dee6f4] bg-[#fafdff]">
-            <div className="absolute inset-[18%] rounded-full border border-[#e2e9f5]" />
-            <div className="absolute inset-[34%] rounded-full border border-[#e2e9f5]" />
-            <div className="absolute inset-[50%] rounded-full border border-[#e2e9f5]" />
-            <div className="absolute h-[2px] w-full bg-[#e2e9f5]" />
-            <div className="absolute h-full w-[2px] bg-[#e2e9f5]" />
-            {categoryBudgets.map((item, index) => {
-              const angle = (360 / categoryBudgets.length) * index - 90;
-              const length =
-                46 +
-                (item.value /
-                  Math.max(...categoryBudgets.map((x) => x.value))) *
-                  86;
-              return (
-                <div
-                  key={item.label}
-                  className="absolute left-1/2 top-1/2 origin-left rounded-full"
-                  style={{
-                    width: `${length}px`,
-                    height: '12px',
-                    transform: `translateY(-50%) rotate(${angle}deg)`,
-                    background: item.color
-                  }}
-                />
-              );
-            })}
-          </div>
-          <div className="mt-3 flex flex-wrap justify-center gap-2 text-[0.9rem] font-semibold text-[#60759f]">
-            {categoryBudgets.map((item) => (
-              <span
-                key={item.label}
-                className="inline-flex items-center gap-1.5"
-              >
-                <span
-                  className="h-2.5 w-6 rounded"
-                  style={{ background: item.color }}
-                />
-                {item.label}
-              </span>
-            ))}
+          <div className="h-[320px]">
+            <canvas ref={typeChartRef} />
           </div>
         </Panel>
       </section>

--- a/frontend/src/views/dashboard/DashboardView.tsx
+++ b/frontend/src/views/dashboard/DashboardView.tsx
@@ -1,6 +1,10 @@
 /* eslint-disable no-unused-vars */
 import { formatKrwCompact, formatPercent } from '../../app/format';
-import type { PortfolioSummary, ProjectSummary, RoleInsight } from '../../app/portfolioData';
+import type {
+  PortfolioSummary,
+  ProjectSummary,
+  RoleInsight
+} from '../../app/portfolioData';
 import { Panel } from '../../shared/components/Panel';
 
 type DashboardViewProps = {
@@ -8,7 +12,10 @@ type DashboardViewProps = {
   selectedInsight: RoleInsight;
   portfolio: PortfolioSummary;
   priorityProjects: ProjectSummary[];
-  onOpenWorkspace(target: 'accounting' | 'valuation', projectCode: string): void;
+  onOpenWorkspace(
+    target: 'accounting' | 'valuation',
+    projectCode: string
+  ): void;
 };
 
 export function DashboardView({
@@ -35,45 +42,98 @@ export function DashboardView({
     1,
     riskCounts.high + riskCounts.mid + riskCounts.low
   );
+  const primaryProject = priorityProjects[0] ?? null;
 
   return (
-    <section>
-      <header className="mb-3.5 flex items-baseline justify-between gap-4">
-        <div>
-          <h2 className="m-0 text-[1.9rem] font-bold text-[#182847]">통합 대시보드</h2>
-          <p className="mt-1 text-[#607397]">전사 5개 본부 · 프로젝트 원가/평가 현황</p>
+    <section className="grid gap-4">
+      <header className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="m-0 text-xs font-semibold uppercase tracking-[0.1em] text-[#5f7399]">
+              Executive Overview
+            </p>
+            <h2 className="m-0 mt-1 text-[1.9rem] font-bold text-[#182847]">
+              통합 대시보드
+            </h2>
+            <p className="mt-1 text-[#607397]">
+              전사 5개 본부 · 프로젝트 원가/평가 현황
+            </p>
+          </div>
+          {primaryProject ? (
+            <div className="flex flex-wrap gap-2" aria-label="빠른 실행">
+              <button
+                type="button"
+                onClick={() =>
+                  onOpenWorkspace('accounting', primaryProject.code)
+                }
+                className="rounded-xl border border-[rgba(63,121,234,0.24)] bg-[rgba(63,121,234,0.08)] px-3.5 py-2 text-sm font-semibold text-[#2f57c8] transition-colors hover:bg-[rgba(63,121,234,0.14)]"
+              >
+                {primaryProject.code} 원가 워크스페이스
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  onOpenWorkspace('valuation', primaryProject.code)
+                }
+                className="rounded-xl border border-[rgba(16,33,61,0.16)] bg-[#f6f8fc] px-3.5 py-2 text-sm font-semibold text-[#22375d] transition-colors hover:bg-[#eef3fb]"
+              >
+                {primaryProject.code} 가치평가 워크스페이스
+              </button>
+            </div>
+          ) : null}
         </div>
       </header>
 
       <section
-        className="mb-4 grid grid-cols-4 gap-3.5 max-[1280px]:grid-cols-2"
+        className="grid grid-cols-4 gap-3.5 max-[1280px]:grid-cols-2"
         aria-label="핵심 지표"
       >
-        <article className="rounded-[14px] border border-cw-cardBorder bg-white p-5">
-          <span className="text-sm font-semibold text-[#5f7399]">운영 본부</span>
+        <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+          <span className="inline-flex rounded-full bg-[#eef3ff] px-2.5 py-1 text-xs font-semibold text-[#3f63ba]">
+            조직
+          </span>
+          <span className="mt-3 block text-sm font-semibold text-[#5f7399]">
+            운영 본부
+          </span>
           <strong className="mt-2 block text-[1.85rem] font-bold text-[#172747]">
             {portfolio.overview.headquarterCount}
           </strong>
           <p className="mt-2 text-sm text-[#7589ad]">5개 본부 가동중</p>
         </article>
-        <article className="rounded-[14px] border border-cw-cardBorder bg-white p-5">
-          <span className="text-sm font-semibold text-[#5f7399]">활성 프로젝트</span>
+        <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+          <span className="inline-flex rounded-full bg-[#e8f7ff] px-2.5 py-1 text-xs font-semibold text-[#21739a]">
+            운영
+          </span>
+          <span className="mt-3 block text-sm font-semibold text-[#5f7399]">
+            활성 프로젝트
+          </span>
           <strong className="mt-2 block text-[1.85rem] font-bold text-[#172747]">
             {portfolio.overview.projectCount}
           </strong>
           <p className="mt-2 text-sm text-[#7589ad]">총 20여개 동시 운영</p>
         </article>
-        <article className="rounded-[14px] border border-cw-cardBorder bg-white p-5">
-          <span className="text-sm font-semibold text-[#5f7399]">총 예산</span>
+        <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+          <span className="inline-flex rounded-full bg-[#ebfff7] px-2.5 py-1 text-xs font-semibold text-[#1d7e61]">
+            재무
+          </span>
+          <span className="mt-3 block text-sm font-semibold text-[#5f7399]">
+            총 예산
+          </span>
           <strong className="mt-2 block text-[1.85rem] font-bold text-[#172747]">
             {formatKrwCompact(portfolio.overview.totalInvestmentKrw)}
           </strong>
           <p className="mt-2 text-sm text-[#7589ad]">
-            집행 기준 {formatKrwCompact(portfolio.overview.totalExpectedRevenueKrw)}
+            집행 기준{' '}
+            {formatKrwCompact(portfolio.overview.totalExpectedRevenueKrw)}
           </p>
         </article>
-        <article className="rounded-[14px] border border-cw-cardBorder bg-white p-5">
-          <span className="text-sm font-semibold text-[#5f7399]">미확인 경보</span>
+        <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+          <span className="inline-flex rounded-full bg-[#fff3f1] px-2.5 py-1 text-xs font-semibold text-[#b0503f]">
+            주의
+          </span>
+          <span className="mt-3 block text-sm font-semibold text-[#5f7399]">
+            미확인 경보
+          </span>
           <strong className="mt-2 block text-[1.85rem] font-bold text-[#172747]">
             {portfolio.overview.conditionalCount}
           </strong>
@@ -81,9 +141,21 @@ export function DashboardView({
         </article>
       </section>
 
-      <section className="mb-4 grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
-        <Panel title="본부별 예산 vs 집행" subtitle="본부 단위 집행 차이를 비교합니다.">
-          <div className="grid gap-2.5">
+      <section className="grid gap-2">
+        <h3 className="m-0 text-lg font-bold text-[#162947]">
+          재무 건전성 모니터링
+        </h3>
+        <p className="m-0 text-sm text-[#6f83a8]">
+          본부별 집행률과 리스크 비중을 한 화면에서 확인합니다.
+        </p>
+      </section>
+
+      <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
+        <Panel
+          title="본부별 예산 vs 집행"
+          subtitle="본부 단위 집행 차이를 비교합니다."
+        >
+          <div className="grid gap-3">
             {portfolio.headquarters.map((headquarter) => {
               const ratio = Math.min(
                 100,
@@ -94,14 +166,22 @@ export function DashboardView({
                 )
               );
               return (
-                <article key={headquarter.code} className="grid gap-2">
+                <article
+                  key={headquarter.code}
+                  className="grid gap-2 rounded-xl border border-slate-200/80 bg-[#f8faff] px-3.5 py-3"
+                >
                   <div className="flex items-baseline justify-between gap-3">
-                    <strong>{headquarter.name}</strong>
+                    <strong className="text-[0.94rem] text-[#1d2c4d]">
+                      {headquarter.name}
+                    </strong>
                     <span className="text-[0.88rem] text-[#7388ac]">
-                      예산 {formatKrwCompact(headquarter.totalInvestmentKrw)} · 집행{' '}
-                      {formatKrwCompact(headquarter.totalExpectedRevenueKrw)}
+                      {ratio}% 집행
                     </span>
                   </div>
+                  <span className="text-[0.82rem] text-[#7388ac]">
+                    예산 {formatKrwCompact(headquarter.totalInvestmentKrw)} ·
+                    집행 {formatKrwCompact(headquarter.totalExpectedRevenueKrw)}
+                  </span>
                   <div
                     className="h-3 overflow-hidden rounded-full bg-[#edf2fa]"
                     aria-hidden="true"
@@ -118,7 +198,10 @@ export function DashboardView({
         </Panel>
 
         <Panel title="리스크 분포" subtitle="프로젝트 리스크 등급 분포">
-          <div className="grid justify-items-center gap-3 py-2.5" aria-label="리스크 도넛">
+          <div
+            className="grid justify-items-center gap-3 py-2.5"
+            aria-label="리스크 도넛"
+          >
             <div
               className="relative h-[220px] w-[220px] rounded-full after:absolute after:inset-[30px] after:rounded-full after:bg-white after:content-['']"
               style={{
@@ -129,33 +212,77 @@ export function DashboardView({
               )`
               }}
             />
-            <div className="flex flex-wrap justify-center gap-2.5 text-[0.86rem] font-bold text-[#546991]">
-              <span>CRITICAL {riskCounts.high}</span>
-              <span>MEDIUM {riskCounts.mid}</span>
-              <span>LOW {riskCounts.low}</span>
+            <div className="grid w-full gap-1.5 rounded-xl border border-slate-200 bg-[#f9fbff] px-3 py-2.5 text-[0.82rem] font-semibold text-[#546991]">
+              <span className="flex items-center justify-between">
+                <span className="text-[#d14444]">CRITICAL</span>
+                <span>
+                  {riskCounts.high}건 (
+                  {Math.round((riskCounts.high / totalRiskCount) * 100)}%)
+                </span>
+              </span>
+              <span className="flex items-center justify-between">
+                <span className="text-[#b0791a]">MEDIUM</span>
+                <span>
+                  {riskCounts.mid}건 (
+                  {Math.round((riskCounts.mid / totalRiskCount) * 100)}%)
+                </span>
+              </span>
+              <span className="flex items-center justify-between">
+                <span className="text-[#278f45]">LOW</span>
+                <span>
+                  {riskCounts.low}건 (
+                  {Math.round((riskCounts.low / totalRiskCount) * 100)}%)
+                </span>
+              </span>
             </div>
           </div>
         </Panel>
       </section>
 
+      <section className="grid gap-2">
+        <h3 className="m-0 text-lg font-bold text-[#162947]">집중 검토 대상</h3>
+        <p className="m-0 text-sm text-[#6f83a8]">
+          우선순위 프로젝트 지표와 즉시 실행 가능한 작업을 제공합니다.
+        </p>
+      </section>
+
       <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
-        <Panel title="월별 원가 추이 (실적 vs 표준)" subtitle="우선순위 프로젝트 기준">
-          <ol className="m-0 grid list-none gap-3 p-0">
+        <Panel
+          title="월별 원가 추이 (실적 vs 표준)"
+          subtitle="우선순위 프로젝트 기준"
+        >
+          <ol className="m-0 grid list-none gap-2.5 p-0">
             {priorityProjects.slice(0, 5).map((project) => (
               <li
                 key={project.code}
-                className="grid gap-1.5 rounded-[18px] border border-[rgba(123,137,167,0.12)] bg-[#f8faff] px-4 py-3.5"
+                className="grid gap-2 rounded-[16px] border border-[rgba(123,137,167,0.16)] bg-[#f8faff] px-4 py-3"
               >
-                <strong className="text-[0.95rem] font-semibold text-[#20293d]">
-                  {project.code} · {project.name}
-                </strong>
-                <span className="m-0 leading-relaxed text-[#707a92]">
-                  투자 {formatKrwCompact(project.investmentKrw)} / NPV{' '}
-                  {formatKrwCompact(project.npvKrw)}
-                </span>
-                <small className="text-[#707a92]">
-                  IRR {formatPercent(project.irr)} · 회수 {project.paybackYears.toFixed(1)}년
-                </small>
+                <div className="flex flex-wrap items-start justify-between gap-2.5">
+                  <strong className="text-[0.95rem] font-semibold text-[#20293d]">
+                    {project.code} · {project.name}
+                  </strong>
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-[0.73rem] font-semibold ${
+                      project.risk === '높음'
+                        ? 'bg-red-100 text-red-700'
+                        : project.risk === '중간'
+                          ? 'bg-amber-100 text-amber-700'
+                          : 'bg-emerald-100 text-emerald-700'
+                    }`}
+                  >
+                    리스크 {project.risk}
+                  </span>
+                </div>
+                <div className="grid gap-1 text-[0.83rem] text-[#707a92]">
+                  <span>
+                    투자 {formatKrwCompact(project.investmentKrw)} / NPV{' '}
+                    {formatKrwCompact(project.npvKrw)}
+                  </span>
+                  <small className="text-[#707a92]">
+                    IRR {formatPercent(project.irr)} · 회수{' '}
+                    {project.paybackYears.toFixed(1)}년
+                  </small>
+                </div>
               </li>
             ))}
           </ol>
@@ -166,19 +293,39 @@ export function DashboardView({
             <strong className="text-[0.95rem] font-semibold text-[#20293d]">
               {selectedInsight.decisionFocus}
             </strong>
-            <p className="m-0 leading-relaxed text-[#707a92]">{selectedInsight.summary}</p>
-            <p className="m-0 leading-relaxed text-[#707a92]">{selectedInsight.nextAction}</p>
+            <p className="m-0 leading-relaxed text-[#707a92]">
+              {selectedInsight.summary}
+            </p>
+            <p className="m-0 leading-relaxed text-[#707a92]">
+              {selectedInsight.nextAction}
+            </p>
           </article>
-          <div className="flex flex-wrap gap-2.5">
+          <div className="grid gap-2">
             {priorityProjects.slice(0, 2).map((project) => (
-              <button
+              <div
                 key={project.code}
-                type="button"
-                onClick={() => onOpenWorkspace('accounting', project.code)}
-                className="rounded-[14px] border border-[rgba(79,103,246,0.18)] bg-[rgba(79,103,246,0.08)] px-3 py-2.5 text-sm font-bold text-[#3d52dc] transition-colors hover:bg-[rgba(79,103,246,0.14)]"
+                className="grid gap-2 rounded-xl border border-slate-200 bg-white p-2.5"
               >
-                {project.code} 원가 분석
-              </button>
+                <strong className="text-sm text-[#1d2c4d]">
+                  {project.code} · {project.name}
+                </strong>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onOpenWorkspace('accounting', project.code)}
+                    className="rounded-[12px] border border-[rgba(79,103,246,0.18)] bg-[rgba(79,103,246,0.08)] px-3 py-2 text-xs font-bold text-[#3d52dc] transition-colors hover:bg-[rgba(79,103,246,0.14)]"
+                  >
+                    원가 분석
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onOpenWorkspace('valuation', project.code)}
+                    className="rounded-[12px] border border-slate-300 bg-white px-3 py-2 text-xs font-bold text-[#304564] transition-colors hover:bg-slate-50"
+                  >
+                    가치평가
+                  </button>
+                </div>
+              </div>
             ))}
           </div>
         </Panel>

--- a/frontend/src/views/dashboard/DashboardView.tsx
+++ b/frontend/src/views/dashboard/DashboardView.tsx
@@ -34,9 +34,27 @@ const hqCodeToLabel: Record<string, string> = {
   HQ05: '리스크관리본부'
 };
 
+const monthlyTrend = [
+  { month: '2026-01', actual: 1120, standard: 1080 },
+  { month: '2026-02', actual: 1065, standard: 1010 },
+  { month: '2026-03', actual: 825, standard: 780 }
+];
+
+const categoryBudgets = [
+  { label: 'BOND', value: 150, color: '#3f79ea' },
+  { label: 'DERIVATIVE', value: 95, color: '#17acc8' },
+  { label: 'EQUITY', value: 65, color: '#7a56dc' },
+  { label: 'INFRA', value: 110, color: '#f2a50f' },
+  { label: 'PROJECT', value: 28, color: '#22b659' },
+  { label: 'REAL_ESTATE', value: 45, color: '#e9509c' },
+  { label: 'STOCK', value: 92, color: '#23b2a4' }
+];
+
 export function DashboardView({
-  portfolio,
+  decisionSignals,
   selectedInsight,
+  portfolio,
+  priorityProjects,
   onOpenWorkspace
 }: DashboardViewProps) {
   const now = new Date().toLocaleString('sv-SE').replace('T', ' ');
@@ -52,23 +70,39 @@ export function DashboardView({
       (item): item is NonNullable<(typeof portfolio.headquarters)[number]> =>
         Boolean(item)
     );
-  const totalInvestment = Math.max(
+
+  const maxBudget = Math.max(
     1,
-    orderedHeadquarters.reduce(
-      (sum, headquarter) => sum + headquarter.totalInvestmentKrw,
-      0
-    )
+    ...orderedHeadquarters.map((item) => item.totalInvestmentKrw)
   );
+  const maxTrend = Math.max(...monthlyTrend.map((item) => item.actual), 1);
+  const minTrend = Math.min(...monthlyTrend.map((item) => item.standard), 0);
+  const trendRange = Math.max(1, maxTrend - minTrend);
+  const chartWidth = 680;
+  const chartHeight = 240;
+  const xStep = chartWidth / Math.max(1, monthlyTrend.length - 1);
+  const actualPoints = monthlyTrend
+    .map((point, index) => {
+      const x = index * xStep;
+      const y =
+        chartHeight - ((point.actual - minTrend) / trendRange) * chartHeight;
+      return `${x},${y}`;
+    })
+    .join(' ');
+  const standardPoints = monthlyTrend
+    .map((point, index) => {
+      const x = index * xStep;
+      const y =
+        chartHeight - ((point.standard - minTrend) / trendRange) * chartHeight;
+      return `${x},${y}`;
+    })
+    .join(' ');
 
   const riskCounts = portfolio.projects.reduce(
     (acc, project) => {
-      if (project.risk === '높음') {
-        acc.high += 1;
-      } else if (project.risk === '중간') {
-        acc.mid += 1;
-      } else {
-        acc.low += 1;
-      }
+      if (project.risk === '높음') acc.high += 1;
+      else if (project.risk === '중간') acc.mid += 1;
+      else acc.low += 1;
       return acc;
     },
     { high: 0, mid: 0, low: 0 }
@@ -77,125 +111,107 @@ export function DashboardView({
     1,
     riskCounts.high + riskCounts.mid + riskCounts.low
   );
-  const monthlyTrend = [
-    { month: '2026-01', actual: 1120, standard: 1080 },
-    { month: '2026-02', actual: 1065, standard: 1010 },
-    { month: '2026-03', actual: 825, standard: 780 }
-  ];
-  const categoryBudgets = [
-    { label: 'BOND', value: 150 },
-    { label: 'DERIVATIVE', value: 95 },
-    { label: 'EQUITY', value: 65 },
-    { label: 'INFRA', value: 110 },
-    { label: 'PROJECT', value: 28 },
-    { label: 'REAL_ESTATE', value: 45 },
-    { label: 'STOCK', value: 92 }
-  ];
+  const quickFocus = priorityProjects.slice(0, 5);
   const maxCategoryBudget = Math.max(
     ...categoryBudgets.map((item) => item.value),
     1
   );
-  const recentReviews = portfolio.projects.slice(0, 6);
 
   return (
-    <section className="grid gap-4">
-      <header className="flex flex-wrap items-start justify-between gap-3">
+    <section className="grid gap-5">
+      <header className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h2 className="m-0 text-[2.05rem] font-extrabold tracking-[-0.01em] text-[#192a49]">
+          <h2 className="m-0 text-[2.55rem] font-extrabold tracking-[-0.02em] text-[#172a4a]">
             통합 대시보드
           </h2>
-          <p className="mt-1 text-[1.05rem] text-[#62779d]">
+          <p className="mt-1.5 text-[1.2rem] leading-snug text-[#5e759f]">
             전사 5개 본부 · 프로젝트 원가/평가 현황
           </p>
         </div>
-        <span className="text-sm text-[#667ca4]">{now}</span>
+        <span className="text-[1.05rem] font-medium text-[#6780aa]">{now}</span>
       </header>
 
       <section className="grid grid-cols-4 gap-4 max-[1280px]:grid-cols-2">
-        <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#2f67e3] text-xl text-white">
+        <article className="rounded-3xl border border-[#d7e0f0] bg-white px-6 py-5 shadow-[0_10px_24px_rgba(13,28,58,0.07)]">
+          <span className="inline-grid h-14 w-14 place-items-center rounded-2xl bg-[#356ee6] text-2xl text-white">
             ▦
           </span>
-          <strong className="mt-3 block text-[2.15rem] font-extrabold text-[#172747]">
+          <strong className="mt-4 block text-[3rem] font-extrabold leading-none text-[#172a4a]">
             {portfolio.overview.headquarterCount}
           </strong>
-          <span className="block text-[1.02rem] font-semibold text-[#536c96]">
+          <span className="mt-2 block text-[1.3rem] font-bold text-[#526b96]">
             운영 본부
           </span>
-          <p className="mt-1 text-[0.9rem] text-[#8092b1]">5개 본부 가동중</p>
+          <p className="mt-1 text-[1.02rem] text-[#8396b6]">5개 본부 가동중</p>
         </article>
-        <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#17a8c8] text-xl text-white">
+        <article className="rounded-3xl border border-[#d7e0f0] bg-white px-6 py-5 shadow-[0_10px_24px_rgba(13,28,58,0.07)]">
+          <span className="inline-grid h-14 w-14 place-items-center rounded-2xl bg-[#1ba8c7] text-2xl text-white">
             ⊞
           </span>
-          <strong className="mt-3 block text-[2.15rem] font-extrabold text-[#172747]">
+          <strong className="mt-4 block text-[3rem] font-extrabold leading-none text-[#172a4a]">
             {portfolio.overview.projectCount}
           </strong>
-          <span className="block text-[1.02rem] font-semibold text-[#536c96]">
+          <span className="mt-2 block text-[1.3rem] font-bold text-[#526b96]">
             활성 프로젝트
           </span>
-          <p className="mt-1 text-[0.9rem] text-[#8092b1]">
+          <p className="mt-1 text-[1.02rem] text-[#8396b6]">
             총 20여개 동시 운영
           </p>
         </article>
-        <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#22b659] text-xl text-white">
+        <article className="rounded-3xl border border-[#d7e0f0] bg-white px-6 py-5 shadow-[0_10px_24px_rgba(13,28,58,0.07)]">
+          <span className="inline-grid h-14 w-14 place-items-center rounded-2xl bg-[#23b45e] text-2xl text-white">
             ⛁
           </span>
-          <strong className="mt-3 block text-[2.15rem] font-extrabold text-[#172747]">
+          <strong className="mt-4 block text-[3rem] font-extrabold leading-none text-[#172a4a]">
             {formatKrwCompact(portfolio.overview.totalInvestmentKrw)}
           </strong>
-          <span className="block text-[1.02rem] font-semibold text-[#536c96]">
+          <span className="mt-2 block text-[1.3rem] font-bold text-[#526b96]">
             총 예산
           </span>
-          <p className="mt-1 text-[0.9rem] text-[#8092b1]">
+          <p className="mt-1 text-[1.02rem] text-[#8396b6]">
             집행: {formatKrwCompact(portfolio.overview.totalExpectedRevenueKrw)}
           </p>
         </article>
-        <article className="rounded-2xl border border-cw-cardBorder bg-white px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-          <span className="inline-grid h-12 w-12 place-items-center rounded-xl bg-[#ef3b45] text-xl text-white">
+        <article className="rounded-3xl border border-[#d7e0f0] bg-white px-6 py-5 shadow-[0_10px_24px_rgba(13,28,58,0.07)]">
+          <span className="inline-grid h-14 w-14 place-items-center rounded-2xl bg-[#ef3b45] text-2xl text-white">
             ⚠
           </span>
-          <strong className="mt-3 block text-[2.15rem] font-extrabold text-[#172747]">
+          <strong className="mt-4 block text-[3rem] font-extrabold leading-none text-[#172a4a]">
             {portfolio.overview.conditionalCount}
           </strong>
-          <span className="block text-[1.02rem] font-semibold text-[#536c96]">
+          <span className="mt-2 block text-[1.3rem] font-bold text-[#526b96]">
             미확인 경보
           </span>
-          <p className="mt-1 text-[0.9rem] text-[#8092b1]">클릭하여 확인</p>
+          <p className="mt-1 text-[1.02rem] text-[#8396b6]">클릭하여 확인</p>
         </article>
       </section>
 
       <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
         <Panel title="본부별 예산 vs 집행">
-          <div className="mb-3 flex items-center justify-center gap-5 text-sm font-semibold text-[#5e739a]">
+          <div className="mb-4 flex justify-center gap-6 text-[1rem] font-semibold text-[#5e759f]">
             <span className="inline-flex items-center gap-2">
-              <span className="h-3 w-8 rounded bg-[#3f79ea]" />
-              예산
+              <span className="h-3.5 w-10 rounded bg-[#3f79ea]" /> 예산
             </span>
             <span className="inline-flex items-center gap-2">
-              <span className="h-3 w-8 rounded bg-[#17acc8]" />
-              집행
+              <span className="h-3.5 w-10 rounded bg-[#1ba8c7]" /> 집행
             </span>
           </div>
-          <div className="grid gap-3">
+          <div className="grid gap-3.5">
             {orderedHeadquarters.map((headquarter) => {
               const budgetWidth = Math.max(
-                3,
-                Math.round(
-                  (headquarter.totalInvestmentKrw / totalInvestment) * 100
-                )
+                4,
+                Math.round((headquarter.totalInvestmentKrw / maxBudget) * 100)
               );
               const expenseWidth = Math.max(
-                3,
+                4,
                 Math.round(
-                  (headquarter.totalExpectedRevenueKrw / totalInvestment) * 100
+                  (headquarter.totalExpectedRevenueKrw / maxBudget) * 100
                 )
               );
               return (
                 <article key={headquarter.code} className="grid gap-1.5">
-                  <div className="flex items-center justify-between text-[0.88rem] text-[#5f7399]">
-                    <strong className="text-[#1d2c4d]">
+                  <div className="flex items-center justify-between text-[1rem] text-[#5d759f]">
+                    <strong className="text-[1.2rem] text-[#1a2f53]">
                       {headquarter.name}
                     </strong>
                     <span>
@@ -203,16 +219,16 @@ export function DashboardView({
                       {formatKrwCompact(headquarter.totalExpectedRevenueKrw)}
                     </span>
                   </div>
-                  <div className="grid gap-1">
-                    <div className="h-2.5 overflow-hidden rounded-full bg-[#edf2fa]">
+                  <div className="grid gap-1.5">
+                    <div className="h-3 overflow-hidden rounded-full bg-[#e8eef8]">
                       <span
                         className="block h-full rounded-full bg-[#3f79ea]"
                         style={{ width: `${budgetWidth}%` }}
                       />
                     </div>
-                    <div className="h-2.5 overflow-hidden rounded-full bg-[#edf2fa]">
+                    <div className="h-3 overflow-hidden rounded-full bg-[#e8eef8]">
                       <span
-                        className="block h-full rounded-full bg-[#17acc8]"
+                        className="block h-full rounded-full bg-[#1ba8c7]"
                         style={{ width: `${expenseWidth}%` }}
                       />
                     </div>
@@ -224,33 +240,29 @@ export function DashboardView({
         </Panel>
 
         <Panel title="리스크 분포">
-          <div className="grid place-items-center gap-3 py-2">
+          <div className="grid place-items-center gap-4 py-3">
             <div
-              className="relative h-[270px] w-[270px] rounded-full after:absolute after:inset-[68px] after:rounded-full after:bg-white after:content-['']"
+              className="relative h-[280px] w-[280px] rounded-full after:absolute after:inset-[68px] after:rounded-full after:bg-white after:shadow-[inset_0_0_0_1px_#e4ebf8] after:content-['']"
               style={{
                 background: `conic-gradient(
                   #e52f2f 0% ${(riskCounts.high / riskTotal) * 100}%,
-                  #fa7a15 ${(riskCounts.high / riskTotal) * 100}% ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}%,
+                  #f67a13 ${(riskCounts.high / riskTotal) * 100}% ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}%,
                   #24be62 ${((riskCounts.high + riskCounts.mid) / riskTotal) * 100}% 100%
                 )`
               }}
             />
-            <div className="flex flex-wrap items-center justify-center gap-3 text-sm font-semibold text-[#63779f]">
+            <div className="flex flex-wrap items-center justify-center gap-3 text-[1.02rem] font-semibold text-[#5f749d]">
               <span className="inline-flex items-center gap-1.5">
-                <span className="h-2.5 w-6 rounded bg-[#e52f2f]" />
-                CRITICAL
+                <span className="h-3 w-8 rounded bg-[#e52f2f]" /> CRITICAL
               </span>
               <span className="inline-flex items-center gap-1.5">
-                <span className="h-2.5 w-6 rounded bg-[#fa7a15]" />
-                HIGH
+                <span className="h-3 w-8 rounded bg-[#f67a13]" /> HIGH
               </span>
               <span className="inline-flex items-center gap-1.5">
-                <span className="h-2.5 w-6 rounded bg-[#f0a20b]" />
-                MEDIUM
+                <span className="h-3 w-8 rounded bg-[#f0a20b]" /> MEDIUM
               </span>
               <span className="inline-flex items-center gap-1.5">
-                <span className="h-2.5 w-6 rounded bg-[#24be62]" />
-                LOW
+                <span className="h-3 w-8 rounded bg-[#24be62]" /> LOW
               </span>
             </div>
           </div>
@@ -259,61 +271,103 @@ export function DashboardView({
 
       <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
         <Panel title="월별 원가 추이 (실적 vs 표준)">
-          <div className="overflow-hidden rounded-xl border border-[#dbe4f2] bg-[#f9fbff]">
-            <table className="min-w-full text-sm">
-              <thead className="bg-[#eef3fb] text-[#5b7097]">
-                <tr>
-                  <th className="px-4 py-3 text-left">월</th>
-                  <th className="px-4 py-3 text-left">실제원가</th>
-                  <th className="px-4 py-3 text-left">표준원가</th>
-                  <th className="px-4 py-3 text-left">차이율</th>
-                </tr>
-              </thead>
-              <tbody>
-                {monthlyTrend.map((item) => {
-                  const diffRate =
-                    item.standard === 0
-                      ? 0
-                      : (item.actual - item.standard) / item.standard;
-                  return (
-                    <tr key={item.month} className="border-t border-[#e6edf8]">
-                      <td className="px-4 py-3 font-semibold text-[#1f3458]">
-                        {item.month}
-                      </td>
-                      <td className="px-4 py-3 text-[#2d446b]">
-                        {item.actual.toFixed(1)}억
-                      </td>
-                      <td className="px-4 py-3 text-[#2d446b]">
-                        {item.standard.toFixed(1)}억
-                      </td>
-                      <td
-                        className={`px-4 py-3 font-semibold ${
-                          diffRate > 0 ? 'text-[#db3a3a]' : 'text-[#1b9a62]'
-                        }`}
-                      >
-                        {formatPercent(diffRate)}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+          <div className="mb-3 flex items-center justify-center gap-5 text-[1rem] font-semibold text-[#5f749d]">
+            <span className="inline-flex items-center gap-2">
+              <span className="h-[3px] w-10 rounded bg-[#2f57d8]" />
+              실제원가
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <span className="h-[3px] w-10 rounded border-2 border-dashed border-[#16a268]" />
+              표준원가
+            </span>
+          </div>
+          <div className="rounded-2xl border border-[#dce5f4] bg-[#f9fbff] p-4">
+            <svg
+              viewBox={`0 0 ${chartWidth} ${chartHeight + 36}`}
+              className="w-full"
+            >
+              <line
+                x1="0"
+                y1={chartHeight}
+                x2={chartWidth}
+                y2={chartHeight}
+                stroke="#d3dded"
+                strokeWidth="1"
+              />
+              <line
+                x1="0"
+                y1={chartHeight * 0.66}
+                x2={chartWidth}
+                y2={chartHeight * 0.66}
+                stroke="#e2e9f5"
+                strokeWidth="1"
+              />
+              <line
+                x1="0"
+                y1={chartHeight * 0.33}
+                x2={chartWidth}
+                y2={chartHeight * 0.33}
+                stroke="#e2e9f5"
+                strokeWidth="1"
+              />
+              <polyline
+                points={actualPoints}
+                fill="none"
+                stroke="#2f57d8"
+                strokeWidth="4"
+              />
+              <polyline
+                points={standardPoints}
+                fill="none"
+                stroke="#16a268"
+                strokeWidth="4"
+                strokeDasharray="10 8"
+              />
+              {monthlyTrend.map((point, index) => {
+                const x = index * xStep;
+                const yActual =
+                  chartHeight -
+                  ((point.actual - minTrend) / trendRange) * chartHeight;
+                const yStandard =
+                  chartHeight -
+                  ((point.standard - minTrend) / trendRange) * chartHeight;
+                return (
+                  <g key={point.month}>
+                    <circle cx={x} cy={yActual} r="5.5" fill="#2f57d8" />
+                    <circle cx={x} cy={yStandard} r="5.5" fill="#16a268" />
+                    <text
+                      x={x}
+                      y={chartHeight + 28}
+                      textAnchor="middle"
+                      fontSize="14"
+                      fill="#62779d"
+                    >
+                      {point.month}
+                    </text>
+                  </g>
+                );
+              })}
+            </svg>
           </div>
         </Panel>
 
         <Panel title="유형별 예산">
-          <div className="grid gap-2">
+          <div className="grid gap-3">
             {categoryBudgets.map((item) => (
-              <article key={item.label} className="grid gap-1">
-                <div className="flex items-center justify-between text-[0.86rem] text-[#5f7399]">
-                  <strong className="text-[#1e2f4c]">{item.label}</strong>
+              <article
+                key={item.label}
+                className="grid gap-1.5 rounded-xl border border-[#e0e8f5] bg-[#f9fbff] px-3 py-2.5"
+              >
+                <div className="flex items-center justify-between text-[0.95rem] text-[#5f759f]">
+                  <strong className="text-[#1f3359]">{item.label}</strong>
                   <span>{item.value.toFixed(1)}억</span>
                 </div>
-                <div className="h-2.5 overflow-hidden rounded-full bg-[#eaf0f9]">
+                <div className="h-2.5 overflow-hidden rounded-full bg-[#e4ebf6]">
                   <span
-                    className="block h-full rounded-full bg-[linear-gradient(90deg,#3f79ea,#17acc8)]"
+                    className="block h-full rounded-full"
                     style={{
-                      width: `${Math.round((item.value / maxCategoryBudget) * 100)}%`
+                      width: `${Math.round((item.value / maxCategoryBudget) * 100)}%`,
+                      background: item.color
                     }}
                   />
                 </div>
@@ -324,99 +378,71 @@ export function DashboardView({
       </section>
 
       <section className="grid grid-cols-[2fr_1fr] gap-4 max-[1280px]:grid-cols-1">
-        <Panel title="본부별 현황">
-          <div className="overflow-hidden rounded-xl border border-[#dbe4f2] bg-white">
-            <table className="min-w-full text-sm">
-              <thead className="bg-[#eef3fb] text-[#5b7097]">
-                <tr>
-                  <th className="px-4 py-3 text-left">코드</th>
-                  <th className="px-4 py-3 text-left">본부</th>
-                  <th className="px-4 py-3 text-left">프로젝트</th>
-                  <th className="px-4 py-3 text-left">예산</th>
-                  <th className="px-4 py-3 text-left">집행</th>
-                  <th className="px-4 py-3 text-left">집행률</th>
-                </tr>
-              </thead>
-              <tbody>
-                {orderedHeadquarters.map((headquarter) => {
-                  const runRate =
-                    headquarter.totalInvestmentKrw === 0
-                      ? 0
-                      : headquarter.totalExpectedRevenueKrw /
-                        headquarter.totalInvestmentKrw;
-                  return (
-                    <tr
-                      key={headquarter.code}
-                      className="border-t border-[#e6edf8]"
-                    >
-                      <td className="px-4 py-3 font-semibold text-[#22375d]">
-                        {headquarter.code.replace('HQ', 'DIV-')}
-                      </td>
-                      <td className="px-4 py-3 text-[#22375d]">
-                        {headquarter.name}
-                      </td>
-                      <td className="px-4 py-3 text-[#2b3f63]">
-                        {headquarter.projectCount}
-                      </td>
-                      <td className="px-4 py-3 text-[#2b3f63]">
-                        {formatKrwCompact(headquarter.totalInvestmentKrw)}
-                      </td>
-                      <td className="px-4 py-3 text-[#2b3f63]">
-                        {formatKrwCompact(headquarter.totalExpectedRevenueKrw)}
-                      </td>
-                      <td
-                        className={`px-4 py-3 font-bold ${
-                          runRate > 0.9 ? 'text-[#d73333]' : 'text-[#16955f]'
-                        }`}
-                      >
-                        {formatPercent(runRate)}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </Panel>
-
         <Panel title="최근 평가">
-          <div className="grid max-h-[440px] gap-2 overflow-y-auto pr-1">
-            {recentReviews.map((project) => (
+          <div className="grid max-h-[360px] gap-2.5 overflow-y-auto pr-1">
+            {quickFocus.map((project) => (
               <article
                 key={project.code}
-                className="rounded-xl border border-[#dbe4f2] bg-[#f9fbff] px-3 py-2.5"
+                className="rounded-xl border border-[#dce5f4] bg-[#f9fbff] px-4 py-3"
               >
                 <span className="text-xs text-[#6b82aa]">
                   {project.code} · {project.assetCategory}
                 </span>
-                <strong className="mt-1 block text-[0.96rem] text-[#1e2f4c]">
+                <strong className="mt-1.5 block text-[1.03rem] text-[#1f3359]">
                   {project.name}
                 </strong>
-                <p className="mt-1 text-sm text-[#647ca5]">
+                <p className="mt-1 text-[0.94rem] text-[#657da6]">
                   NPV {formatKrwCompact(project.npvKrw)} · IRR{' '}
-                  {formatPercent(project.irr)} · {project.status}
+                  {formatPercent(project.irr)}
                 </p>
-                <div className="mt-2 flex gap-2">
-                  <button
-                    type="button"
-                    onClick={() => onOpenWorkspace('valuation', project.code)}
-                    className="rounded-lg border border-[#ccd7ea] bg-white px-2.5 py-1.5 text-xs font-semibold text-[#395078]"
-                  >
-                    평가 상세
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onOpenWorkspace('accounting', project.code)}
-                    className="rounded-lg border border-[#c7d4ea] bg-[#eef3fc] px-2.5 py-1.5 text-xs font-semibold text-[#2f57c8]"
-                  >
-                    원가 보기
-                  </button>
-                </div>
               </article>
             ))}
-            <article className="rounded-xl border border-[#dbe4f2] bg-[#f9fbff] px-3 py-2.5 text-sm text-[#62779d]">
+          </div>
+        </Panel>
+
+        <Panel title="다음 액션">
+          <article className="rounded-2xl border border-[#dce5f4] bg-[#f9fbff] px-4 py-3">
+            <strong className="text-[1.08rem] text-[#1f3359]">
+              {selectedInsight.decisionFocus}
+            </strong>
+            <p className="mt-2 text-[0.97rem] leading-relaxed text-[#5f759f]">
               {selectedInsight.nextAction}
-            </article>
+            </p>
+          </article>
+          <div className="mt-3 grid gap-2.5">
+            {decisionSignals.slice(0, 2).map((signal) => (
+              <article
+                key={signal.label}
+                className="rounded-xl border border-[#dce5f4] bg-white px-3 py-2.5 text-[0.93rem]"
+              >
+                <span className="text-[#6c82aa]">{signal.label}</span>
+                <strong className="mt-1 block text-[#1f3359]">
+                  {signal.value}
+                </strong>
+              </article>
+            ))}
+            {priorityProjects[0] ? (
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() =>
+                    onOpenWorkspace('accounting', priorityProjects[0].code)
+                  }
+                  className="rounded-lg border border-[#c7d4ea] bg-[#eef3fc] px-3 py-2 text-xs font-semibold text-[#2f57c8]"
+                >
+                  원가 보기
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    onOpenWorkspace('valuation', priorityProjects[0].code)
+                  }
+                  className="rounded-lg border border-[#ccd7ea] bg-white px-3 py-2 text-xs font-semibold text-[#395078]"
+                >
+                  가치평가
+                </button>
+              </div>
+            ) : null}
           </div>
         </Panel>
       </section>

--- a/frontend/src/views/dashboard/DashboardView.tsx
+++ b/frontend/src/views/dashboard/DashboardView.tsx
@@ -117,9 +117,6 @@ export function DashboardView({
           <h2 className="m-0 text-[2.05rem] font-extrabold tracking-[-0.015em] text-[#172a4a]">
             통합 대시보드
           </h2>
-          <p className="mt-1 text-[1.05rem] text-[#60759f]">
-            전사 5개 본부 · 프로젝트 원가/평가 현황
-          </p>
         </div>
         <span className="text-[1rem] text-[#667da8]">{now}</span>
       </header>

--- a/frontend/src/views/layout/TaskSidebar.tsx
+++ b/frontend/src/views/layout/TaskSidebar.tsx
@@ -52,17 +52,17 @@ export function TaskSidebar({
   const renderedSections = new Set<string>();
 
   return (
-    <aside className="min-h-screen w-[306px] border-r border-[#21345b] bg-[linear-gradient(180deg,#071227_0%,#0b1c3f_52%,#102652_100%)] px-4 pb-6 pt-5 shadow-[8px_0_26px_rgba(4,8,22,0.35)]">
-      <div className="mb-6 rounded-2xl border border-[#355487] bg-[linear-gradient(140deg,rgba(22,40,84,0.96),rgba(14,29,62,0.92))] px-4 py-3.5 shadow-[0_10px_20px_rgba(4,12,34,0.28)]">
+    <aside className="min-h-screen w-[292px] shrink-0 overflow-x-hidden border-r border-[#1b2f52] bg-[linear-gradient(180deg,#08162f_0%,#0a1c3a_70%,#0b2146_100%)] px-4 pb-6 pt-5">
+      <div className="mb-6 rounded-2xl border border-[#2e4671] bg-[linear-gradient(140deg,rgba(16,32,68,0.96),rgba(12,26,56,0.94))] px-4 py-3.5">
         <div className="flex items-center gap-3">
-          <div className="grid h-[46px] w-[46px] place-items-center rounded-xl bg-[linear-gradient(135deg,#2b68e4,#1bb3db)] text-base font-extrabold text-white shadow-[0_8px_16px_rgba(25,82,212,0.45)]">
+          <div className="grid h-[44px] w-[44px] place-items-center rounded-xl bg-[linear-gradient(135deg,#2a67e0,#1ba9d4)] text-[0.98rem] font-extrabold text-white">
             CW
           </div>
           <div className="min-w-0">
-            <strong className="block text-[1.2rem] font-extrabold leading-tight tracking-[0.01em] text-white">
+            <strong className="block text-[1.15rem] font-extrabold leading-tight tracking-[0.005em] text-white">
               CostWise
             </strong>
-            <p className="m-0 mt-1 text-[0.76rem] font-semibold tracking-[0.04em] text-[#9eb5de]">
+            <p className="m-0 mt-1 text-[0.74rem] font-semibold tracking-[0.03em] text-[#9bb2db]">
               원가·평가 통합관리
             </p>
           </div>
@@ -80,20 +80,20 @@ export function TaskSidebar({
           return (
             <div key={item.key}>
               {showSection ? (
-                <p className="mb-2 ml-2.5 mr-2 mt-5 text-[0.69rem] font-extrabold tracking-[0.16em] text-[#809ac8]">
+                <p className="mb-2 ml-2.5 mr-2 mt-5 text-[0.68rem] font-extrabold tracking-[0.12em] text-[#7f98c6]">
                   {section}
                 </p>
               ) : null}
               <button
                 type="button"
-                className={`flex w-full items-center gap-3 rounded-2xl border px-4 py-[0.7rem] text-left text-[0.93rem] font-semibold tracking-[0.01em] transition-all duration-150 ${
+                className={`flex w-full items-center gap-3 rounded-2xl border px-4 py-[0.66rem] text-left text-[0.91rem] font-semibold tracking-[0.005em] transition-all duration-150 ${
                   activeView === item.key
-                    ? 'border-[#5480ec] bg-[linear-gradient(96deg,#2a64de_0%,#1da8d1_100%)] text-white shadow-[0_10px_20px_rgba(20,71,188,0.33)]'
-                    : 'border-transparent text-[#c8d6ee] hover:border-white/15 hover:bg-white/[0.07] hover:text-white'
+                    ? 'border-[#4f78dc] bg-[linear-gradient(96deg,#2b63d7_0%,#239cca_100%)] text-white shadow-[0_4px_10px_rgba(13,53,146,0.24)]'
+                    : 'border-transparent text-[#c8d5ec] hover:border-white/10 hover:bg-white/[0.06] hover:text-white'
                 }`}
                 onClick={() => onChangeView(item.key)}
               >
-                <span className="inline-block w-5 text-center text-[0.88rem] opacity-95">
+                <span className="inline-block w-5 text-center text-[0.86rem] opacity-95">
                   {iconByKey[item.key] ?? '•'}
                 </span>
                 <span className="leading-none">{item.label}</span>

--- a/frontend/src/views/layout/TaskSidebar.tsx
+++ b/frontend/src/views/layout/TaskSidebar.tsx
@@ -52,18 +52,20 @@ export function TaskSidebar({
   const renderedSections = new Set<string>();
 
   return (
-    <aside className="min-h-screen w-[320px] border-r border-[rgba(136,153,196,0.2)] bg-[linear-gradient(180deg,#0a1433_0%,#1f1b67_58%,#2a2a78_100%)] px-3 pb-4 pt-5 shadow-cw-sidebar">
-      <div className="mb-[18px] ml-3 mr-2 flex items-center gap-3">
-        <div className="grid h-[42px] w-[42px] place-items-center rounded-[11px] bg-[linear-gradient(135deg,#2d68e4,#19b2db)] text-base font-extrabold text-white">
-          CW
-        </div>
-        <div>
-          <strong className="text-[2.65rem] font-bold leading-none tracking-[-0.02em] text-white">
-            CostWise
-          </strong>
-          <p className="m-0 mt-0.5 text-[0.88rem] text-[#8fa7d3]">
-            원가·평가 통합관리
-          </p>
+    <aside className="min-h-screen w-[306px] border-r border-[#21345b] bg-[linear-gradient(180deg,#071227_0%,#0b1c3f_52%,#102652_100%)] px-4 pb-6 pt-5 shadow-[8px_0_26px_rgba(4,8,22,0.35)]">
+      <div className="mb-6 rounded-2xl border border-[#355487] bg-[linear-gradient(140deg,rgba(22,40,84,0.96),rgba(14,29,62,0.92))] px-4 py-3.5 shadow-[0_10px_20px_rgba(4,12,34,0.28)]">
+        <div className="flex items-center gap-3">
+          <div className="grid h-[46px] w-[46px] place-items-center rounded-xl bg-[linear-gradient(135deg,#2b68e4,#1bb3db)] text-base font-extrabold text-white shadow-[0_8px_16px_rgba(25,82,212,0.45)]">
+            CW
+          </div>
+          <div className="min-w-0">
+            <strong className="block text-[1.2rem] font-extrabold leading-tight tracking-[0.01em] text-white">
+              CostWise
+            </strong>
+            <p className="m-0 mt-1 text-[0.76rem] font-semibold tracking-[0.04em] text-[#9eb5de]">
+              원가·평가 통합관리
+            </p>
+          </div>
         </div>
       </div>
 
@@ -78,23 +80,23 @@ export function TaskSidebar({
           return (
             <div key={item.key}>
               {showSection ? (
-                <p className="mb-1.5 ml-2.5 mr-2.5 mt-3.5 text-[0.78rem] font-extrabold tracking-[0.08em] text-[#6f84b1]">
+                <p className="mb-2 ml-2.5 mr-2 mt-5 text-[0.69rem] font-extrabold tracking-[0.16em] text-[#809ac8]">
                   {section}
                 </p>
               ) : null}
               <button
                 type="button"
-                className={`flex w-full items-center gap-3 rounded-xl border-0 bg-transparent px-4 py-3 text-left text-[1.02rem] font-semibold transition-colors ${
+                className={`flex w-full items-center gap-3 rounded-2xl border px-4 py-[0.7rem] text-left text-[0.93rem] font-semibold tracking-[0.01em] transition-all duration-150 ${
                   activeView === item.key
-                    ? 'bg-[linear-gradient(90deg,#2666e2_0%,#1ab3dc_100%)] text-white shadow-[0_8px_18px_rgba(27,88,220,0.26)]'
-                    : 'text-[#cbd5e1] hover:bg-white/10 hover:text-white'
+                    ? 'border-[#5480ec] bg-[linear-gradient(96deg,#2a64de_0%,#1da8d1_100%)] text-white shadow-[0_10px_20px_rgba(20,71,188,0.33)]'
+                    : 'border-transparent text-[#c8d6ee] hover:border-white/15 hover:bg-white/[0.07] hover:text-white'
                 }`}
                 onClick={() => onChangeView(item.key)}
               >
-                <span className="inline-block w-5 text-center opacity-95">
+                <span className="inline-block w-5 text-center text-[0.88rem] opacity-95">
                   {iconByKey[item.key] ?? '•'}
                 </span>
-                <span>{item.label}</span>
+                <span className="leading-none">{item.label}</span>
               </button>
             </div>
           );

--- a/frontend/src/views/layout/TaskTopbar.tsx
+++ b/frontend/src/views/layout/TaskTopbar.tsx
@@ -42,26 +42,26 @@ export function TaskTopbar({
   const pendingCount = Math.max(0, conditionalCount);
 
   return (
-    <header className="sticky top-0 z-10 flex min-h-[72px] items-center justify-between gap-4 border-b border-[#d7deea] bg-[linear-gradient(180deg,#f6f8fc_0%,#eef3fa_100%)] px-5 py-3 shadow-[0_1px_0_rgba(12,26,56,0.02)] backdrop-blur">
+    <header className="sticky top-0 z-10 flex min-h-[68px] items-center justify-between gap-4 border-b border-[#d9e1ee] bg-[#f3f7fc] px-5 py-2.5">
       <div className="flex items-center pl-0.5">
-        <p className="m-0 text-[0.76rem] font-extrabold tracking-[0.1em] text-[#6e81a6]">
+        <p className="m-0 text-[0.74rem] font-extrabold tracking-[0.06em] text-[#6e82a8]">
           {meta.eyebrow}
         </p>
       </div>
 
-      <div className="flex items-center gap-2.5">
-        <span className="rounded-full border border-[#cfd8e8] bg-white px-3 py-1.5 text-[0.74rem] font-bold tracking-[0.02em] text-[#4b628c] shadow-[0_1px_2px_rgba(21,34,67,0.05)]">
+      <div className="flex items-center gap-2">
+        <span className="rounded-full border border-[#ced8e8] bg-white px-3 py-1.5 text-[0.73rem] font-bold tracking-[0.01em] text-[#4e658f]">
           {source === 'api'
             ? `CostWise API 정상 연결 · ${projectCount}개 프로젝트`
             : `CostWise API 일부 제한 · ${projectCount}개 프로젝트`}
         </span>
         {divisionScope ? (
-          <label className="inline-flex items-center gap-2 rounded-full border border-[#cfd8e8] bg-white px-3 py-1.5 shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
-            <span className="text-[0.72rem] font-extrabold tracking-[0.04em] text-cw-muted">
+          <label className="inline-flex items-center gap-2 rounded-full border border-[#ced8e8] bg-white px-3 py-1.5">
+            <span className="text-[0.71rem] font-extrabold tracking-[0.03em] text-cw-muted">
               본부 범위
             </span>
             <select
-              className="rounded-lg border border-slate-300 bg-white px-2 py-1 text-[0.83rem] text-[#1e2f4c]"
+              className="rounded-lg border border-slate-300 bg-white px-2 py-1 text-[0.81rem] text-[#1e2f4c]"
               value={divisionScope}
               onChange={(event) => onChangeDivision(event.target.value)}
             >
@@ -73,29 +73,29 @@ export function TaskTopbar({
             </select>
           </label>
         ) : null}
-        <div className="flex items-center gap-2.5 rounded-full border border-[#d3dae9] bg-white px-2.5 py-1.5 shadow-[0_1px_2px_rgba(15,23,42,0.05)]">
+        <div className="flex items-center gap-2 rounded-full border border-[#d3dae9] bg-white px-2.5 py-1.5">
           <span
-            className="grid h-[18px] min-w-[18px] place-items-center rounded-full bg-[#e53935] px-1 text-[0.66rem] font-extrabold leading-none text-white ring-2 ring-white"
+            className="grid h-[18px] min-w-[18px] place-items-center rounded-full bg-[#e53935] px-1 text-[0.64rem] font-extrabold leading-none text-white ring-2 ring-white"
             aria-label={`알림 ${pendingCount}건`}
           >
             {pendingCount}
           </span>
-          <div className="grid h-[32px] w-[32px] place-items-center rounded-full bg-[linear-gradient(135deg,#2f67e3,#23b3db)] text-[0.82rem] font-extrabold text-white">
+          <div className="grid h-[31px] w-[31px] place-items-center rounded-full bg-[linear-gradient(135deg,#2f67e3,#25afd7)] text-[0.8rem] font-extrabold text-white">
             {username.charAt(0)}
           </div>
           <div className="pr-1">
-            <strong className="block text-[0.81rem] leading-tight text-[#182844]">
+            <strong className="block text-[0.8rem] leading-tight text-[#182844]">
               {username}
             </strong>
-            <small className="block text-[0.72rem] tracking-[0.02em] text-[#63769b]">
+            <small className="block text-[0.71rem] tracking-[0.01em] text-[#63769b]">
               {getRoleLabel(selectedRole)}
             </small>
           </div>
-          <span className="whitespace-nowrap border-l border-[#e1e6f0] pl-2 text-[0.74rem] text-[#63779f]">
+          <span className="whitespace-nowrap border-l border-[#e1e6f0] pl-2 text-[0.73rem] text-[#63779f]">
             {now}
           </span>
           <button
-            className="whitespace-nowrap rounded-full border border-[#cbd5e6] bg-[#f7f9fc] px-2.5 py-1 text-[0.74rem] font-bold text-[#4f6289] transition-colors hover:bg-[#edf2f9]"
+            className="whitespace-nowrap rounded-full border border-[#cbd5e6] bg-[#f7f9fc] px-2.5 py-1 text-[0.72rem] font-bold text-[#4f6289] transition-colors hover:bg-[#edf2f9]"
             type="button"
             onClick={onLogout}
           >

--- a/frontend/src/views/layout/TaskTopbar.tsx
+++ b/frontend/src/views/layout/TaskTopbar.tsx
@@ -42,24 +42,26 @@ export function TaskTopbar({
   const pendingCount = Math.max(0, conditionalCount);
 
   return (
-    <header className="sticky top-0 z-10 flex min-h-[72px] items-center justify-between gap-3 border-b border-[#d4dceb] bg-[#f8fbff] px-5 py-3">
-      <div className="flex items-center">
-        <p className="m-0 text-[0.95rem] font-bold text-[#6c7e9f]">
+    <header className="sticky top-0 z-10 flex min-h-[72px] items-center justify-between gap-4 border-b border-[#d7deea] bg-[linear-gradient(180deg,#f6f8fc_0%,#eef3fa_100%)] px-5 py-3 shadow-[0_1px_0_rgba(12,26,56,0.02)] backdrop-blur">
+      <div className="flex items-center pl-0.5">
+        <p className="m-0 text-[0.76rem] font-extrabold tracking-[0.1em] text-[#6e81a6]">
           {meta.eyebrow}
         </p>
       </div>
 
       <div className="flex items-center gap-2.5">
-        <span className="rounded-full border border-[#d8e0ef] bg-[#eff4fb] px-3 py-1.5 text-[0.8rem] font-bold text-[#556a93]">
+        <span className="rounded-full border border-[#cfd8e8] bg-white px-3 py-1.5 text-[0.74rem] font-bold tracking-[0.02em] text-[#4b628c] shadow-[0_1px_2px_rgba(21,34,67,0.05)]">
           {source === 'api'
             ? `CostWise API 정상 연결 · ${projectCount}개 프로젝트`
             : `CostWise API 일부 제한 · ${projectCount}개 프로젝트`}
         </span>
         {divisionScope ? (
-          <label className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1">
-            <span className="text-xs font-bold text-cw-muted">본부 범위</span>
+          <label className="inline-flex items-center gap-2 rounded-full border border-[#cfd8e8] bg-white px-3 py-1.5 shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
+            <span className="text-[0.72rem] font-extrabold tracking-[0.04em] text-cw-muted">
+              본부 범위
+            </span>
             <select
-              className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-sm"
+              className="rounded-lg border border-slate-300 bg-white px-2 py-1 text-[0.83rem] text-[#1e2f4c]"
               value={divisionScope}
               onChange={(event) => onChangeDivision(event.target.value)}
             >
@@ -71,27 +73,29 @@ export function TaskTopbar({
             </select>
           </label>
         ) : null}
-        <div className="flex items-center gap-2.5">
+        <div className="flex items-center gap-2.5 rounded-full border border-[#d3dae9] bg-white px-2.5 py-1.5 shadow-[0_1px_2px_rgba(15,23,42,0.05)]">
           <span
-            className="grid h-5 w-5 place-items-center rounded-full bg-[#ef4444] text-[0.72rem] font-extrabold text-white"
+            className="grid h-[18px] min-w-[18px] place-items-center rounded-full bg-[#e53935] px-1 text-[0.66rem] font-extrabold leading-none text-white ring-2 ring-white"
             aria-label={`알림 ${pendingCount}건`}
           >
             {pendingCount}
           </span>
-          <div className="grid h-[34px] w-[34px] place-items-center rounded-full bg-[linear-gradient(135deg,#2f67e3,#23b3db)] font-extrabold text-white">
+          <div className="grid h-[32px] w-[32px] place-items-center rounded-full bg-[linear-gradient(135deg,#2f67e3,#23b3db)] text-[0.82rem] font-extrabold text-white">
             {username.charAt(0)}
           </div>
-          <div>
-            <strong className="block text-[0.84rem] text-[#182844]">
+          <div className="pr-1">
+            <strong className="block text-[0.81rem] leading-tight text-[#182844]">
               {username}
             </strong>
-            <small className="block text-[0.76rem] tracking-[0.02em] text-[#62759a]">
+            <small className="block text-[0.72rem] tracking-[0.02em] text-[#63769b]">
               {getRoleLabel(selectedRole)}
             </small>
           </div>
-          <span className="text-[0.8rem] text-[#6c7e9f]">{now}</span>
+          <span className="whitespace-nowrap border-l border-[#e1e6f0] pl-2 text-[0.74rem] text-[#63779f]">
+            {now}
+          </span>
           <button
-            className="border-0 bg-transparent text-[0.8rem] font-bold text-[#4c5f85]"
+            className="whitespace-nowrap rounded-full border border-[#cbd5e6] bg-[#f7f9fc] px-2.5 py-1 text-[0.74rem] font-bold text-[#4f6289] transition-colors hover:bg-[#edf2f9]"
             type="button"
             onClick={onLogout}
           >

--- a/frontend/src/views/portfolio/PortfolioView.tsx
+++ b/frontend/src/views/portfolio/PortfolioView.tsx
@@ -1057,17 +1057,21 @@ export function PortfolioView({
   }
 
   const actionButtonBaseClass =
-    'inline-flex h-10 items-center justify-center rounded-md border px-3 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-45';
-  const secondaryActionButtonClass = `${actionButtonBaseClass} border-slate-300 bg-white text-slate-700 hover:border-slate-400 hover:bg-slate-50`;
-  const primaryActionButtonClass = `${actionButtonBaseClass} border-blue-700 bg-blue-700 text-white hover:bg-blue-600`;
+    'inline-flex h-10 items-center justify-center rounded-lg border px-3.5 text-sm font-semibold tracking-tight transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-45';
+  const secondaryActionButtonClass = `${actionButtonBaseClass} border-slate-300 bg-white text-slate-700 shadow-sm hover:border-slate-400 hover:bg-slate-50`;
+  const primaryActionButtonClass = `${actionButtonBaseClass} border-blue-700 bg-blue-700 text-white shadow-sm hover:bg-blue-600`;
   const controlSurfaceClass =
-    'h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-700 shadow-sm outline-none transition placeholder:text-slate-400 focus:border-slate-500 focus:ring-2 focus:ring-slate-200';
+    'h-10 w-full rounded-lg border border-slate-300 bg-white px-3 text-sm text-slate-700 shadow-sm outline-none transition placeholder:text-slate-400 focus:border-slate-500 focus:ring-2 focus:ring-slate-200';
   const stateBoxClass =
     'grid gap-2 rounded-lg border border-slate-200 bg-slate-50 p-4';
   const stateButtonClass =
     'inline-flex h-9 items-center rounded-md border border-slate-300 bg-white px-3 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100';
   const statusPillBaseClass =
-    'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold';
+    'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold leading-none';
+  const filterGroupClass =
+    'grid gap-2 rounded-xl border border-slate-200 bg-white/90 p-3';
+  const filterPillBaseClass =
+    'inline-flex h-8 items-center rounded-full border px-3 text-xs font-medium transition';
   const projectFormClass = 'mt-4 grid gap-4';
   const projectFormGridClass = 'grid gap-3 sm:grid-cols-2';
   const projectFormFieldClass =
@@ -1235,47 +1239,24 @@ export function PortfolioView({
         ) : null}
 
         {!isErrorWithoutData && !isLoadingWithoutData ? (
-          <div className="rounded-xl border border-slate-200 bg-gradient-to-b from-slate-50 to-white p-4 shadow-sm sm:p-5">
-            <div className="flex flex-col gap-4 border-b border-slate-200 pb-4 lg:flex-row lg:items-start lg:justify-between">
-              <div className="max-w-2xl space-y-2">
+          <div className="rounded-2xl border border-slate-200 bg-gradient-to-b from-white via-slate-50/65 to-white p-4 shadow-sm sm:p-5">
+            <div className="grid gap-4 border-b border-slate-200 pb-4 xl:grid-cols-[1fr_auto] xl:items-start">
+              <div className="space-y-2">
                 <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
-                  프로젝트 운영
+                  프로젝트 운영 센터
                 </p>
                 <h3 className="text-xl font-semibold tracking-tight text-slate-900">
                   프로젝트 목록
                 </h3>
-                <p className="text-sm leading-6 text-slate-600">
-                  이름/코드 검색과 상태·본부 필터로 운영 대상을 추린 뒤, 상세
-                  허브 또는 워크스페이스로 바로 진입합니다.
+                <p className="max-w-3xl text-sm leading-6 text-slate-600">
+                  검색과 다중 필터로 운영 후보를 좁힌 뒤, 상세 허브에서
+                  컨텍스트를 정리하고 분석 워크스페이스로 이동합니다.
                 </p>
               </div>
               <div
-                className="flex flex-wrap items-center gap-2.5"
+                className="grid gap-2 rounded-xl border border-slate-200 bg-white p-2.5 shadow-sm sm:grid-cols-2 xl:w-[26.5rem]"
                 aria-label="운영 액션"
               >
-                {isProjectWritable ? (
-                  <button
-                    type="button"
-                    className={secondaryActionButtonClass}
-                    onClick={handleExportCsv}
-                    disabled={displayedProjects.length === 0}
-                  >
-                    CSV 내보내기
-                  </button>
-                ) : null}
-                {isProjectWritable ? (
-                  <button
-                    type="button"
-                    className={primaryActionButtonClass}
-                    onClick={(event: ReactMouseEvent<HTMLButtonElement>) =>
-                      openProjectCreateModal(event.currentTarget)
-                    }
-                  >
-                    + 새 프로젝트
-                  </button>
-                ) : (
-                  <p className="text-xs text-slate-500">{writeAccessMessage}</p>
-                )}
                 <button
                   type="button"
                   className={primaryActionButtonClass}
@@ -1294,6 +1275,21 @@ export function PortfolioView({
                 {isProjectWritable ? (
                   <button
                     type="button"
+                    className={primaryActionButtonClass}
+                    onClick={(event: ReactMouseEvent<HTMLButtonElement>) =>
+                      openProjectCreateModal(event.currentTarget)
+                    }
+                  >
+                    + 새 프로젝트
+                  </button>
+                ) : (
+                  <span className="col-span-full rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-800">
+                    {writeAccessMessage}
+                  </span>
+                )}
+                {isProjectWritable ? (
+                  <button
+                    type="button"
                     className={secondaryActionButtonClass}
                     onClick={(event: ReactMouseEvent<HTMLButtonElement>) => {
                       if (explicitSelectedProject) {
@@ -1308,142 +1304,184 @@ export function PortfolioView({
                     프로젝트 편집
                   </button>
                 ) : null}
+                {isProjectWritable ? (
+                  <button
+                    type="button"
+                    className={secondaryActionButtonClass}
+                    onClick={handleExportCsv}
+                    disabled={displayedProjects.length === 0}
+                  >
+                    CSV 내보내기
+                  </button>
+                ) : null}
               </div>
             </div>
 
             <div
-              className="mt-4 grid gap-3 rounded-lg border border-slate-200 bg-slate-50/70 p-3 md:grid-cols-2 xl:grid-cols-[minmax(280px,1.2fr)_minmax(180px,0.65fr)_1fr_1fr_1fr]"
+              className="mt-4 grid gap-3 xl:grid-cols-12"
               aria-label="프로젝트 운영 필터"
             >
-              <label
-                className="flex min-w-0 flex-col gap-1.5"
-                htmlFor="project-search-input"
-              >
-                <span className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
-                  검색
-                </span>
-                <input
-                  id="project-search-input"
-                  type="search"
-                  value={searchTerm}
-                  placeholder="프로젝트명, 코드, 본부 검색"
-                  onChange={(event) => onChangeSearchTerm(event.target.value)}
-                  className={controlSurfaceClass}
-                />
-              </label>
-
-              <label
-                className="flex min-w-0 flex-col gap-1.5"
-                htmlFor="project-sort-select"
-              >
-                <span className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
-                  정렬
-                </span>
-                <select
-                  id="project-sort-select"
-                  value={explorerSort}
-                  onChange={(event) =>
-                    onChangeSort(event.target.value as ExplorerSortKey)
-                  }
-                  className={controlSurfaceClass}
+              <div className={`${filterGroupClass} xl:col-span-4`}>
+                <label
+                  className="flex min-w-0 flex-col gap-1.5"
+                  htmlFor="project-search-input"
                 >
-                  {explorerSortOptions.map((option) => (
-                    <option key={option.key} value={option.key}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.09em] text-slate-500">
+                    검색
+                  </span>
+                  <input
+                    id="project-search-input"
+                    type="search"
+                    value={searchTerm}
+                    placeholder="프로젝트명, 코드, 본부 검색"
+                    onChange={(event) => onChangeSearchTerm(event.target.value)}
+                    className={controlSurfaceClass}
+                  />
+                </label>
+                <label
+                  className="flex min-w-0 flex-col gap-1.5"
+                  htmlFor="project-sort-select"
+                >
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.09em] text-slate-500">
+                    정렬
+                  </span>
+                  <select
+                    id="project-sort-select"
+                    value={explorerSort}
+                    onChange={(event) =>
+                      onChangeSort(event.target.value as ExplorerSortKey)
+                    }
+                    className={controlSurfaceClass}
+                  >
+                    {explorerSortOptions.map((option) => (
+                      <option key={option.key} value={option.key}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
 
               <div
-                className="flex flex-wrap items-start gap-1.5 rounded-lg border border-slate-200 bg-white p-2"
+                className={`${filterGroupClass} xl:col-span-3`}
                 aria-label="빠른 필터"
               >
-                <span className="w-full text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
-                  빠른 필터
-                </span>
-                {explorerQuickFilterOptions.map((filter) => (
-                  <button
-                    key={filter.key}
-                    type="button"
-                    className={`inline-flex h-8 items-center rounded-full border px-3 text-xs font-medium transition ${
-                      explorerQuickFilter === filter.key
-                        ? 'border-slate-900 bg-slate-900 text-white shadow-sm'
-                        : 'border-slate-300 bg-white text-slate-700 hover:border-slate-400'
-                    }`}
-                    aria-pressed={explorerQuickFilter === filter.key}
-                    onClick={() => onChangeQuickFilter(filter.key)}
-                    title={filter.helper}
-                  >
-                    {filter.label}
-                  </button>
-                ))}
+                <div className="flex items-center justify-between">
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.09em] text-slate-500">
+                    빠른 필터
+                  </span>
+                  <span className="text-xs text-slate-500">
+                    {explorerQuickFilterOptions.length}개
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {explorerQuickFilterOptions.map((filter) => (
+                    <button
+                      key={filter.key}
+                      type="button"
+                      className={`${filterPillBaseClass} ${
+                        explorerQuickFilter === filter.key
+                          ? 'border-slate-900 bg-slate-900 text-white shadow-sm'
+                          : 'border-slate-300 bg-white text-slate-700 hover:border-slate-400'
+                      }`}
+                      aria-pressed={explorerQuickFilter === filter.key}
+                      onClick={() => onChangeQuickFilter(filter.key)}
+                      title={filter.helper}
+                    >
+                      {filter.label}
+                    </button>
+                  ))}
+                </div>
               </div>
 
               <div
-                className="flex flex-wrap items-start gap-1.5 rounded-lg border border-slate-200 bg-white p-2"
+                className={`${filterGroupClass} xl:col-span-2`}
                 aria-label="상태 필터"
               >
-                <span className="w-full text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
-                  상태
-                </span>
-                {projectStatusFilterOptions.map((filter) => (
-                  <button
-                    key={filter.key}
-                    type="button"
-                    className={`inline-flex h-8 items-center rounded-full border px-3 text-xs font-medium transition ${
-                      statusFilter === filter.key
-                        ? 'border-slate-900 bg-slate-900 text-white shadow-sm'
-                        : 'border-slate-300 bg-white text-slate-600 hover:border-slate-400 hover:text-slate-800'
-                    }`}
-                    aria-pressed={statusFilter === filter.key}
-                    onClick={() => setStatusFilter(filter.key)}
-                  >
-                    {filter.label}
-                  </button>
-                ))}
+                <div className="flex items-center justify-between">
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.09em] text-slate-500">
+                    상태
+                  </span>
+                  <span className="text-xs text-slate-500">
+                    {statusFilter === 'all' ? '전체' : statusFilter}
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {projectStatusFilterOptions.map((filter) => (
+                    <button
+                      key={filter.key}
+                      type="button"
+                      className={`${filterPillBaseClass} ${
+                        statusFilter === filter.key
+                          ? 'border-blue-700 bg-blue-700 text-white shadow-sm'
+                          : 'border-slate-300 bg-white text-slate-600 hover:border-slate-400 hover:text-slate-800'
+                      }`}
+                      aria-pressed={statusFilter === filter.key}
+                      onClick={() => setStatusFilter(filter.key)}
+                    >
+                      {filter.label}
+                    </button>
+                  ))}
+                </div>
               </div>
 
               <div
-                className="flex flex-wrap items-start gap-1.5 rounded-lg border border-slate-200 bg-white p-2"
+                className={`${filterGroupClass} xl:col-span-3`}
                 aria-label="본부 필터"
               >
-                <span className="w-full text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
-                  본부
-                </span>
-                {renderedHeadquarterOptions.map((headquarter) => (
-                  <button
-                    key={headquarter}
-                    type="button"
-                    className={`inline-flex h-8 items-center rounded-full border px-3 text-xs font-medium transition ${
-                      resolvedHeadquarterFilter === headquarter
-                        ? 'border-slate-900 bg-slate-900 text-white shadow-sm'
-                        : 'border-slate-300 bg-white text-slate-600 hover:border-slate-400 hover:text-slate-800'
-                    }`}
-                    aria-pressed={resolvedHeadquarterFilter === headquarter}
-                    onClick={() => onChangeHeadquarterFilter(headquarter)}
-                  >
-                    {headquarter === 'all' ? '전체 본부' : headquarter}
-                  </button>
-                ))}
+                <div className="flex items-center justify-between">
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.09em] text-slate-500">
+                    본부
+                  </span>
+                  <span className="text-xs text-slate-500">
+                    {resolvedHeadquarterFilter === 'all'
+                      ? '전체'
+                      : resolvedHeadquarterFilter}
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {renderedHeadquarterOptions.map((headquarter) => (
+                    <button
+                      key={headquarter}
+                      type="button"
+                      className={`${filterPillBaseClass} ${
+                        resolvedHeadquarterFilter === headquarter
+                          ? 'border-indigo-700 bg-indigo-700 text-white shadow-sm'
+                          : 'border-slate-300 bg-white text-slate-600 hover:border-slate-400 hover:text-slate-800'
+                      }`}
+                      aria-pressed={resolvedHeadquarterFilter === headquarter}
+                      onClick={() => onChangeHeadquarterFilter(headquarter)}
+                    >
+                      {headquarter === 'all' ? '전체 본부' : headquarter}
+                    </button>
+                  ))}
+                </div>
               </div>
             </div>
 
-            <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-slate-200 bg-white p-3">
-              <p className="text-sm text-slate-600">
-                운영 대상 <strong>{displayedProjects.length}</strong> / 필터
-                결과 {recomputedFilteredProjects.length} / 전체{' '}
-                {mergedProjects.length}
-              </p>
-              <div className="flex flex-wrap items-center gap-2.5">
+            <div className="mt-4 grid gap-2 rounded-xl border border-slate-200 bg-white p-3 sm:grid-cols-[auto_auto_1fr_auto] sm:items-center">
+              <span className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-700">
+                운영 대상 {displayedProjects.length}
+              </span>
+              <span className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-700">
+                필터 결과 {recomputedFilteredProjects.length}
+              </span>
+              <span className="text-sm text-slate-600">
+                전체 프로젝트 <strong>{mergedProjects.length}</strong>
+              </span>
+              <div className="flex flex-wrap items-center justify-end gap-2">
                 {explicitSelectedProject ? (
                   <span className="rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-800">
                     현재 선택 {explicitSelectedProject.name}
                   </span>
-                ) : null}
+                ) : (
+                  <span className="rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+                    선택된 프로젝트 없음
+                  </span>
+                )}
                 <button
                   type="button"
-                  className="inline-flex h-9 items-center rounded-md border border-slate-300 px-3 text-xs font-medium text-slate-600 transition hover:border-slate-400 hover:bg-slate-50"
+                  className="inline-flex h-9 items-center rounded-lg border border-slate-300 px-3 text-xs font-medium text-slate-600 transition hover:border-slate-400 hover:bg-slate-50"
                   onClick={resetOperationalFilters}
                 >
                   필터 초기화
@@ -1451,39 +1489,39 @@ export function PortfolioView({
               </div>
             </div>
 
-            <div className="mt-4 overflow-hidden rounded-lg border border-slate-200 bg-white">
+            <div className="mt-4 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
               <div className="overflow-x-auto">
-                <table className="min-w-[980px] w-full border-collapse text-sm">
-                  <thead className="sticky top-0 z-[1] bg-slate-100/90 backdrop-blur">
+                <table className="min-w-[1000px] w-full border-collapse text-sm">
+                  <thead className="sticky top-0 z-[1] bg-slate-100/95 backdrop-blur">
                     <tr>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th className="px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-500">
                         우선
                       </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th className="px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-500">
                         프로젝트
                       </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th className="px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-500">
                         본부
                       </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th className="px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-500">
                         상태
                       </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th className="px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-500">
                         리스크
                       </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th className="px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-500">
                         투자액
                       </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th className="px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-500">
                         NPV
                       </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th className="px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-500">
                         IRR
                       </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th className="px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-500">
                         회수
                       </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th className="px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-500">
                         허브
                       </th>
                     </tr>
@@ -1492,22 +1530,22 @@ export function PortfolioView({
                     {displayedProjects.map((project) => (
                       <tr
                         key={project.code}
-                        className={`border-t border-slate-200 align-top transition odd:bg-white even:bg-slate-50/35 hover:bg-cyan-50/60 ${
+                        className={`border-t border-slate-200 align-top transition odd:bg-white even:bg-slate-50/40 hover:bg-cyan-50/70 ${
                           project.code === selectedProjectCode
-                            ? 'bg-emerald-50/70'
+                            ? 'bg-emerald-50/80'
                             : ''
                         } ${
                           project.code === modalProjectCode
-                            ? 'bg-indigo-50/70'
+                            ? 'bg-indigo-50/80'
                             : ''
                         }`}
                       >
-                        <td className="whitespace-nowrap px-3 py-2.5">
+                        <td className="whitespace-nowrap px-3 py-2">
                           <span className="inline-flex rounded-md border border-slate-300 bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-600">
                             #{project.rank}
                           </span>
                         </td>
-                        <td className="px-3 py-2.5">
+                        <td className="px-3 py-2">
                           <strong className="font-semibold text-slate-800">
                             {project.name}
                           </strong>
@@ -1515,35 +1553,37 @@ export function PortfolioView({
                             {project.code} · {project.assetCategory}
                           </div>
                         </td>
-                        <td className="whitespace-nowrap px-3 py-2.5 text-slate-700">
+                        <td className="whitespace-nowrap px-3 py-2 text-slate-700">
                           {project.headquarter}
                         </td>
-                        <td className="whitespace-nowrap px-3 py-2.5">
+                        <td className="whitespace-nowrap px-3 py-2">
                           <span className={statusPillClass(project.status)}>
+                            <span className="h-1.5 w-1.5 rounded-full bg-current/80" />
                             {project.status}
                           </span>
                         </td>
-                        <td className="whitespace-nowrap px-3 py-2.5">
+                        <td className="whitespace-nowrap px-3 py-2">
                           <span className={riskPillClass(project.risk)}>
+                            <span className="h-1.5 w-1.5 rounded-full bg-current/80" />
                             {project.risk}
                           </span>
                         </td>
-                        <td className="whitespace-nowrap px-3 py-2.5 text-slate-700">
+                        <td className="whitespace-nowrap px-3 py-2 font-medium text-slate-700">
                           {formatKrwCompact(project.investmentKrw)}
                         </td>
-                        <td className="whitespace-nowrap px-3 py-2.5 text-slate-700">
+                        <td className="whitespace-nowrap px-3 py-2 font-medium text-slate-700">
                           {formatKrwCompact(project.npvKrw)}
                         </td>
-                        <td className="whitespace-nowrap px-3 py-2.5 text-slate-700">
+                        <td className="whitespace-nowrap px-3 py-2 text-slate-700">
                           {(project.irr * 100).toFixed(1)}%
                         </td>
-                        <td className="whitespace-nowrap px-3 py-2.5 text-slate-700">
+                        <td className="whitespace-nowrap px-3 py-2 text-slate-700">
                           {project.paybackYears.toFixed(1)}년
                         </td>
-                        <td className="whitespace-nowrap px-3 py-2.5">
+                        <td className="whitespace-nowrap px-3 py-2">
                           <button
                             type="button"
-                            className="inline-flex h-8 items-center rounded-md border border-slate-300 px-3 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
+                            className="inline-flex h-8 items-center rounded-lg border border-slate-300 px-3 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
                             aria-label={`${project.name} 상세 허브 열기`}
                             onClick={(
                               event: ReactMouseEvent<HTMLButtonElement>
@@ -1560,7 +1600,7 @@ export function PortfolioView({
                 </table>
               </div>
               {displayedProjects.length === 0 ? (
-                <div className="mt-3 grid gap-2 rounded-lg border border-slate-200 bg-slate-50 p-4">
+                <div className="m-3 grid gap-2 rounded-lg border border-slate-200 bg-slate-50 p-4">
                   <p className="m-0 text-sm text-slate-600">
                     조건에 맞는 프로젝트가 없습니다.
                   </p>
@@ -2169,120 +2209,128 @@ export function PortfolioView({
                   </button>
                 </div>
 
-                <div className="mt-4 grid gap-2 rounded-lg border border-slate-200 bg-slate-50 p-3 sm:grid-cols-3">
-                  <span className="flex flex-col gap-0.5 rounded-md border border-slate-200 bg-white px-3 py-2">
-                    <small>본부</small>
-                    <strong>{modalProject.headquarter}</strong>
-                  </span>
-                  <span className="flex flex-col gap-0.5 rounded-md border border-slate-200 bg-white px-3 py-2">
-                    <small>상태</small>
-                    <strong>
-                      <span className={statusPillClass(modalProject.status)}>
-                        {modalProject.status}
+                <div className="mt-4 grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+                  <div className="grid gap-3 rounded-xl border border-slate-200 bg-slate-50 p-3">
+                    <div className="grid gap-2 sm:grid-cols-3">
+                      <span className="flex flex-col gap-1 rounded-lg border border-slate-200 bg-white px-3 py-2">
+                        <small className="text-xs text-slate-500">본부</small>
+                        <strong>{modalProject.headquarter}</strong>
                       </span>
-                    </strong>
-                  </span>
-                  <span className="flex flex-col gap-0.5 rounded-md border border-slate-200 bg-white px-3 py-2">
-                    <small>리스크</small>
-                    <strong>
-                      <span className={riskPillClass(modalProject.risk)}>
-                        {modalProject.risk}
+                      <span className="flex flex-col gap-1 rounded-lg border border-slate-200 bg-white px-3 py-2">
+                        <small className="text-xs text-slate-500">상태</small>
+                        <strong>
+                          <span
+                            className={statusPillClass(modalProject.status)}
+                          >
+                            <span className="h-1.5 w-1.5 rounded-full bg-current/80" />
+                            {modalProject.status}
+                          </span>
+                        </strong>
                       </span>
-                    </strong>
-                  </span>
-                </div>
+                      <span className="flex flex-col gap-1 rounded-lg border border-slate-200 bg-white px-3 py-2">
+                        <small className="text-xs text-slate-500">리스크</small>
+                        <strong>
+                          <span className={riskPillClass(modalProject.risk)}>
+                            <span className="h-1.5 w-1.5 rounded-full bg-current/80" />
+                            {modalProject.risk}
+                          </span>
+                        </strong>
+                      </span>
+                    </div>
 
-                <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
-                  <article className="rounded-lg border border-slate-200 bg-white px-3 py-2">
-                    <span className="text-xs font-medium text-slate-500">
-                      투자 예산
-                    </span>
-                    <strong className="mt-1 block text-sm font-semibold text-slate-900">
-                      {formatKrwCompact(modalProject.investmentKrw)}
-                    </strong>
-                  </article>
-                  <article className="rounded-lg border border-slate-200 bg-white px-3 py-2">
-                    <span className="text-xs font-medium text-slate-500">
-                      예상 매출
-                    </span>
-                    <strong className="mt-1 block text-sm font-semibold text-slate-900">
-                      {formatKrwCompact(modalProject.expectedRevenueKrw)}
-                    </strong>
-                  </article>
-                  <article className="rounded-lg border border-slate-200 bg-white px-3 py-2">
-                    <span className="text-xs font-medium text-slate-500">
-                      NPV
-                    </span>
-                    <strong className="mt-1 block text-sm font-semibold text-slate-900">
-                      {formatKrwCompact(modalProject.npvKrw)}
-                    </strong>
-                  </article>
-                  <article className="rounded-lg border border-slate-200 bg-white px-3 py-2">
-                    <span className="text-xs font-medium text-slate-500">
-                      IRR / 회수기간
-                    </span>
-                    <strong className="mt-1 block text-sm font-semibold text-slate-900">
-                      {(modalProject.irr * 100).toFixed(1)}% ·{' '}
-                      {modalProject.paybackYears.toFixed(1)}년
-                    </strong>
-                  </article>
-                </div>
-
-                <div className="mt-4 flex flex-col gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 sm:p-4">
-                  <div className="space-y-1">
-                    <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500">
-                      워크스페이스 진입
-                    </span>
-                    <strong className="block text-sm font-semibold text-slate-900">
-                      선택 후 필요한 분석 레인으로 바로 진입
-                    </strong>
-                    <p className="text-sm text-slate-600">
-                      현재 행위는 기존 라우팅과 동일하며, 프로젝트 컨텍스트만
-                      먼저 정리합니다.
-                    </p>
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      <article className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                        <span className="text-xs font-medium text-slate-500">
+                          투자 예산
+                        </span>
+                        <strong className="mt-1 block text-sm font-semibold text-slate-900">
+                          {formatKrwCompact(modalProject.investmentKrw)}
+                        </strong>
+                      </article>
+                      <article className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                        <span className="text-xs font-medium text-slate-500">
+                          예상 매출
+                        </span>
+                        <strong className="mt-1 block text-sm font-semibold text-slate-900">
+                          {formatKrwCompact(modalProject.expectedRevenueKrw)}
+                        </strong>
+                      </article>
+                      <article className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                        <span className="text-xs font-medium text-slate-500">
+                          NPV
+                        </span>
+                        <strong className="mt-1 block text-sm font-semibold text-slate-900">
+                          {formatKrwCompact(modalProject.npvKrw)}
+                        </strong>
+                      </article>
+                      <article className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                        <span className="text-xs font-medium text-slate-500">
+                          IRR / 회수기간
+                        </span>
+                        <strong className="mt-1 block text-sm font-semibold text-slate-900">
+                          {(modalProject.irr * 100).toFixed(1)}% ·{' '}
+                          {modalProject.paybackYears.toFixed(1)}년
+                        </strong>
+                      </article>
+                    </div>
                   </div>
-                  <div className="flex flex-wrap items-center gap-2.5">
-                    {isProjectWritable ? (
+
+                  <div className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-3 sm:p-4">
+                    <div className="space-y-1.5">
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500">
+                        다음 액션
+                      </span>
+                      <strong className="block text-sm font-semibold text-slate-900">
+                        컨텍스트 선택 후 분석 레인 진입
+                      </strong>
+                      <p className="text-sm text-slate-600">
+                        기존 라우팅 로직은 동일하며, 상세 허브에서 진입 목적만
+                        명확히 구분합니다.
+                      </p>
+                    </div>
+                    <div className="grid gap-2">
                       <button
                         type="button"
-                        className={secondaryActionButtonClass}
+                        className={primaryActionButtonClass}
+                        onClick={() => {
+                          onSelectProject(modalProject.code);
+                          handleModalClose();
+                        }}
+                      >
+                        현재 프로젝트로 선택
+                      </button>
+                      <button
+                        type="button"
+                        className={`${actionButtonBaseClass} border-transparent bg-cyan-700 text-white hover:bg-cyan-600`}
                         onClick={() =>
-                          openProjectEditModal(modalProject, {
-                            returnMode: 'detail'
-                          })
+                          handleWorkspaceEntry('accounting', modalProject.code)
                         }
                       >
-                        프로젝트 편집
+                        관리회계 워크스페이스
                       </button>
-                    ) : null}
-                    <button
-                      type="button"
-                      className={primaryActionButtonClass}
-                      onClick={() => {
-                        onSelectProject(modalProject.code);
-                        handleModalClose();
-                      }}
-                    >
-                      선택
-                    </button>
-                    <button
-                      type="button"
-                      className={`${actionButtonBaseClass} border-transparent bg-cyan-700 text-white hover:bg-cyan-600`}
-                      onClick={() =>
-                        handleWorkspaceEntry('accounting', modalProject.code)
-                      }
-                    >
-                      관리회계
-                    </button>
-                    <button
-                      type="button"
-                      className={`${actionButtonBaseClass} border-transparent bg-indigo-700 text-white hover:bg-indigo-600`}
-                      onClick={() =>
-                        handleWorkspaceEntry('valuation', modalProject.code)
-                      }
-                    >
-                      재무평가
-                    </button>
+                      <button
+                        type="button"
+                        className={`${actionButtonBaseClass} border-transparent bg-indigo-700 text-white hover:bg-indigo-600`}
+                        onClick={() =>
+                          handleWorkspaceEntry('valuation', modalProject.code)
+                        }
+                      >
+                        재무평가 워크스페이스
+                      </button>
+                      {isProjectWritable ? (
+                        <button
+                          type="button"
+                          className={secondaryActionButtonClass}
+                          onClick={() =>
+                            openProjectEditModal(modalProject, {
+                              returnMode: 'detail'
+                            })
+                          }
+                        >
+                          프로젝트 편집
+                        </button>
+                      ) : null}
+                    </div>
                   </div>
                 </div>
               </>

--- a/frontend/src/views/reviews/ReviewsView.tsx
+++ b/frontend/src/views/reviews/ReviewsView.tsx
@@ -29,12 +29,15 @@ export function ReviewsView({
   const isAuditError = auditStatus === 'error';
   const hasAuditEvents = auditEvents.length > 0;
   const recentEvent = hasAuditEvents ? auditEvents[0] : null;
+  const uniqueActors = new Set(auditEvents.map((event) => event.actor)).size;
 
   return (
     <section className="grid gap-4">
-      <div className="grid gap-3 md:grid-cols-3">
-        <article className="rounded-xl border border-slate-200 bg-white px-4 py-3">
-          <span className="text-xs text-slate-500">감사 이벤트</span>
+      <div className="grid gap-3 md:grid-cols-4">
+        <article className="rounded-xl border border-slate-200 bg-white px-4 py-3.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+          <span className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+            감사 이벤트
+          </span>
           <strong className="mt-1 block text-[1.75rem] font-semibold leading-none text-[#142542]">
             {auditEvents.length}
           </strong>
@@ -42,8 +45,10 @@ export function ReviewsView({
             현재 컨텍스트 기준 누적 이력
           </p>
         </article>
-        <article className="rounded-xl border border-slate-200 bg-white px-4 py-3">
-          <span className="text-xs text-slate-500">데이터 소스</span>
+        <article className="rounded-xl border border-slate-200 bg-white px-4 py-3.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+          <span className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+            데이터 소스
+          </span>
           <strong className="mt-1 block text-base font-semibold text-[#142542]">
             {auditSource === 'api' ? '감사 API' : 'API 제한 모드'}
           </strong>
@@ -53,13 +58,26 @@ export function ReviewsView({
               : '포트폴리오 전체 기준'}
           </p>
         </article>
-        <article className="rounded-xl border border-slate-200 bg-white px-4 py-3">
-          <span className="text-xs text-slate-500">최근 기록</span>
+        <article className="rounded-xl border border-slate-200 bg-white px-4 py-3.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+          <span className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+            최근 기록
+          </span>
           <strong className="mt-1 block text-base font-semibold text-[#142542]">
             {recentEvent ? recentEvent.action : '-'}
           </strong>
           <p className="mt-2 text-sm text-cw-muted">
             {recentEvent ? formatDateTime(recentEvent.at) : '기록 없음'}
+          </p>
+        </article>
+        <article className="rounded-xl border border-slate-200 bg-white px-4 py-3.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+          <span className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+            참여 사용자
+          </span>
+          <strong className="mt-1 block text-[1.25rem] font-semibold leading-none text-[#142542]">
+            {uniqueActors}
+          </strong>
+          <p className="mt-2 text-sm text-cw-muted">
+            감사 이력 작성/승인 참여 인원
           </p>
         </article>
       </div>
@@ -91,7 +109,7 @@ export function ReviewsView({
           subtitle="변경 이력과 승인 흐름을 시간순으로 확인합니다."
         >
           <div
-            className="mb-4 flex items-start gap-3 rounded-xl border border-slate-200 bg-slate-50/70 px-3 py-2.5"
+            className="mb-4 flex items-start gap-3 rounded-xl border border-slate-200 bg-slate-50/80 px-3 py-2.5"
             aria-live="polite"
           >
             <span
@@ -156,39 +174,58 @@ export function ReviewsView({
           {!isAuditLoading && !isAuditError && hasAuditEvents ? (
             <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
               <div className="overflow-x-auto">
-                <table className="min-w-[620px] w-full border-collapse text-sm">
-                  <thead className="bg-slate-100/70">
+                <table className="w-full min-w-[620px] border-collapse text-sm">
+                  <thead className="bg-slate-100/80">
                     <tr>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th
+                        scope="col"
+                        className="px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500"
+                      >
                         사용자
                       </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th
+                        scope="col"
+                        className="px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500"
+                      >
                         액션
                       </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th
+                        scope="col"
+                        className="px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500"
+                      >
                         도메인
                       </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      <th
+                        scope="col"
+                        className="px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500"
+                      >
                         시각
                       </th>
                     </tr>
                   </thead>
                   <tbody>
-                    {auditEvents.map((item) => (
+                    {auditEvents.map((item, index) => (
                       <tr
                         key={`${item.actor}-${item.action}-${item.at}`}
-                        className="border-t border-slate-200 align-top"
+                        className={`align-top ${
+                          index === 0 ? '' : 'border-t border-slate-200'
+                        } ${index % 2 === 0 ? 'bg-white' : 'bg-slate-50/35'} hover:bg-[#eef4ff]`}
                       >
-                        <td className="whitespace-nowrap px-3 py-2.5 font-semibold text-[#142542]">
+                        <th
+                          scope="row"
+                          className="whitespace-nowrap px-3 py-2.5 text-left text-[13px] font-semibold text-[#142542]"
+                        >
                           {item.actor}
-                        </td>
-                        <td className="px-3 py-2.5 text-cw-muted">
+                        </th>
+                        <td className="px-3 py-2.5 text-[13px] text-cw-muted">
                           {item.action}
                         </td>
-                        <td className="whitespace-nowrap px-3 py-2.5 text-cw-muted">
-                          {item.domain}
+                        <td className="whitespace-nowrap px-3 py-2.5 text-[13px] text-cw-muted">
+                          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[12px] font-medium text-slate-700">
+                            {item.domain}
+                          </span>
                         </td>
-                        <td className="whitespace-nowrap px-3 py-2.5 text-cw-muted">
+                        <td className="whitespace-nowrap px-3 py-2.5 text-[13px] text-cw-muted">
                           {formatDateTime(item.at)}
                         </td>
                       </tr>

--- a/frontend/src/views/settings/SettingsView.tsx
+++ b/frontend/src/views/settings/SettingsView.tsx
@@ -1,6 +1,5 @@
 import type { RoleInsight, Role } from '../../app/portfolioData';
 import { getRoleLabel } from '../../features/auth/permissions';
-import { InfoTile } from '../../shared/components/InfoTile';
 import { Panel } from '../../shared/components/Panel';
 
 type SettingsViewProps = {
@@ -12,6 +11,7 @@ export function SettingsView({
   selectedRole,
   selectedInsight
 }: SettingsViewProps) {
+  const selectedRoleLabel = getRoleLabel(selectedRole);
   const usageSteps = [
     {
       title: '1. 프로젝트 목록에서 대상 선택',
@@ -31,21 +31,25 @@ export function SettingsView({
   ];
   const roleChecklist = [
     {
+      roles: ['ADMIN'],
       role: '관리자',
       guide:
         '권한/메뉴 정책 확인 후 사용자·감사 로그 이상 여부를 먼저 점검합니다.'
     },
     {
+      roles: ['EXECUTIVE'],
       role: '임원',
       guide:
         '프로젝트 목록에서 우선순위 대상을 선택하고 가치평가·리스크 핵심 수치만 빠르게 판단합니다.'
     },
     {
+      roles: ['PM', 'ACCOUNTANT'],
       role: 'PM/원가담당자',
       guide:
         '투자액, 예상매출, 근거 데이터를 최신화하고 검토 상태(검토중/조건부/보류)를 명확히 관리합니다.'
     },
     {
+      roles: ['AUDITOR'],
       role: '감사',
       guide:
         '승인·수정 이력이 내부 통제 기준과 일치하는지 감사 로그 중심으로 검증합니다.'
@@ -53,39 +57,88 @@ export function SettingsView({
   ];
 
   return (
-    <section className="grid gap-4 xl:grid-cols-[1.15fr_1fr]">
+    <section className="grid gap-5 xl:grid-cols-[1.38fr_1fr]">
       <Panel
         title="사용 가이드"
         subtitle="실무에서 바로 쓰는 CostWise 운영 절차를 단계별로 안내합니다."
       >
-        <div className="grid gap-3 md:grid-cols-4">
-          <InfoTile label="현재 역할" value={getRoleLabel(selectedRole)} />
-          <InfoTile label="기본 진입" value="프로젝트 목록" />
-          <InfoTile label="권장 분석 화면" value="가치평가 / 리스크·VaR" />
-          <InfoTile label="플랫폼명" value="CostWise" />
+        <div className="rounded-2xl border border-[#d9e3f1] bg-[linear-gradient(135deg,#f7fafc_0%,#eef4fd_100%)] px-5 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.1em] text-[#6c7d97]">
+            Guide Board
+          </p>
+          <h3 className="mt-1 text-[29px] font-extrabold leading-[1.2] tracking-[-0.02em] text-[#10213d]">
+            설정 전 확인하면
+            <br />
+            운영 정확도가 올라갑니다.
+          </h3>
+          <p className="mt-2 text-[14px] leading-6 text-[#5e708b]">
+            역할별 기준 화면과 검토 절차를 짧은 카드로 정리했습니다.
+          </p>
         </div>
+
+        <ul className="mt-3.5 grid gap-2.5 md:grid-cols-2 xl:grid-cols-4">
+          <li className="rounded-xl border border-slate-200 bg-slate-50/70 px-3.5 py-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.09em] text-[#6d7f99]">
+              현재 역할
+            </p>
+            <p className="mt-1 text-[15px] font-semibold text-[#132744]">
+              {selectedRoleLabel}
+            </p>
+          </li>
+          <li className="rounded-xl border border-slate-200 bg-slate-50/70 px-3.5 py-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.09em] text-[#6d7f99]">
+              기본 진입
+            </p>
+            <p className="mt-1 text-[15px] font-semibold text-[#132744]">
+              프로젝트 목록
+            </p>
+          </li>
+          <li className="rounded-xl border border-slate-200 bg-slate-50/70 px-3.5 py-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.09em] text-[#6d7f99]">
+              권장 분석
+            </p>
+            <p className="mt-1 text-[15px] font-semibold text-[#132744]">
+              가치평가 / 리스크·VaR
+            </p>
+          </li>
+          <li className="rounded-xl border border-slate-200 bg-slate-50/70 px-3.5 py-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.09em] text-[#6d7f99]">
+              플랫폼명
+            </p>
+            <p className="mt-1 text-[15px] font-semibold text-[#132744]">
+              CostWise
+            </p>
+          </li>
+        </ul>
 
         <ol className="mt-4 grid gap-2.5">
           {usageSteps.map((step) => (
             <li
               key={step.title}
-              className="rounded-xl border border-slate-200 bg-slate-50/70 px-3.5 py-3.5"
+              className="rounded-xl border border-slate-200 bg-white px-4 py-3.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)]"
             >
-              <strong className="block text-sm font-semibold text-[#142542]">
-                {step.title}
-              </strong>
-              <p className="mt-1 text-sm leading-6 text-cw-muted">
-                {step.description}
-              </p>
+              <div className="flex gap-3">
+                <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-md border border-[#c7d6eb] bg-[#edf3fc] px-1.5 text-[12px] font-bold text-[#365a84]">
+                  {step.title.split('.')[0]}
+                </span>
+                <div>
+                  <strong className="block text-sm font-semibold text-[#142542]">
+                    {step.title.replace(/^\d+\.\s*/, '')}
+                  </strong>
+                  <p className="mt-1 text-sm leading-6 text-cw-muted">
+                    {step.description}
+                  </p>
+                </div>
+              </div>
             </li>
           ))}
         </ol>
 
-        <div className="mt-4 rounded-xl border border-blue-100 bg-blue-50/70 px-4 py-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-blue-700">
+        <div className="mt-4 rounded-xl border border-[#cfe0f6] bg-[#f2f7ff] px-4 py-3.5">
+          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[#275382]">
             운영 팁
           </p>
-          <p className="mt-1 text-sm leading-6 text-slate-700">
+          <p className="mt-1 text-sm leading-6 text-[#334a68]">
             프로젝트 선택 전 필터를 먼저 고정하면 화면 간 이동 시에도 동일한
             운영 컨텍스트를 유지할 수 있습니다.
           </p>
@@ -96,31 +149,56 @@ export function SettingsView({
         title="역할별 운영 체크포인트"
         subtitle="역할마다 반드시 확인할 핵심 점검 항목을 간단히 정리했습니다."
       >
-        <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
-          <p className="text-base font-semibold leading-6 text-[#142542]">
-            {selectedInsight.headline}
-          </p>
-          <p className="mt-2 text-sm leading-6 text-cw-muted">
-            {selectedInsight.summary}
-          </p>
+        <div className="grid gap-3.5">
+          <div className="rounded-2xl border border-[#cedcf2] bg-[linear-gradient(135deg,#f5f9ff_0%,#edf4ff_100%)] px-[18px] py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.09em] text-[#5a7295]">
+              선택 역할 요약 · {selectedRoleLabel}
+            </p>
+            <p className="mt-1 text-[17px] font-semibold leading-7 text-[#132744]">
+              {selectedInsight.headline}
+            </p>
+            <p className="mt-2 text-sm leading-6 text-[#5c6f8a]">
+              {selectedInsight.summary}
+            </p>
+          </div>
 
-          <ul className="mt-4 grid gap-2">
-            {roleChecklist.map((item) => (
-              <li
-                key={item.role}
-                className="rounded-xl border border-slate-200 bg-white px-3 py-2.5"
-              >
-                <p className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
-                  {item.role}
-                </p>
-                <p className="mt-1 text-sm leading-6 text-slate-700">
-                  {item.guide}
-                </p>
-              </li>
-            ))}
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-[0.09em] text-[#6d809b]">
+              역할별 체크리스트
+            </h3>
+          </div>
+
+          <ul className="grid gap-2.5">
+            {roleChecklist.map((item) => {
+              const isSelected = item.roles.includes(selectedRole);
+              return (
+                <li
+                  key={item.role}
+                  className={`rounded-xl px-3.5 py-3 ${
+                    isSelected
+                      ? 'border border-[#9eb8da] bg-[#edf4ff]'
+                      : 'border border-slate-200 bg-white'
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                      {item.role}
+                    </p>
+                    {isSelected ? (
+                      <span className="rounded-md border border-[#b5c8e5] bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-[#436a99]">
+                        현재 역할
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="mt-1 text-sm leading-6 text-slate-700">
+                    {item.guide}
+                  </p>
+                </li>
+              );
+            })}
           </ul>
 
-          <dl className="mt-4 grid gap-2 rounded-xl border border-slate-200 bg-white p-3 text-sm text-cw-muted">
+          <dl className="grid gap-2 rounded-xl border border-[#d5dfed] bg-[#f9fbff] p-3.5 text-sm text-cw-muted">
             <div className="grid gap-0.5">
               <dt className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
                 현재 역할 다음 액션

--- a/frontend/src/views/users/UsersView.tsx
+++ b/frontend/src/views/users/UsersView.tsx
@@ -37,7 +37,13 @@ const defaultFormState: UpsertUserRequest = {
   mfaEnabled: false
 };
 
-const formRoleOptions = ['ADMIN', 'EXECUTIVE', 'PM', 'ACCOUNTANT', 'AUDITOR'] as const;
+const formRoleOptions = [
+  'ADMIN',
+  'EXECUTIVE',
+  'PM',
+  'ACCOUNTANT',
+  'AUDITOR'
+] as const;
 const formStatusOptions = ['ACTIVE', 'SUSPENDED', 'INVITED'] as const;
 
 type UsersViewProps = {
@@ -52,16 +58,21 @@ export function UsersView({
   divisionOptions
 }: UsersViewProps) {
   const [users, setUsers] = useState<UserAccount[]>([]);
-  const [usersStatus, setUsersStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [usersStatus, setUsersStatus] = useState<'loading' | 'ready' | 'error'>(
+    'loading'
+  );
   const [usersError, setUsersError] = useState<string | null>(null);
   const [usersReloadKey, setUsersReloadKey] = useState(0);
   const [auditEvents, setAuditEvents] = useState<AuditEvent[]>([]);
-  const [auditStatus, setAuditStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [auditStatus, setAuditStatus] = useState<'loading' | 'ready' | 'error'>(
+    'loading'
+  );
   const [auditError, setAuditError] = useState<string | null>(null);
   const [auditReloadKey, setAuditReloadKey] = useState(0);
   const [modalMode, setModalMode] = useState<'create' | 'edit' | null>(null);
   const [editingUser, setEditingUser] = useState<UserAccount | null>(null);
-  const [formState, setFormState] = useState<UpsertUserRequest>(defaultFormState);
+  const [formState, setFormState] =
+    useState<UpsertUserRequest>(defaultFormState);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -202,7 +213,9 @@ export function UsersView({
       setUsersReloadKey((current) => current + 1);
       setAuditReloadKey((current) => current + 1);
     } catch (error) {
-      setSubmitError(error instanceof Error ? error.message : '저장에 실패했습니다.');
+      setSubmitError(
+        error instanceof Error ? error.message : '저장에 실패했습니다.'
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -297,28 +310,74 @@ export function UsersView({
           <div className="rounded-xl border border-slate-200 bg-white">
             <div className="overflow-x-auto">
               <table className="min-w-[980px] table-auto border-collapse">
-              <thead>
-                <tr>
-                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">사용자</th>
-                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">역할</th>
-                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">본부</th>
-                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">상태</th>
-                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">MFA</th>
-                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">업데이트</th>
-                    <th className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500" scope="col">작업</th>
-                </tr>
-              </thead>
-                  <tbody>
-                {visibleUsers.map((user) => (
-                    <tr key={user.id} className="border-t border-slate-200 align-top hover:bg-slate-50">
+                <thead>
+                  <tr>
+                    <th
+                      className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500"
+                      scope="col"
+                    >
+                      사용자
+                    </th>
+                    <th
+                      className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500"
+                      scope="col"
+                    >
+                      역할
+                    </th>
+                    <th
+                      className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500"
+                      scope="col"
+                    >
+                      본부
+                    </th>
+                    <th
+                      className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500"
+                      scope="col"
+                    >
+                      상태
+                    </th>
+                    <th
+                      className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500"
+                      scope="col"
+                    >
+                      MFA
+                    </th>
+                    <th
+                      className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500"
+                      scope="col"
+                    >
+                      업데이트
+                    </th>
+                    <th
+                      className="px-3 py-2 text-left text-xs font-semibold tracking-wide text-slate-500"
+                      scope="col"
+                    >
+                      작업
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visibleUsers.map((user) => (
+                    <tr
+                      key={user.id}
+                      className="border-t border-slate-200 align-top hover:bg-slate-50"
+                    >
                       <td className="px-3 py-2.5">
                         <strong>{user.displayName}</strong>
-                        <p className="mt-0.5 text-xs text-slate-500">{user.email}</p>
+                        <p className="mt-0.5 text-xs text-slate-500">
+                          {user.email}
+                        </p>
                       </td>
-                      <td className="px-3 py-2.5 text-slate-700">{user.role}</td>
-                      <td className="px-3 py-2.5 text-slate-700">{user.division}</td>
+                      <td className="px-3 py-2.5 text-slate-700">
+                        {user.role}
+                      </td>
+                      <td className="px-3 py-2.5 text-slate-700">
+                        {user.division}
+                      </td>
                       <td className="px-3 py-2.5">
-                        <span className={tonePillClass(statusTone(user.status))}>
+                        <span
+                          className={tonePillClass(statusTone(user.status))}
+                        >
                           {user.status}
                         </span>
                       </td>
@@ -349,9 +408,9 @@ export function UsersView({
                         </div>
                       </td>
                     </tr>
-                ))}
-              </tbody>
-            </table>
+                  ))}
+                </tbody>
+              </table>
             </div>
 
             {visibleUsers.length === 0 ? (
@@ -408,7 +467,9 @@ export function UsersView({
                 key={`${event.actor}-${event.action}-${event.at}`}
                 className="grid gap-1 border-b border-slate-200 px-3 py-2.5 text-sm last:border-b-0"
               >
-                <strong className="font-semibold text-[#142542]">{event.actor}</strong>
+                <strong className="font-semibold text-[#142542]">
+                  {event.actor}
+                </strong>
                 <span className="text-cw-muted">{event.action}</span>
                 <small className="text-xs text-cw-muted">
                   {event.domain} · {formatDateTime(event.at)}
@@ -434,7 +495,9 @@ export function UsersView({
             className="relative z-10 w-full max-w-4xl max-h-[90vh] overflow-y-auto rounded-xl border border-slate-200 bg-white p-4 shadow-2xl sm:p-6"
             role="dialog"
             aria-modal="true"
-            aria-labelledby={modalMode === 'create' ? 'users-create-title' : 'users-edit-title'}
+            aria-labelledby={
+              modalMode === 'create' ? 'users-create-title' : 'users-edit-title'
+            }
           >
             <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 pb-4">
               <div>
@@ -442,13 +505,18 @@ export function UsersView({
                   {modalMode === 'create' ? 'New user' : editingUser?.email}
                 </p>
                 <h3
-                  id={modalMode === 'create' ? 'users-create-title' : 'users-edit-title'}
+                  id={
+                    modalMode === 'create'
+                      ? 'users-create-title'
+                      : 'users-edit-title'
+                  }
                   className="mt-1 text-xl font-semibold tracking-tight text-slate-900"
                 >
                   {modalMode === 'create' ? '사용자 등록' : '사용자 수정'}
                 </h3>
                 <p className="mt-1 text-sm leading-6 text-slate-600">
-                  권한/본부/상태를 설정하면 USER-MGMT 감사 로그에 자동 기록됩니다.
+                  권한/본부/상태를 설정하면 USER-MGMT 감사 로그에 자동
+                  기록됩니다.
                 </p>
               </div>
               <button
@@ -578,7 +646,10 @@ export function UsersView({
               </div>
 
               <div className={formActionsClass}>
-                <p className="m-0 text-sm leading-6 text-slate-600" role="alert">
+                <p
+                  className="m-0 text-sm leading-6 text-slate-600"
+                  role="alert"
+                >
                   {submitError ?? '필수 입력값을 확인한 뒤 저장하세요.'}
                 </p>
                 <div className="flex flex-wrap items-center gap-2.5">

--- a/frontend/src/views/workspace/WorkspaceView.tsx
+++ b/frontend/src/views/workspace/WorkspaceView.tsx
@@ -430,7 +430,6 @@ export function WorkspaceView({
             <h2 className="mt-1 text-[1.9rem] font-bold text-[#182847]">
               {workspaceMeta.title}
             </h2>
-            <p className="mt-1 text-[#607397]">{workspaceMeta.subtitle}</p>
           </div>
           <div className="flex items-center gap-2.5">
             <button

--- a/frontend/src/views/workspace/WorkspaceView.tsx
+++ b/frontend/src/views/workspace/WorkspaceView.tsx
@@ -98,9 +98,17 @@ export function WorkspaceView({
   const listClass = 'mt-3 grid gap-2';
   const listItemClass =
     'rounded-xl border border-[#e0e8f5] bg-[#f9fbff] px-3 py-2 text-sm text-[#41557b]';
+  const focusCardClass =
+    'rounded-2xl border border-[#c6d8f5] bg-[linear-gradient(130deg,#eef4ff_0%,#f8fbff_65%,#ffffff_100%)] p-4 text-[#304668] shadow-[0_8px_22px_rgba(24,40,71,0.08)]';
+  const miniStatClass =
+    'rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3 text-sm text-[#3b4f76]';
 
   if (activeView === 'accounting') {
     const allocationRows = selectedDetail?.allocation.rules ?? [];
+    const maxAllocatedAmount = Math.max(
+      1,
+      ...allocationRows.map((row) => row.allocatedAmount)
+    );
 
     return (
       <section>
@@ -130,31 +138,62 @@ export function WorkspaceView({
         </header>
 
         {hasSelectedProject && detailStatus === 'ready' && selectedDetail ? (
-          <section className={kpiGridClass} aria-label="원가 집계 핵심 지표">
-            <InfoTile
-              label="총 배분원가"
-              value={formatKrwCompact(
-                selectedDetail.allocation.allocatedCostKrw
-              )}
-            />
-            <InfoTile
-              label="표준원가"
-              value={formatKrwCompact(
-                selectedDetail.allocation.standardCostKrw
-              )}
-            />
-            <InfoTile
-              label="효율 갭"
-              value={formatKrwCompact(
-                selectedDetail.allocation.efficiencyGapKrw
-              )}
-            />
-            <InfoTile
-              label="성과 갭"
-              value={formatKrwCompact(
-                selectedDetail.allocation.performanceGapKrw
-              )}
-            />
+          <section
+            className="grid gap-3 xl:grid-cols-[1.5fr_1fr]"
+            aria-label="원가 집계 핵심 지표"
+          >
+            <article className={focusCardClass}>
+              <span className="text-xs font-semibold uppercase tracking-[0.05em] text-[#607ca8]">
+                핵심 KPI
+              </span>
+              <strong className="mt-1.5 block text-[1.45rem] font-bold text-[#1f3458]">
+                총 배분원가{' '}
+                {formatKrwCompact(selectedDetail.allocation.allocatedCostKrw)}
+              </strong>
+              <p className="mt-2 text-sm">
+                표준원가{' '}
+                {formatKrwCompact(selectedDetail.allocation.standardCostKrw)}{' '}
+                대비 효율 갭{' '}
+                {formatKrwCompact(selectedDetail.allocation.efficiencyGapKrw)}를
+                우선 점검하세요.
+              </p>
+              <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                <div className={miniStatClass}>
+                  <span className="text-xs text-[#6881aa]">성과 갭</span>
+                  <strong className="mt-1 block text-[#1f3458]">
+                    {formatKrwCompact(
+                      selectedDetail.allocation.performanceGapKrw
+                    )}
+                  </strong>
+                </div>
+                <div className={miniStatClass}>
+                  <span className="text-xs text-[#6881aa]">배부 룰 수</span>
+                  <strong className="mt-1 block text-[#1f3458]">
+                    {allocationRows.length}개
+                  </strong>
+                </div>
+              </div>
+            </article>
+            <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
+              <InfoTile
+                label="표준원가"
+                value={formatKrwCompact(
+                  selectedDetail.allocation.standardCostKrw
+                )}
+              />
+              <InfoTile
+                label="효율 갭"
+                value={formatKrwCompact(
+                  selectedDetail.allocation.efficiencyGapKrw
+                )}
+              />
+              <InfoTile
+                label="성과 갭"
+                value={formatKrwCompact(
+                  selectedDetail.allocation.performanceGapKrw
+                )}
+              />
+            </div>
           </section>
         ) : null}
 
@@ -193,6 +232,30 @@ export function WorkspaceView({
               title="본부별 원가 차이분석 (실제 vs 표준)"
               subtitle="선택 프로젝트 기준 배부 규칙"
             >
+              <div className="mb-3 grid gap-2.5 sm:grid-cols-3">
+                <article className={miniStatClass}>
+                  <span className="text-xs text-[#6881aa]">총 본부</span>
+                  <strong className="mt-1 block text-[#1f3458]">
+                    {allocationRows.length}개
+                  </strong>
+                </article>
+                <article className={miniStatClass}>
+                  <span className="text-xs text-[#6881aa]">기준 원가</span>
+                  <strong className="mt-1 block text-[#1f3458]">
+                    {formatKrwCompact(
+                      selectedDetail.allocation.standardCostKrw
+                    )}
+                  </strong>
+                </article>
+                <article className={miniStatClass}>
+                  <span className="text-xs text-[#6881aa]">배분 원가</span>
+                  <strong className="mt-1 block text-[#1f3458]">
+                    {formatKrwCompact(
+                      selectedDetail.allocation.allocatedCostKrw
+                    )}
+                  </strong>
+                </article>
+              </div>
               <div className={tableShellClass}>
                 <table className={tableClass}>
                   <thead className="bg-[#f1f5fc] text-xs uppercase tracking-[0.03em] text-[#5a7096]">
@@ -272,12 +335,8 @@ export function WorkspaceView({
               >
                 <div className="grid gap-2.5">
                   {allocationRows.map((rule) => {
-                    const maxAmount = Math.max(
-                      1,
-                      ...allocationRows.map((row) => row.allocatedAmount)
-                    );
                     const width = Math.round(
-                      (rule.allocatedAmount / maxAmount) * 100
+                      (rule.allocatedAmount / maxAllocatedAmount) * 100
                     );
                     return (
                       <article
@@ -304,16 +363,35 @@ export function WorkspaceView({
 
               <Panel title="원가 배분 시뮬레이터" subtitle="간단 배분 입력 폼">
                 <div className="grid gap-2.5">
-                  <input
-                    className="w-full rounded-[10px] border border-[#cbd6ea] px-3 py-2.5"
-                    type="number"
-                    placeholder="배분할 총 금액 (예: 100000000)"
-                  />
-                  <textarea
-                    className="w-full rounded-[10px] border border-[#cbd6ea] px-3 py-2.5"
-                    rows={6}
-                    defaultValue='{"PRJ-001":30,"PRJ-002":20,"PRJ-003":50}'
-                  />
+                  <label className="grid gap-1.5 text-sm text-[#4a6087]">
+                    <span className="font-semibold text-[#2a4168]">
+                      배분 총액
+                    </span>
+                    <input
+                      className="w-full rounded-[10px] border border-[#cbd6ea] px-3 py-2.5"
+                      type="number"
+                      placeholder="배분할 총 금액 (예: 100000000)"
+                    />
+                  </label>
+                  <label className="grid gap-1.5 text-sm text-[#4a6087]">
+                    <span className="font-semibold text-[#2a4168]">
+                      배분 비율 JSON
+                    </span>
+                    <textarea
+                      className="w-full rounded-[10px] border border-[#cbd6ea] px-3 py-2.5 font-mono text-[0.82rem]"
+                      rows={6}
+                      defaultValue='{"PRJ-001":30,"PRJ-002":20,"PRJ-003":50}'
+                    />
+                  </label>
+                  <article className={miniStatClass}>
+                    <strong className="block text-[#1f3458]">
+                      입력 가이드
+                    </strong>
+                    <p className="mt-1 text-xs">
+                      키는 코드, 값은 비율(%). 합계 100 기준으로 입력하면 검토가
+                      빠릅니다.
+                    </p>
+                  </article>
                   <button
                     className="rounded-[10px] bg-[#2b4dbf] px-3 py-[11px] font-extrabold text-white"
                     type="button"
@@ -743,22 +821,35 @@ export function WorkspaceView({
                   '확률 가정 변경 시 재계산 후 승인'
                 ]}
               />
-              <InfoTile
-                label="신용등급"
-                value={selectedDetail.valuation.creditGrade}
-              />
-              <InfoTile
-                label="신용 점수"
-                value={`${selectedDetail.valuation.creditRiskScore}점`}
-              />
-              <InfoTile
-                label="듀레이션"
-                value={`${selectedDetail.valuation.duration}년`}
-              />
-              <InfoTile
-                label="컨벡서티"
-                value={`${selectedDetail.valuation.convexity}`}
-              />
+              <article className={workflowNoteClass}>
+                <strong>보조 신호 카드</strong>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <div className={miniStatClass}>
+                    <span className="text-xs text-[#6881aa]">신용등급</span>
+                    <strong className="mt-1 block text-[#1f3458]">
+                      {selectedDetail.valuation.creditGrade}
+                    </strong>
+                  </div>
+                  <div className={miniStatClass}>
+                    <span className="text-xs text-[#6881aa]">신용 점수</span>
+                    <strong className="mt-1 block text-[#1f3458]">
+                      {selectedDetail.valuation.creditRiskScore}점
+                    </strong>
+                  </div>
+                  <div className={miniStatClass}>
+                    <span className="text-xs text-[#6881aa]">듀레이션</span>
+                    <strong className="mt-1 block text-[#1f3458]">
+                      {selectedDetail.valuation.duration}년
+                    </strong>
+                  </div>
+                  <div className={miniStatClass}>
+                    <span className="text-xs text-[#6881aa]">컨벡서티</span>
+                    <strong className="mt-1 block text-[#1f3458]">
+                      {selectedDetail.valuation.convexity}
+                    </strong>
+                  </div>
+                </div>
+              </article>
             </section>
             <section className="grid grid-cols-[1.8fr_1fr] gap-4 max-[1280px]:grid-cols-1">
               <Panel
@@ -784,42 +875,87 @@ export function WorkspaceView({
                       </tr>
                     </thead>
                     <tbody>
-                      {selectedDetail.scenarioReturns.map((scenario) => (
-                        <tr key={scenario.label}>
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">
-                            {scenario.label}
-                          </td>
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">
-                            {formatPercent(scenario.probability)}
-                          </td>
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">
-                            {formatKrwCompact(scenario.npvKrw)}
-                          </td>
-                          <td className="border-b border-[#e5ecf8] px-4 py-3">
-                            {formatKrwCompact(
-                              Math.round(scenario.npvKrw * scenario.probability)
-                            )}
-                          </td>
-                        </tr>
-                      ))}
+                      {selectedDetail.scenarioReturns.map((scenario) => {
+                        const weighted = Math.round(
+                          scenario.npvKrw * scenario.probability
+                        );
+                        const isExpected =
+                          scenario.label === valuationExpectedCase?.label;
+                        return (
+                          <tr
+                            key={scenario.label}
+                            className={
+                              isExpected ? 'bg-[#f3f7ff]' : 'bg-transparent'
+                            }
+                          >
+                            <td className="border-b border-[#e5ecf8] px-4 py-3 font-semibold text-[#2a4168]">
+                              {isExpected
+                                ? `${scenario.label} (기준)`
+                                : scenario.label}
+                            </td>
+                            <td className="border-b border-[#e5ecf8] px-4 py-3">
+                              {formatPercent(scenario.probability)}
+                            </td>
+                            <td className="border-b border-[#e5ecf8] px-4 py-3">
+                              {formatKrwCompact(scenario.npvKrw)}
+                            </td>
+                            <td className="border-b border-[#e5ecf8] px-4 py-3">
+                              {formatKrwCompact(weighted)}
+                            </td>
+                          </tr>
+                        );
+                      })}
                     </tbody>
+                    <tfoot>
+                      <tr className="bg-[#eef3fd] text-[#2a4168]">
+                        <td
+                          className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-[0.03em]"
+                          colSpan={3}
+                        >
+                          확률가중 합계
+                        </td>
+                        <td className="px-4 py-3 text-sm font-bold">
+                          {formatKrwCompact(
+                            Math.round(
+                              selectedDetail.scenarioReturns.reduce(
+                                (sum, scenario) =>
+                                  sum + scenario.npvKrw * scenario.probability,
+                                0
+                              )
+                            )
+                          )}
+                        </td>
+                      </tr>
+                    </tfoot>
                   </table>
                 </div>
               </Panel>
               <Panel title="평가 판단 패널" subtitle="승인 전 체크 포인트">
                 <div className="grid gap-3">
-                  <article className="rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3.5 text-sm text-[#3b4f76]">
-                    기준 대비 비관 격차는 {formatKrwCompact(valuationGap)}
-                    입니다.
+                  <article className={miniStatClass}>
+                    <strong className="block text-[#1f3458]">Gap Signal</strong>
+                    <p className="mt-1">
+                      기준 대비 비관 격차 {formatKrwCompact(valuationGap)}
+                    </p>
                   </article>
-                  <article className="rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3.5 text-sm text-[#3b4f76]">
-                    할인율{' '}
-                    {formatPercent(selectedDetail.valuation.discountRate)} /
-                    리스크 프리미엄{' '}
-                    {formatPercent(selectedDetail.valuation.riskPremium)}
+                  <article className={miniStatClass}>
+                    <strong className="block text-[#1f3458]">
+                      Valuation Basis
+                    </strong>
+                    <p className="mt-1">
+                      할인율{' '}
+                      {formatPercent(selectedDetail.valuation.discountRate)} /
+                      리스크 프리미엄{' '}
+                      {formatPercent(selectedDetail.valuation.riskPremium)}
+                    </p>
                   </article>
-                  <article className="rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3.5 text-sm text-[#3b4f76]">
-                    승인 코멘트에 시나리오 근거와 민감도 차이를 함께 남기세요.
+                  <article className={miniStatClass}>
+                    <strong className="block text-[#1f3458]">
+                      Approval Memo
+                    </strong>
+                    <p className="mt-1">
+                      승인 코멘트에 시나리오 근거와 민감도 차이를 함께 남기세요.
+                    </p>
                   </article>
                 </div>
               </Panel>
@@ -911,14 +1047,34 @@ export function WorkspaceView({
                   '손실 허용 범위와 승인 조건을 함께 검증'
                 ]}
               />
-              <DecisionSummary
-                title="권장 액션"
-                items={[
-                  '비관 확률 재추정',
-                  '민감도 재평가 후 조건부 승인안 작성',
-                  '승인 코멘트에 하방 한계 수치 명시'
-                ]}
-              />
+              <article className={workflowNoteClass}>
+                <strong>신호 해석 요약</strong>
+                <div className="mt-3 grid gap-2">
+                  <div className={miniStatClass}>
+                    <span className="text-xs text-[#6881aa]">
+                      하방 격차 신호
+                    </span>
+                    <strong className="mt-1 block text-[#1f3458]">
+                      {formatKrwCompact(riskGuardrailGap)}
+                    </strong>
+                  </div>
+                  <div className={miniStatClass}>
+                    <span className="text-xs text-[#6881aa]">
+                      신용 모니터링
+                    </span>
+                    <strong className="mt-1 block text-[#1f3458]">
+                      {selectedDetail.valuation.creditGrade} ·{' '}
+                      {selectedDetail.valuation.creditRiskScore}점
+                    </strong>
+                  </div>
+                  <div className={miniStatClass}>
+                    <span className="text-xs text-[#6881aa]">즉시 액션</span>
+                    <strong className="mt-1 block text-[#1f3458]">
+                      비관 확률 재추정 후 승인 조건 갱신
+                    </strong>
+                  </div>
+                </div>
+              </article>
             </section>
             <section className="grid grid-cols-[1.8fr_1fr] gap-4 max-[1280px]:grid-cols-1">
               <Panel
@@ -1006,17 +1162,32 @@ export function WorkspaceView({
               </Panel>
               <Panel title="리스크 대응 패널" subtitle="승인 조건 및 모니터링">
                 <div className="grid gap-3">
-                  <article className="rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3.5 text-sm text-[#3b4f76]">
-                    하방 격차 {formatKrwCompact(riskGuardrailGap)}를 기준으로
-                    조건부 한도를 조정합니다.
+                  <article className={miniStatClass}>
+                    <span className="text-xs font-semibold text-[#6f86ad]">
+                      STEP 1
+                    </span>
+                    <p className="mt-1">
+                      하방 격차 {formatKrwCompact(riskGuardrailGap)} 기준으로
+                      조건부 한도를 조정합니다.
+                    </p>
                   </article>
-                  <article className="rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3.5 text-sm text-[#3b4f76]">
-                    신용등급 {selectedDetail.valuation.creditGrade} / 점수{' '}
-                    {selectedDetail.valuation.creditRiskScore}점을
-                    모니터링합니다.
+                  <article className={miniStatClass}>
+                    <span className="text-xs font-semibold text-[#6f86ad]">
+                      STEP 2
+                    </span>
+                    <p className="mt-1">
+                      신용등급 {selectedDetail.valuation.creditGrade} / 점수{' '}
+                      {selectedDetail.valuation.creditRiskScore}점을
+                      모니터링합니다.
+                    </p>
                   </article>
-                  <article className="rounded-xl border border-[#d8e2f2] bg-[#f8fbff] p-3.5 text-sm text-[#3b4f76]">
-                    다음 승인 단계: {selectedDetail.workflow.nextStep}
+                  <article className={miniStatClass}>
+                    <span className="text-xs font-semibold text-[#6f86ad]">
+                      STEP 3
+                    </span>
+                    <p className="mt-1">
+                      다음 승인 단계: {selectedDetail.workflow.nextStep}
+                    </p>
                   </article>
                 </div>
               </Panel>


### PR DESCRIPTION
## 요약
레퍼런스 UI와의 시각적 일관성을 맞추기 위해 주요 화면(대시보드/원가/프로젝트/가치평가/리스크-VaR/사용가이드)의 레이아웃과 공통 컴포넌트 스타일을 정렬했습니다.
사이드바/상단바를 포함한 공통 구조를 정비해 화면 간 밀도, 간격, 카드 표현을 일관된 기준으로 통일했습니다.

## 변경 내용
- `frontend/src/views/layout/TaskSidebar.tsx` 사이드바 시각 체계 정리
- `frontend/src/views/layout/TaskTopbar.tsx` 상단바 레이아웃 및 스타일 정리
- `frontend/src/shared/components/Panel.tsx` 공통 패널 스타일 기준 정렬
- `frontend/src/shared/components/InfoTile.tsx` 정보 타일 간격/표현 정렬
- `frontend/src/shared/components/ProgressBar.tsx` 진행바 스타일 일관화
- `frontend/src/views/dashboard/DashboardView.tsx` 대시보드 화면 정렬
- `frontend/src/views/reviews/ReviewsView.tsx` 원가 화면 정렬
- `frontend/src/views/portfolio/PortfolioView.tsx` 프로젝트 화면 정렬
- `frontend/src/views/workspace/WorkspaceView.tsx` 가치평가 화면 정렬
- `frontend/src/views/settings/SettingsView.tsx` 사용가이드 화면 정렬

## 이유
기존 화면별 구현 편차로 인해 동일한 정보 계층에서도 시각적 밀도와 컴포넌트 표현이 달랐고, 유지보수 시 화면별 별도 수정이 반복되었습니다.
이번 정렬로 레퍼런스 기준에 맞는 일관된 UI 규칙을 확보해 사용자 인지 부하와 향후 스타일 수정 비용을 함께 줄이기 위함입니다.

## 검증
- [x] 관련 테스트를 실행했습니다.
- [ ] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
- [ ] 인접한 흐름에서 회귀가 없는지 확인했습니다.

실행 명령:
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

## 스크린샷 또는 로그
- 로그: `npm run lint`, `npm run build` 통과
- 스크린샷: 필요 시 리뷰 코멘트로 추가하겠습니다.

## 체크리스트
- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [ ] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [x] 후속 작업이 필요하면 별도 이슈로 분리했습니다.

## 브랜치
- [x] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
- [x] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
- [x] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.