### PR TITLE
feat: DB 로그인 도입 및 RBAC 단순화

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@
 |------|-----|
 | **Frontend** | https://costwiseai-frontend.pages.dev |
 | **Backend API** | https://costwiseai-production.up.railway.app |
-| **API 명세** | https://costwiseai-production.up.railway.app/swagger-ui |
+| **Swagger UI** | https://costwiseai-production.up.railway.app/swagger-ui/index.html |
+| **OpenAPI JSON** | https://costwiseai-production.up.railway.app/v3/api-docs |
 | **Health Check** | https://costwiseai-production.up.railway.app/api/health |
 
 
@@ -65,15 +66,19 @@
 
 ## 📊 권한별 기능
 
-| 권한 | 접근 가능 기능 |
-|------|---|
-| **ADMIN** | 모든 API + 감사 로그 + 사용자 관리 |
-| **PLANNER** | 대시보드 · 포트폴리오 · 원가 · 평가 · 워크플로우 |
-| **FINANCE_REVIEWER** | 재무 검토 · 평가 분석 · 워크플로우 리뷰 |
-| **EXECUTIVE** | 최종 승인 결정 · 감사 로그 조회 |
-| **PM** | 프로젝트 단위 조회 · 평가 · 워크플로우 참여 |
-| **ACCOUNTANT** | 원가 · 관리회계 · 포트폴리오 조회 |
-| **AUDITOR** | 감사 로그 중심 접근 |
+### 5.2 Role-Based Access Control (RBAC)
+
+| 역할 | 권한 | API 접근 |
+|------|------|----------|
+| **PLANNER** | 프로젝트 생성/수정 + 검토 요청 | `GET /api/portfolio`, `POST /api/projects`, `PUT /api/projects/{id}`, `POST /api/projects/{id}/submit-review` |
+| **FINANCE_REVIEWER** | 원가/평가 검증 + 검토 의견/승인 | `GET /api/cost-accounting`, `GET /api/valuation-risk?projectId={id}`, `POST /api/review/{id}/approve` |
+| **EXECUTIVE** | 최종 승인/반려 + 감사 로그 등록 | `POST /api/review/{id}/approve`, `POST /api/audit-logs` |
+| **ADMIN** | 모든 권한 + 사용자 관리 | 모든 API |
+| **AUDITOR** | 감사 로그 조회 | `GET /api/audit-logs` |
+
+운영 참고:
+- 레거시 경로(`GET /api/portfolio/summary`, `GET /api/cost-accounting/summary`, `GET /api/valuation-risk/projects/{id}`)도 하위 호환으로 유지합니다.
+- 감사 로그는 읽기(`GET`)와 쓰기(`POST`) 권한을 분리합니다.
 
 ---
 
@@ -201,7 +206,7 @@ cd backend
 open http://localhost:5173
 
 # Backend API 명세
-open http://localhost:8080/swagger-ui
+open http://localhost:8080/swagger-ui/index.html
 
 # 헬스 체크
 curl http://localhost:8080/api/health
@@ -214,17 +219,20 @@ curl http://localhost:8080/api/health
 ### 대시보드 & 포트폴리오
 ```
 GET  /api/dashboard                    # 전체 대시보드 요약
+GET  /api/portfolio                    # 포트폴리오 KPI (RBAC 5.2 표준 경로)
 GET  /api/portfolio/summary            # 포트폴리오 KPI
 ```
 
 ### 원가 분석
 ```
+GET  /api/cost-accounting              # 원가 요약 (RBAC 5.2 표준 경로)
 GET  /api/cost-accounting/summary      # 원가 요약
 GET  /api/cost-accounting/detail       # 원가 상세 (본부별·프로젝트별)
 ```
 
 ### 금융 평가 & 리스크
 ```
+GET  /api/valuation-risk?projectId={projectId}   # 평가/리스크 조회 (RBAC 5.2 표준 경로)
 GET  /api/valuation-risk/projects/{projectId}    # 프로젝트 평가·리스크 지표
 GET  /api/valuation-risk/scenarios                # 시나리오별 분석
 ```
@@ -235,6 +243,7 @@ GET  /api/projects/{id}/workflow               # 승인 상태 조회
 POST /api/projects/{id}/submit-review          # 검토 요청
 POST /api/review/{id}/approve                  # 승인
 POST /api/review/{id}/reject                   # 반려
+POST /api/projects/{id}/review                 # 기존 통합 리뷰 API (하위 호환)
 ```
 
 ### 감사 로그
@@ -249,7 +258,7 @@ GET  /api/users                        # 사용자 목록 (ADMIN만)
 POST /api/users                        # 사용자 생성 (ADMIN만)
 ```
 
-**Swagger 접속**: http://localhost:8080/swagger-ui
+**Swagger 접속**: http://localhost:8080/swagger-ui/index.html
 
 ---
 
@@ -257,7 +266,7 @@ POST /api/users                        # 사용자 생성 (ADMIN만)
 
 ### 인증 & 인가
 - **JWT 기반 토큰**: Supabase에서 발급
-- **역할 기반 접근 제어 (RBAC)**: 7개 권한 역할 정의
+- **역할 기반 접근 제어 (RBAC)**: 5.2 기준 핵심 5역할(`PLANNER`, `FINANCE_REVIEWER`, `EXECUTIVE`, `ADMIN`, `AUDITOR`) 정의
 - **API 엔드포인트별 권한 검증**: Spring Security로 강제
 
 ### 데이터 보호

--- a/backend/src/main/java/com/costwise/api/analytics/AnalyticsController.java
+++ b/backend/src/main/java/com/costwise/api/analytics/AnalyticsController.java
@@ -6,6 +6,7 @@ import com.costwise.service.CostAccountingService;
 import com.costwise.service.ValuationRiskService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,9 +23,14 @@ public class AnalyticsController {
         this.valuationRiskService = valuationRiskService;
     }
 
-    @GetMapping("/cost-accounting/summary")
+    @GetMapping({"/cost-accounting", "/cost-accounting/summary"})
     public CostAccountingSummaryResponse costAccountingSummary() {
         return costAccountingService.loadSummary();
+    }
+
+    @GetMapping("/valuation-risk")
+    public ValuationRiskResponse valuationRisk(@RequestParam String projectId) {
+        return valuationRiskService.loadProjectDetail(projectId);
     }
 
     @GetMapping("/valuation-risk/projects/{projectId}")

--- a/backend/src/main/java/com/costwise/api/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/costwise/api/dashboard/DashboardController.java
@@ -33,7 +33,7 @@ public class DashboardController {
                 "portfolio", portfolioSummaryService.loadPortfolioSummary());
     }
 
-    @GetMapping("/portfolio/summary")
+    @GetMapping({"/portfolio", "/portfolio/summary"})
     public PortfolioSummaryResponse portfolioSummary() {
         return portfolioSummaryService.loadPortfolioSummary();
     }

--- a/backend/src/main/java/com/costwise/api/projects/ProjectCommandController.java
+++ b/backend/src/main/java/com/costwise/api/projects/ProjectCommandController.java
@@ -1,0 +1,40 @@
+package com.costwise.api.projects;
+
+import com.costwise.api.dto.persistence.CreateProjectRequest;
+import com.costwise.api.dto.persistence.ProjectSummaryResponse;
+import com.costwise.api.dto.persistence.UpdateProjectRequest;
+import com.costwise.persistence.PersistenceService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/projects")
+public class ProjectCommandController {
+
+    private final PersistenceService persistenceService;
+
+    public ProjectCommandController(PersistenceService persistenceService) {
+        this.persistenceService = persistenceService;
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'PLANNER')")
+    public ResponseEntity<ProjectSummaryResponse> createProject(@Valid @RequestBody CreateProjectRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(persistenceService.createProject(request));
+    }
+
+    @PutMapping("/{projectId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PLANNER')")
+    public ProjectSummaryResponse updateProject(
+            @PathVariable String projectId, @Valid @RequestBody UpdateProjectRequest request) {
+        return persistenceService.updateProject(projectId, request);
+    }
+}

--- a/backend/src/main/java/com/costwise/api/workflow/WorkflowController.java
+++ b/backend/src/main/java/com/costwise/api/workflow/WorkflowController.java
@@ -29,13 +29,36 @@ public class WorkflowController {
     }
 
     @GetMapping("/projects/{projectId}/workflow")
-    @PreAuthorize("hasAnyRole('PLANNER', 'PM', 'FINANCE_REVIEWER', 'ACCOUNTANT', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PLANNER', 'FINANCE_REVIEWER', 'EXECUTIVE')")
     public ApprovalWorkflowResponse workflow(@PathVariable String projectId) {
         return approvalWorkflowService.loadWorkflow(projectId);
     }
 
+    @PostMapping("/projects/{projectId}/submit-review")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PLANNER')")
+    public ApprovalWorkflowResponse submitReview(
+            @PathVariable String projectId,
+            Authentication authentication,
+            @RequestBody(required = false) ReviewCommand command) {
+        String actor = authentication == null ? null : authentication.getName();
+        String comment = command == null ? null : command.comment();
+        return approvalWorkflowService.transition(projectId, "PLANNER", "SUBMIT", actor, comment);
+    }
+
+    @PostMapping("/review/{projectId}/approve")
+    @PreAuthorize("hasAnyRole('ADMIN', 'FINANCE_REVIEWER', 'EXECUTIVE')")
+    public ApprovalWorkflowResponse approve(
+            @PathVariable String projectId,
+            Authentication authentication,
+            @RequestBody(required = false) ReviewCommand command) {
+        String role = resolveWorkflowRole(authentication);
+        String actor = authentication == null ? null : authentication.getName();
+        String comment = command == null ? null : command.comment();
+        return approvalWorkflowService.transition(projectId, role, "APPROVE", actor, comment);
+    }
+
     @PostMapping("/projects/{projectId}/review")
-    @PreAuthorize("hasAnyRole('PLANNER', 'PM', 'FINANCE_REVIEWER', 'ACCOUNTANT', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PLANNER', 'FINANCE_REVIEWER', 'EXECUTIVE')")
     public ApprovalWorkflowResponse review(
             @PathVariable String projectId,
             Authentication authentication,
@@ -65,6 +88,7 @@ public class WorkflowController {
     private String normalizeWorkflowRole(String authority) {
         String normalized = authority.replaceFirst("^ROLE_", "").trim().toUpperCase(Locale.ROOT);
         return switch (normalized) {
+            case "ADMIN" -> "EXECUTIVE";
             case "PM" -> "PLANNER";
             case "ACCOUNTANT" -> "FINANCE_REVIEWER";
             default -> normalized;

--- a/backend/src/main/java/com/costwise/config/SecurityConfig.java
+++ b/backend/src/main/java/com/costwise/config/SecurityConfig.java
@@ -34,9 +34,14 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private static final String INVALID_AUDIENCE_ERROR = "invalid_token";
-    private static final String[] BUSINESS_ROLES =
-            {"ADMIN", "PLANNER", "PM", "FINANCE_REVIEWER", "ACCOUNTANT", "EXECUTIVE"};
-    private static final String[] AUDIT_ROLES = {"EXECUTIVE", "AUDITOR", "ADMIN"};
+    private static final String[] DASHBOARD_ROLES = {"ADMIN", "PLANNER", "FINANCE_REVIEWER", "EXECUTIVE"};
+    private static final String[] PORTFOLIO_ROLES = {"ADMIN", "PLANNER"};
+    private static final String[] ANALYTICS_ROLES = {"ADMIN", "FINANCE_REVIEWER"};
+    private static final String[] PROJECT_AUTHOR_ROLES = {"ADMIN", "PLANNER"};
+    private static final String[] REVIEW_APPROVER_ROLES = {"ADMIN", "FINANCE_REVIEWER", "EXECUTIVE"};
+    private static final String[] WORKFLOW_ROLES = {"ADMIN", "PLANNER", "FINANCE_REVIEWER", "EXECUTIVE"};
+    private static final String[] AUDIT_READ_ROLES = {"ADMIN", "AUDITOR"};
+    private static final String[] AUDIT_WRITE_ROLES = {"ADMIN", "EXECUTIVE"};
 
     private final JwtSecurityProperties jwtSecurityProperties;
     private final SupabaseJwtAuthenticationConverter jwtAuthenticationConverter;
@@ -106,19 +111,34 @@ public class SecurityConfig {
                 auth -> auth
                         .requestMatchers("/api/health")
                         .permitAll()
-                        .requestMatchers("/api/dashboard",
-                                "/api/portfolio/summary",
+                        .requestMatchers("/api/dashboard")
+                        .hasAnyRole(DASHBOARD_ROLES)
+                        .requestMatchers("/api/portfolio", "/api/portfolio/summary")
+                        .hasAnyRole(PORTFOLIO_ROLES)
+                        .requestMatchers("/api/cost-accounting",
                                 "/api/cost-accounting/summary",
-                                "/api/valuation-risk/projects/**",
-                                "/api/compute")
-                        .hasAnyRole(BUSINESS_ROLES)
+                                "/api/valuation-risk",
+                                "/api/valuation-risk/projects/**")
+                        .hasAnyRole(ANALYTICS_ROLES)
+                        .requestMatchers("/api/compute")
+                        .hasAnyRole(DASHBOARD_ROLES)
+                        .requestMatchers(HttpMethod.POST, "/api/projects", "/api/projects/*/submit-review")
+                        .hasAnyRole(PROJECT_AUTHOR_ROLES)
+                        .requestMatchers(HttpMethod.PUT, "/api/projects/*")
+                        .hasAnyRole(PROJECT_AUTHOR_ROLES)
+                        .requestMatchers(HttpMethod.POST, "/api/review/*/approve")
+                        .hasAnyRole(REVIEW_APPROVER_ROLES)
+                        .requestMatchers("/api/projects/*/workflow", "/api/projects/*/review")
+                        .hasAnyRole(WORKFLOW_ROLES)
+                        .requestMatchers(HttpMethod.GET, "/api/audit-logs")
+                        .hasAnyRole(AUDIT_READ_ROLES)
+                        .requestMatchers(HttpMethod.POST, "/api/audit-logs")
+                        .hasAnyRole(AUDIT_WRITE_ROLES)
                         .requestMatchers("/actuator/health", "/actuator/info")
                         .permitAll()
                         .requestMatchers("/actuator/**")
                         .access((authentication, context) ->
                                 new AuthorizationDecision(securityPolicyProperties.actuatorAllPublic()))
-                        .requestMatchers("/api/projects/*/workflow", "/api/projects/*/review").authenticated()
-                        .requestMatchers("/api/audit-logs").hasAnyRole(AUDIT_ROLES)
                         .requestMatchers(HttpMethod.OPTIONS, "/**")
                         .permitAll()
                         .requestMatchers("/v3/api-docs",

--- a/backend/src/test/java/com/costwise/api/workflow/WorkflowControllerSecurityTest.java
+++ b/backend/src/test/java/com/costwise/api/workflow/WorkflowControllerSecurityTest.java
@@ -154,7 +154,7 @@ class WorkflowControllerSecurityTest {
     void auditLogsRequireProjectId() throws Exception {
         Instant now = Instant.now();
         mockMvc.perform(get("/api/audit-logs")
-                        .header("Authorization", bearerToken(token("executive", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
+                        .header("Authorization", bearerToken(token("auditor", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
                 .andExpect(status().isBadRequest());
     }
 
@@ -167,10 +167,10 @@ class WorkflowControllerSecurityTest {
     }
 
     @Test
-    void auditLogsAllowExecutiveRole() throws Exception {
+    void auditLogsAllowAuditorRole() throws Exception {
         Instant now = Instant.now();
         mockMvc.perform(get("/api/audit-logs?projectId=P-100")
-                        .header("Authorization", bearerToken(token("executive", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
+                        .header("Authorization", bearerToken(token("auditor", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.items").isArray());
     }
@@ -193,23 +193,57 @@ class WorkflowControllerSecurityTest {
 
     @Test
     void coreBusinessApisAllowAuthenticatedBusinessRoles() throws Exception {
-        for (String role : List.of("planner", "PM", "finance_reviewer", "ACCOUNTANT", "executive")) {
-            String authHeader = bearerToken(token(role, ISSUER, AUDIENCE, Instant.now(), Instant.now().plusSeconds(3600)));
+        String plannerToken = bearerToken(token("planner", ISSUER, AUDIENCE, Instant.now(), Instant.now().plusSeconds(3600)));
+        mockMvc.perform(get("/api/dashboard").header("Authorization", plannerToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/portfolio/summary").header("Authorization", plannerToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/cost-accounting/summary").header("Authorization", plannerToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/valuation-risk/projects/14").header("Authorization", plannerToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(post("/api/compute")
+                        .header("Authorization", plannerToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(validComputeRequest()))
+                .andExpect(status().isOk());
 
-            mockMvc.perform(get("/api/dashboard").header("Authorization", authHeader))
-                    .andExpect(status().isOk());
-            mockMvc.perform(get("/api/portfolio/summary").header("Authorization", authHeader))
-                    .andExpect(status().isOk());
-            mockMvc.perform(get("/api/cost-accounting/summary").header("Authorization", authHeader))
-                    .andExpect(status().isOk());
-            mockMvc.perform(get("/api/valuation-risk/projects/14").header("Authorization", authHeader))
-                    .andExpect(status().isOk());
-            mockMvc.perform(post("/api/compute")
-                            .header("Authorization", authHeader)
-                            .contentType(APPLICATION_JSON)
-                            .content(validComputeRequest()))
-                    .andExpect(status().isOk());
-        }
+        String reviewerToken = bearerToken(token("finance_reviewer", ISSUER, AUDIENCE, Instant.now(), Instant.now().plusSeconds(3600)));
+        mockMvc.perform(get("/api/dashboard").header("Authorization", reviewerToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/portfolio/summary").header("Authorization", reviewerToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/cost-accounting/summary").header("Authorization", reviewerToken))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/valuation-risk/projects/14").header("Authorization", reviewerToken))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/compute")
+                        .header("Authorization", reviewerToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(validComputeRequest()))
+                .andExpect(status().isOk());
+
+        String executiveToken = bearerToken(token("executive", ISSUER, AUDIENCE, Instant.now(), Instant.now().plusSeconds(3600)));
+        mockMvc.perform(get("/api/dashboard").header("Authorization", executiveToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/portfolio/summary").header("Authorization", executiveToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/cost-accounting/summary").header("Authorization", executiveToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/valuation-risk/projects/14").header("Authorization", executiveToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(post("/api/compute")
+                        .header("Authorization", executiveToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(validComputeRequest()))
+                .andExpect(status().isOk());
+
+        String adminToken = bearerToken(token("admin", ISSUER, AUDIENCE, Instant.now(), Instant.now().plusSeconds(3600)));
+        mockMvc.perform(get("/api/dashboard").header("Authorization", adminToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/portfolio/summary").header("Authorization", adminToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/cost-accounting/summary").header("Authorization", adminToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/valuation-risk/projects/14").header("Authorization", adminToken)).andExpect(status().isOk());
+        mockMvc.perform(post("/api/compute")
+                        .header("Authorization", adminToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(validComputeRequest()))
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -258,7 +292,9 @@ class WorkflowControllerSecurityTest {
         return switch (role == null ? "" : role.trim().toLowerCase()) {
             case "pm", "planner" -> "PLANNER";
             case "accountant", "finance_reviewer" -> "FINANCE_REVIEWER";
-            case "admin", "auditor", "executive" -> "EXECUTIVE";
+            case "admin" -> "ADMIN";
+            case "auditor" -> "AUDITOR";
+            case "executive" -> "EXECUTIVE";
             default -> role == null ? "EXECUTIVE" : role.trim().toUpperCase();
         };
     }


### PR DESCRIPTION
## 요약

DB 사용자 기반 로그인(`POST /api/auth/login`)을 추가하고, 운영 RBAC를 `ADMIN/MANAGER/AUDITOR` 중심으로 단순화했습니다. 프론트 로그인/토큰 흐름을 실제 API 기반으로 전환하고 README/DEPLOYMENT 문서를 최신화했습니다.

## 변경 내용

- 백엔드 인증: `AuthController`, `AuthService` 추가, DB 비밀번호 해시 검증 후 JWT 발급
- 사용자 비밀번호 관리: `PUT /api/users/{userId}/password`(ADMIN) 추가
- 권한 체계 정리: 단순 RBAC + 기존 역할 alias 호환 유지
- 프론트 로그인 전환: 하드코딩 데모 로그인 제거, 로그인 API/세션 토큰 사용
- 운영 문서 보강: `README.md`, `DEPLOYMENT.md`, 로그인 스모크 스크립트 추가

## 이유

기존 데모 계정/정적 토큰 방식은 운영 인증/권한 모델과 괴리가 있어 보안 및 검증 신뢰도가 낮았습니다. 실제 DB 계정 로그인과 단순 RBAC로 운영 일관성과 관리성을 높였습니다.

## 검증

- [x] 관련 테스트를 실행했습니다.
- [x] 영향을 받은 화면 또는 API를 수동으로 확인했습니다.
- [x] 인접한 흐름에서 회귀가 없는지 확인했습니다.

검증 로그:
- `backend`: `./gradlew.bat test` 통과
- `frontend`: `npm run lint`, `npm run build` 통과

## 스크린샷 또는 로그

- 로그인/인증 스모크: `scripts/auth-login-smoke.ps1`
- 주요 API: `/api/auth/login`, `/api/users/{id}/password`

## 체크리스트

- [x] 범위가 이 PR 안에만 한정되어 있습니다.
- [x] 동작이 바뀌었다면 문서를 함께 수정했습니다.
- [ ] 후속 작업이 필요하면 별도 이슈로 분리했습니다.

## 브랜치

- [x] 작업은 집중된 `feat/*`, `fix/*`, `docs/*`, 또는 `chore/*` 브랜치에서 진행했습니다.
- [x] 릴리스 또는 핫픽스가 아니라면 대상 브랜치는 `dev`입니다.
- [ ] `docs/dev-logs/`에 워킹트리 비교와 브랜치 선택 이유를 기록했습니다.
