### PR TITLE
release: dev 최신 변경(main 반영)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@
 |------|-----|
 | **Frontend** | https://costwiseai-frontend.pages.dev |
 | **Backend API** | https://costwiseai-production.up.railway.app |
-| **API 명세** | https://costwiseai-production.up.railway.app/swagger-ui |
+| **Swagger UI** | https://costwiseai-production.up.railway.app/swagger-ui/index.html |
+| **OpenAPI JSON** | https://costwiseai-production.up.railway.app/v3/api-docs |
 | **Health Check** | https://costwiseai-production.up.railway.app/api/health |
 
 
@@ -65,15 +66,19 @@
 
 ## 📊 권한별 기능
 
-| 권한 | 접근 가능 기능 |
-|------|---|
-| **ADMIN** | 모든 API + 감사 로그 + 사용자 관리 |
-| **PLANNER** | 대시보드 · 포트폴리오 · 원가 · 평가 · 워크플로우 |
-| **FINANCE_REVIEWER** | 재무 검토 · 평가 분석 · 워크플로우 리뷰 |
-| **EXECUTIVE** | 최종 승인 결정 · 감사 로그 조회 |
-| **PM** | 프로젝트 단위 조회 · 평가 · 워크플로우 참여 |
-| **ACCOUNTANT** | 원가 · 관리회계 · 포트폴리오 조회 |
-| **AUDITOR** | 감사 로그 중심 접근 |
+### 5.2 Role-Based Access Control (RBAC)
+
+| 역할 | 권한 | API 접근 |
+|------|------|----------|
+| **PLANNER** | 프로젝트 생성/수정 + 검토 요청 | `GET /api/portfolio`, `POST /api/projects`, `PUT /api/projects/{id}`, `POST /api/projects/{id}/submit-review` |
+| **FINANCE_REVIEWER** | 원가/평가 검증 + 검토 의견/승인 | `GET /api/cost-accounting`, `GET /api/valuation-risk?projectId={id}`, `POST /api/review/{id}/approve` |
+| **EXECUTIVE** | 최종 승인/반려 + 감사 로그 등록 | `POST /api/review/{id}/approve`, `POST /api/audit-logs` |
+| **ADMIN** | 모든 권한 + 사용자 관리 | 모든 API |
+| **AUDITOR** | 감사 로그 조회 | `GET /api/audit-logs` |
+
+운영 참고:
+- 레거시 경로(`GET /api/portfolio/summary`, `GET /api/cost-accounting/summary`, `GET /api/valuation-risk/projects/{id}`)도 하위 호환으로 유지합니다.
+- 감사 로그는 읽기(`GET`)와 쓰기(`POST`) 권한을 분리합니다.
 
 ---
 
@@ -201,7 +206,7 @@ cd backend
 open http://localhost:5173
 
 # Backend API 명세
-open http://localhost:8080/swagger-ui
+open http://localhost:8080/swagger-ui/index.html
 
 # 헬스 체크
 curl http://localhost:8080/api/health
@@ -214,17 +219,20 @@ curl http://localhost:8080/api/health
 ### 대시보드 & 포트폴리오
 ```
 GET  /api/dashboard                    # 전체 대시보드 요약
+GET  /api/portfolio                    # 포트폴리오 KPI (RBAC 5.2 표준 경로)
 GET  /api/portfolio/summary            # 포트폴리오 KPI
 ```
 
 ### 원가 분석
 ```
+GET  /api/cost-accounting              # 원가 요약 (RBAC 5.2 표준 경로)
 GET  /api/cost-accounting/summary      # 원가 요약
 GET  /api/cost-accounting/detail       # 원가 상세 (본부별·프로젝트별)
 ```
 
 ### 금융 평가 & 리스크
 ```
+GET  /api/valuation-risk?projectId={projectId}   # 평가/리스크 조회 (RBAC 5.2 표준 경로)
 GET  /api/valuation-risk/projects/{projectId}    # 프로젝트 평가·리스크 지표
 GET  /api/valuation-risk/scenarios                # 시나리오별 분석
 ```
@@ -235,6 +243,7 @@ GET  /api/projects/{id}/workflow               # 승인 상태 조회
 POST /api/projects/{id}/submit-review          # 검토 요청
 POST /api/review/{id}/approve                  # 승인
 POST /api/review/{id}/reject                   # 반려
+POST /api/projects/{id}/review                 # 기존 통합 리뷰 API (하위 호환)
 ```
 
 ### 감사 로그
@@ -249,7 +258,7 @@ GET  /api/users                        # 사용자 목록 (ADMIN만)
 POST /api/users                        # 사용자 생성 (ADMIN만)
 ```
 
-**Swagger 접속**: http://localhost:8080/swagger-ui
+**Swagger 접속**: http://localhost:8080/swagger-ui/index.html
 
 ---
 
@@ -257,7 +266,7 @@ POST /api/users                        # 사용자 생성 (ADMIN만)
 
 ### 인증 & 인가
 - **JWT 기반 토큰**: Supabase에서 발급
-- **역할 기반 접근 제어 (RBAC)**: 7개 권한 역할 정의
+- **역할 기반 접근 제어 (RBAC)**: 5.2 기준 핵심 5역할(`PLANNER`, `FINANCE_REVIEWER`, `EXECUTIVE`, `ADMIN`, `AUDITOR`) 정의
 - **API 엔드포인트별 권한 검증**: Spring Security로 강제
 
 ### 데이터 보호

--- a/backend/src/main/java/com/costwise/api/analytics/AnalyticsController.java
+++ b/backend/src/main/java/com/costwise/api/analytics/AnalyticsController.java
@@ -6,6 +6,7 @@ import com.costwise.service.CostAccountingService;
 import com.costwise.service.ValuationRiskService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,9 +23,14 @@ public class AnalyticsController {
         this.valuationRiskService = valuationRiskService;
     }
 
-    @GetMapping("/cost-accounting/summary")
+    @GetMapping({"/cost-accounting", "/cost-accounting/summary"})
     public CostAccountingSummaryResponse costAccountingSummary() {
         return costAccountingService.loadSummary();
+    }
+
+    @GetMapping("/valuation-risk")
+    public ValuationRiskResponse valuationRisk(@RequestParam String projectId) {
+        return valuationRiskService.loadProjectDetail(projectId);
     }
 
     @GetMapping("/valuation-risk/projects/{projectId}")

--- a/backend/src/main/java/com/costwise/api/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/costwise/api/dashboard/DashboardController.java
@@ -33,7 +33,7 @@ public class DashboardController {
                 "portfolio", portfolioSummaryService.loadPortfolioSummary());
     }
 
-    @GetMapping("/portfolio/summary")
+    @GetMapping({"/portfolio", "/portfolio/summary"})
     public PortfolioSummaryResponse portfolioSummary() {
         return portfolioSummaryService.loadPortfolioSummary();
     }

--- a/backend/src/main/java/com/costwise/api/projects/ProjectCommandController.java
+++ b/backend/src/main/java/com/costwise/api/projects/ProjectCommandController.java
@@ -1,0 +1,40 @@
+package com.costwise.api.projects;
+
+import com.costwise.api.dto.persistence.CreateProjectRequest;
+import com.costwise.api.dto.persistence.ProjectSummaryResponse;
+import com.costwise.api.dto.persistence.UpdateProjectRequest;
+import com.costwise.persistence.PersistenceService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/projects")
+public class ProjectCommandController {
+
+    private final PersistenceService persistenceService;
+
+    public ProjectCommandController(PersistenceService persistenceService) {
+        this.persistenceService = persistenceService;
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'PLANNER')")
+    public ResponseEntity<ProjectSummaryResponse> createProject(@Valid @RequestBody CreateProjectRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(persistenceService.createProject(request));
+    }
+
+    @PutMapping("/{projectId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PLANNER')")
+    public ProjectSummaryResponse updateProject(
+            @PathVariable String projectId, @Valid @RequestBody UpdateProjectRequest request) {
+        return persistenceService.updateProject(projectId, request);
+    }
+}

--- a/backend/src/main/java/com/costwise/api/workflow/WorkflowController.java
+++ b/backend/src/main/java/com/costwise/api/workflow/WorkflowController.java
@@ -29,13 +29,36 @@ public class WorkflowController {
     }
 
     @GetMapping("/projects/{projectId}/workflow")
-    @PreAuthorize("hasAnyRole('PLANNER', 'PM', 'FINANCE_REVIEWER', 'ACCOUNTANT', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PLANNER', 'FINANCE_REVIEWER', 'EXECUTIVE')")
     public ApprovalWorkflowResponse workflow(@PathVariable String projectId) {
         return approvalWorkflowService.loadWorkflow(projectId);
     }
 
+    @PostMapping("/projects/{projectId}/submit-review")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PLANNER')")
+    public ApprovalWorkflowResponse submitReview(
+            @PathVariable String projectId,
+            Authentication authentication,
+            @RequestBody(required = false) ReviewCommand command) {
+        String actor = authentication == null ? null : authentication.getName();
+        String comment = command == null ? null : command.comment();
+        return approvalWorkflowService.transition(projectId, "PLANNER", "SUBMIT", actor, comment);
+    }
+
+    @PostMapping("/review/{projectId}/approve")
+    @PreAuthorize("hasAnyRole('ADMIN', 'FINANCE_REVIEWER', 'EXECUTIVE')")
+    public ApprovalWorkflowResponse approve(
+            @PathVariable String projectId,
+            Authentication authentication,
+            @RequestBody(required = false) ReviewCommand command) {
+        String role = resolveWorkflowRole(authentication);
+        String actor = authentication == null ? null : authentication.getName();
+        String comment = command == null ? null : command.comment();
+        return approvalWorkflowService.transition(projectId, role, "APPROVE", actor, comment);
+    }
+
     @PostMapping("/projects/{projectId}/review")
-    @PreAuthorize("hasAnyRole('PLANNER', 'PM', 'FINANCE_REVIEWER', 'ACCOUNTANT', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PLANNER', 'FINANCE_REVIEWER', 'EXECUTIVE')")
     public ApprovalWorkflowResponse review(
             @PathVariable String projectId,
             Authentication authentication,
@@ -65,6 +88,7 @@ public class WorkflowController {
     private String normalizeWorkflowRole(String authority) {
         String normalized = authority.replaceFirst("^ROLE_", "").trim().toUpperCase(Locale.ROOT);
         return switch (normalized) {
+            case "ADMIN" -> "EXECUTIVE";
             case "PM" -> "PLANNER";
             case "ACCOUNTANT" -> "FINANCE_REVIEWER";
             default -> normalized;

--- a/backend/src/main/java/com/costwise/config/SecurityConfig.java
+++ b/backend/src/main/java/com/costwise/config/SecurityConfig.java
@@ -34,9 +34,14 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private static final String INVALID_AUDIENCE_ERROR = "invalid_token";
-    private static final String[] BUSINESS_ROLES =
-            {"ADMIN", "PLANNER", "PM", "FINANCE_REVIEWER", "ACCOUNTANT", "EXECUTIVE"};
-    private static final String[] AUDIT_ROLES = {"EXECUTIVE", "AUDITOR", "ADMIN"};
+    private static final String[] DASHBOARD_ROLES = {"ADMIN", "PLANNER", "FINANCE_REVIEWER", "EXECUTIVE"};
+    private static final String[] PORTFOLIO_ROLES = {"ADMIN", "PLANNER"};
+    private static final String[] ANALYTICS_ROLES = {"ADMIN", "FINANCE_REVIEWER"};
+    private static final String[] PROJECT_AUTHOR_ROLES = {"ADMIN", "PLANNER"};
+    private static final String[] REVIEW_APPROVER_ROLES = {"ADMIN", "FINANCE_REVIEWER", "EXECUTIVE"};
+    private static final String[] WORKFLOW_ROLES = {"ADMIN", "PLANNER", "FINANCE_REVIEWER", "EXECUTIVE"};
+    private static final String[] AUDIT_READ_ROLES = {"ADMIN", "AUDITOR"};
+    private static final String[] AUDIT_WRITE_ROLES = {"ADMIN", "EXECUTIVE"};
 
     private final JwtSecurityProperties jwtSecurityProperties;
     private final SupabaseJwtAuthenticationConverter jwtAuthenticationConverter;
@@ -106,19 +111,34 @@ public class SecurityConfig {
                 auth -> auth
                         .requestMatchers("/api/health")
                         .permitAll()
-                        .requestMatchers("/api/dashboard",
-                                "/api/portfolio/summary",
+                        .requestMatchers("/api/dashboard")
+                        .hasAnyRole(DASHBOARD_ROLES)
+                        .requestMatchers("/api/portfolio", "/api/portfolio/summary")
+                        .hasAnyRole(PORTFOLIO_ROLES)
+                        .requestMatchers("/api/cost-accounting",
                                 "/api/cost-accounting/summary",
-                                "/api/valuation-risk/projects/**",
-                                "/api/compute")
-                        .hasAnyRole(BUSINESS_ROLES)
+                                "/api/valuation-risk",
+                                "/api/valuation-risk/projects/**")
+                        .hasAnyRole(ANALYTICS_ROLES)
+                        .requestMatchers("/api/compute")
+                        .hasAnyRole(DASHBOARD_ROLES)
+                        .requestMatchers(HttpMethod.POST, "/api/projects", "/api/projects/*/submit-review")
+                        .hasAnyRole(PROJECT_AUTHOR_ROLES)
+                        .requestMatchers(HttpMethod.PUT, "/api/projects/*")
+                        .hasAnyRole(PROJECT_AUTHOR_ROLES)
+                        .requestMatchers(HttpMethod.POST, "/api/review/*/approve")
+                        .hasAnyRole(REVIEW_APPROVER_ROLES)
+                        .requestMatchers("/api/projects/*/workflow", "/api/projects/*/review")
+                        .hasAnyRole(WORKFLOW_ROLES)
+                        .requestMatchers(HttpMethod.GET, "/api/audit-logs")
+                        .hasAnyRole(AUDIT_READ_ROLES)
+                        .requestMatchers(HttpMethod.POST, "/api/audit-logs")
+                        .hasAnyRole(AUDIT_WRITE_ROLES)
                         .requestMatchers("/actuator/health", "/actuator/info")
                         .permitAll()
                         .requestMatchers("/actuator/**")
                         .access((authentication, context) ->
                                 new AuthorizationDecision(securityPolicyProperties.actuatorAllPublic()))
-                        .requestMatchers("/api/projects/*/workflow", "/api/projects/*/review").authenticated()
-                        .requestMatchers("/api/audit-logs").hasAnyRole(AUDIT_ROLES)
                         .requestMatchers(HttpMethod.OPTIONS, "/**")
                         .permitAll()
                         .requestMatchers("/v3/api-docs",

--- a/backend/src/main/java/com/costwise/config/SecurityConfig.java
+++ b/backend/src/main/java/com/costwise/config/SecurityConfig.java
@@ -70,7 +70,19 @@ public class SecurityConfig {
         http.csrf(AbstractHttpConfigurer::disable);
         http.cors(Customizer.withDefaults());
         http.headers(headers -> {
-            headers.contentSecurityPolicy(csp -> csp.policyDirectives(securityPolicyProperties.contentSecurityPolicy()));
+            headers.addHeaderWriter((request, response) -> {
+                String path = request.getRequestURI();
+                String policy = isDocsPath(path)
+                        ? "default-src 'self'; "
+                                + "img-src 'self' data:; "
+                                + "style-src 'self' 'unsafe-inline'; "
+                                + "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+                                + "object-src 'none'; "
+                                + "base-uri 'self'; "
+                                + "frame-ancestors 'none'"
+                        : securityPolicyProperties.contentSecurityPolicy();
+                response.setHeader("Content-Security-Policy", policy);
+            });
             headers.referrerPolicy(referrer -> referrer.policy(
                     ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN));
             headers.frameOptions(frame -> frame.deny());
@@ -135,5 +147,12 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    private boolean isDocsPath(String path) {
+        return path != null
+                && (path.startsWith("/swagger-ui")
+                        || path.equals("/swagger-ui.html")
+                        || path.startsWith("/v3/api-docs"));
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
 
 server:
   port: 8080
+  forward-headers-strategy: framework
 
 app:
   security:

--- a/backend/src/test/java/com/costwise/api/workflow/WorkflowControllerSecurityTest.java
+++ b/backend/src/test/java/com/costwise/api/workflow/WorkflowControllerSecurityTest.java
@@ -154,7 +154,7 @@ class WorkflowControllerSecurityTest {
     void auditLogsRequireProjectId() throws Exception {
         Instant now = Instant.now();
         mockMvc.perform(get("/api/audit-logs")
-                        .header("Authorization", bearerToken(token("executive", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
+                        .header("Authorization", bearerToken(token("auditor", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
                 .andExpect(status().isBadRequest());
     }
 
@@ -167,10 +167,10 @@ class WorkflowControllerSecurityTest {
     }
 
     @Test
-    void auditLogsAllowExecutiveRole() throws Exception {
+    void auditLogsAllowAuditorRole() throws Exception {
         Instant now = Instant.now();
         mockMvc.perform(get("/api/audit-logs?projectId=P-100")
-                        .header("Authorization", bearerToken(token("executive", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
+                        .header("Authorization", bearerToken(token("auditor", ISSUER, AUDIENCE, now, now.plusSeconds(3600)))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.items").isArray());
     }
@@ -193,23 +193,57 @@ class WorkflowControllerSecurityTest {
 
     @Test
     void coreBusinessApisAllowAuthenticatedBusinessRoles() throws Exception {
-        for (String role : List.of("planner", "PM", "finance_reviewer", "ACCOUNTANT", "executive")) {
-            String authHeader = bearerToken(token(role, ISSUER, AUDIENCE, Instant.now(), Instant.now().plusSeconds(3600)));
+        String plannerToken = bearerToken(token("planner", ISSUER, AUDIENCE, Instant.now(), Instant.now().plusSeconds(3600)));
+        mockMvc.perform(get("/api/dashboard").header("Authorization", plannerToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/portfolio/summary").header("Authorization", plannerToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/cost-accounting/summary").header("Authorization", plannerToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/valuation-risk/projects/14").header("Authorization", plannerToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(post("/api/compute")
+                        .header("Authorization", plannerToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(validComputeRequest()))
+                .andExpect(status().isOk());
 
-            mockMvc.perform(get("/api/dashboard").header("Authorization", authHeader))
-                    .andExpect(status().isOk());
-            mockMvc.perform(get("/api/portfolio/summary").header("Authorization", authHeader))
-                    .andExpect(status().isOk());
-            mockMvc.perform(get("/api/cost-accounting/summary").header("Authorization", authHeader))
-                    .andExpect(status().isOk());
-            mockMvc.perform(get("/api/valuation-risk/projects/14").header("Authorization", authHeader))
-                    .andExpect(status().isOk());
-            mockMvc.perform(post("/api/compute")
-                            .header("Authorization", authHeader)
-                            .contentType(APPLICATION_JSON)
-                            .content(validComputeRequest()))
-                    .andExpect(status().isOk());
-        }
+        String reviewerToken = bearerToken(token("finance_reviewer", ISSUER, AUDIENCE, Instant.now(), Instant.now().plusSeconds(3600)));
+        mockMvc.perform(get("/api/dashboard").header("Authorization", reviewerToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/portfolio/summary").header("Authorization", reviewerToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/cost-accounting/summary").header("Authorization", reviewerToken))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/valuation-risk/projects/14").header("Authorization", reviewerToken))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/compute")
+                        .header("Authorization", reviewerToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(validComputeRequest()))
+                .andExpect(status().isOk());
+
+        String executiveToken = bearerToken(token("executive", ISSUER, AUDIENCE, Instant.now(), Instant.now().plusSeconds(3600)));
+        mockMvc.perform(get("/api/dashboard").header("Authorization", executiveToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/portfolio/summary").header("Authorization", executiveToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/cost-accounting/summary").header("Authorization", executiveToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/valuation-risk/projects/14").header("Authorization", executiveToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(post("/api/compute")
+                        .header("Authorization", executiveToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(validComputeRequest()))
+                .andExpect(status().isOk());
+
+        String adminToken = bearerToken(token("admin", ISSUER, AUDIENCE, Instant.now(), Instant.now().plusSeconds(3600)));
+        mockMvc.perform(get("/api/dashboard").header("Authorization", adminToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/portfolio/summary").header("Authorization", adminToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/cost-accounting/summary").header("Authorization", adminToken)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/valuation-risk/projects/14").header("Authorization", adminToken)).andExpect(status().isOk());
+        mockMvc.perform(post("/api/compute")
+                        .header("Authorization", adminToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(validComputeRequest()))
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -258,7 +292,9 @@ class WorkflowControllerSecurityTest {
         return switch (role == null ? "" : role.trim().toLowerCase()) {
             case "pm", "planner" -> "PLANNER";
             case "accountant", "finance_reviewer" -> "FINANCE_REVIEWER";
-            case "admin", "auditor", "executive" -> "EXECUTIVE";
+            case "admin" -> "ADMIN";
+            case "auditor" -> "AUDITOR";
+            case "executive" -> "EXECUTIVE";
             default -> role == null ? "EXECUTIVE" : role.trim().toUpperCase();
         };
     }


### PR DESCRIPTION
## 작업 목적
`dev` 브랜치에 반영된 최신 변경사항을 `main`으로 승격하기 위한 릴리스 PR입니다.

## 포함된 변경
- #90: Railway 환경에서 Swagger 렌더링 안정화
  - docs 경로 CSP 처리 보정
  - `server.forward-headers-strategy: framework` 반영
- #91: RBAC 5.2 역할-API 매트릭스 정렬
  - 역할별 접근 정책 정교화 (`PLANNER`, `FINANCE_REVIEWER`, `EXECUTIVE`, `ADMIN`, `AUDITOR`)
  - 표준 경로 alias 추가
    - `GET /api/portfolio`
    - `GET /api/cost-accounting`
    - `GET /api/valuation-risk?projectId={id}`
    - `POST /api/projects/{id}/submit-review`
    - `POST /api/review/{id}/approve`
  - README 최신화(권한표, 배포 URL, Swagger/OpenAPI 링크)

## 검증
- Backend 테스트: `./gradlew test` 통과
- 운영 엔드포인트 확인(HTTP 200)
  - `/api/health`
  - `/swagger-ui/index.html`
  - Frontend Pages URL

## 영향 범위
- 백엔드 보안 정책(RBAC/CORS/CSP)
- 워크플로우/프로젝트 관련 API 접근 제어
- 문서(README)

## 체크리스트
- [x] `dev` 최신 커밋 기준으로 정리
- [x] Swagger 접근성 확인
- [x] RBAC 5.2 요구사항 반영
- [x] 배포 후 기본 헬스체크 완료